### PR TITLE
MPT-12322: update Ruff ignore rules (add D107, remove UP046 and UP047)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ ignore = [
   "D100",
   "D104",
   "D106",
+  "D107",
   "D203",
   "D212",
   "D401",
@@ -150,8 +151,6 @@ ignore = [
   "PLR6301", # do not require classmethod / staticmethod when self not used
   "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
   "TRY003",  # long exception messages from `tryceratops`
-  "UP046", # Doesn't properly work with ParamSpec and python 3.12
-  "UP047", # Doesn't properly work with ParamSpec and python 3.12
 ]
 external = [ "WPS" ]
 


### PR DESCRIPTION
Update Ruff ignore rules:

* Add D107: https://docs.astral.sh/ruff/rules/undocumented-public-init/
* Remove UP046 and UP047: stop ignoring [PEP 695](https://peps.python.org/pep-0695/), for those places that still need to use the ParamSpec type, we can ignore them using -> # noqa: UP046, UP047