### PR TITLE
[MPT-15606] Updated mixins for create and update in account

### DIFF
--- a/mpt_api_client/http/mixins.py
+++ b/mpt_api_client/http/mixins.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import AsyncIterator, Iterator
 from typing import Self
 from urllib.parse import urljoin
@@ -113,73 +112,146 @@ class FilesOperationsMixin[Model](DownloadFileMixin[Model]):
         return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
 
 
-class CreateWithIconMixin[Model]:
-    """Create resource with icon mixin."""
+class CreateFileMixin[Model]:
+    """Create file mixin."""
 
-    def create(
-        self,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str,
-        icon_key: str,
-    ) -> Model:
-        """Create resource with icon.
+    def create(self, resource_data: ResourceData, file: FileTypes | None = None) -> Model:  # noqa: WPS110
+        """Create logo.
+
+        Create a file resource by specifying a file image.
 
         Args:
             resource_data: Resource data.
-            data_key: Key for the resource data.
-            icon: Icon image in jpg, png, GIF, etc.
-            icon_key: Key for the icon.
+            file: File image.
 
         Returns:
-            Created resource.
+            Model: Created resource.
         """
-        files: dict[str, FileTypes] = {}
-        files[data_key] = (
-            None,
-            json.dumps(resource_data),
-            APPLICATION_JSON,
+        files = {}
+
+        if file:
+            files[self._upload_file_key] = file  # type: ignore[attr-defined]
+
+        response = self.http_client.request(  # type: ignore[attr-defined]
+            "post",
+            self.path,  # type: ignore[attr-defined]
+            json=resource_data,
+            files=files,
+            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
+            force_multipart=True,
         )
-        files[icon_key] = icon
-        response = self.http_client.request("post", self.path, files=files)  # type: ignore[attr-defined]
 
         return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
 
 
-class UpdateWithIconMixin[Model]:
-    """Update resource with icon mixin."""
+class UpdateFileMixin[Model]:
+    """Update file mixin."""
 
     def update(
         self,
         resource_id: str,
         resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str,
-        icon_key: str,
+        file: FileTypes | None = None,  # noqa: WPS110
     ) -> Model:
-        """Update resource with icon.
+        """Update file.
+
+        Update a file resource by specifying a file.
 
         Args:
             resource_id: Resource ID.
             resource_data: Resource data.
-            data_key: Key for the resource data.
-            icon: Icon image in jpg, png, GIF, etc.
-            icon_key: Key for the icon.
+            file: File image.
 
         Returns:
-            Updated resource.
+            Model: Updated resource.
         """
-        files: dict[str, FileTypes] = {}
-        files[data_key] = (
-            None,
-            json.dumps(resource_data),
-            APPLICATION_JSON,
-        )
-        files[icon_key] = icon
+        files = {}
 
         url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
 
-        response = self.http_client.request("put", url, files=files)  # type: ignore[attr-defined]
+        if file:
+            files[self._upload_file_key] = file  # type: ignore[attr-defined]
+
+        response = self.http_client.request(  # type: ignore[attr-defined]
+            "put",
+            url,
+            json=resource_data,
+            files=files,
+            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
+            force_multipart=True,
+        )
+
+        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
+
+
+class AsyncCreateFileMixin[Model]:
+    """Asynchronous Create file mixin."""
+
+    async def create(self, resource_data: ResourceData, file: FileTypes | None = None) -> Model:  # noqa: WPS110
+        """Create file.
+
+        Create a file resource by specifying a file.
+
+        Args:
+            resource_data: Resource data.
+            file: File image.
+
+        Returns:
+            Model: Created resource.
+        """
+        files = {}
+
+        if file:
+            files[self._upload_file_key] = file  # type: ignore[attr-defined]
+
+        response = await self.http_client.request(  # type: ignore[attr-defined]
+            "post",
+            self.path,  # type: ignore[attr-defined]
+            json=resource_data,
+            files=files,
+            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
+            force_multipart=True,
+        )
+
+        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
+
+
+class AsyncUpdateFileMixin[Model]:
+    """Asynchronous Update file mixin."""
+
+    async def update(
+        self,
+        resource_id: str,
+        resource_data: ResourceData,
+        file: FileTypes | None = None,  # noqa: WPS110
+    ) -> Model:
+        """Update file.
+
+        Update a file resource by specifying a file.
+
+        Args:
+            resource_id: Resource ID.
+            resource_data: Resource data.
+            file: File image.
+
+        Returns:
+            Model: Updated resource.
+        """
+        files = {}
+
+        url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
+
+        if file:
+            files[self._upload_file_key] = file  # type: ignore[attr-defined]
+
+        response = await self.http_client.request(  # type: ignore[attr-defined]
+            "put",
+            url,
+            json=resource_data,
+            files=files,
+            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
+            force_multipart=True,
+        )
 
         return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
 
@@ -282,77 +354,6 @@ class AsyncFilesOperationsMixin[Model](AsyncDownloadFileMixin[Model]):
             )
 
         response = await self.http_client.request("post", self.path, files=files)  # type: ignore[attr-defined]
-
-        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
-
-
-class AsyncCreateWithIconMixin[Model]:
-    """Create resource with icon mixin."""
-
-    async def create(
-        self,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str,
-        icon_key: str,
-    ) -> Model:
-        """Create resource with icon.
-
-        Args:
-            resource_data: Resource data.
-            data_key: Key for the resource data.
-            icon: Icon image in jpg, png, GIF, etc.
-            icon_key: Key for the icon.
-
-        Returns:
-            Created resource.
-        """
-        files: dict[str, FileTypes] = {}
-        files[data_key] = (
-            None,
-            json.dumps(resource_data),
-            APPLICATION_JSON,
-        )
-        files[icon_key] = icon
-        response = await self.http_client.request("post", self.path, files=files)  # type: ignore[attr-defined]
-
-        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
-
-
-class AsyncUpdateWithIconMixin[Model]:
-    """Update resource with icon mixin."""
-
-    async def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str,
-        icon_key: str,
-    ) -> Model:
-        """Update resource with icon.
-
-        Args:
-            resource_id: Resource ID.
-            resource_data: Resource data.
-            data_key: Key for the resource data.
-            icon: Icon image in jpg, png, GIF, etc.
-            icon_key: Key for the icon.
-
-        Returns:
-            Updated resource.
-        """
-        files: dict[str, FileTypes] = {}
-        files[data_key] = (
-            None,
-            json.dumps(resource_data),
-            APPLICATION_JSON,
-        )
-        files[icon_key] = icon
-
-        url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
-
-        response = await self.http_client.request("put", url, files=files)  # type: ignore[attr-defined]
 
         return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
 

--- a/mpt_api_client/resources/accounts/account.py
+++ b/mpt_api_client/resources/accounts/account.py
@@ -1,19 +1,15 @@
-from typing import override
-
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncCreateWithIconMixin,
+    AsyncCreateFileMixin,
     AsyncGetMixin,
-    AsyncUpdateWithIconMixin,
+    AsyncUpdateFileMixin,
     CollectionMixin,
-    CreateWithIconMixin,
+    CreateFileMixin,
     GetMixin,
-    UpdateWithIconMixin,
+    UpdateFileMixin,
 )
-from mpt_api_client.http.types import FileTypes
 from mpt_api_client.models import Model
-from mpt_api_client.models.model import ResourceData
 from mpt_api_client.resources.accounts.accounts_users import (
     AccountsUsersService,
     AsyncAccountsUsersService,
@@ -38,77 +34,22 @@ class AccountsServiceConfig:
     _endpoint = "/public/v1/accounts/accounts"
     _model_class = Account
     _collection_key = "data"
+    _upload_file_key = "logo"
+    _upload_data_key = "account"
 
 
 class AccountsService(
-    CreateWithIconMixin[Account],
-    UpdateWithIconMixin[Account],
-    ActivatableMixin[Account],
-    EnablableMixin[Account],
-    ValidateMixin[Account],
+    CreateFileMixin[Model],
+    UpdateFileMixin[Model],
+    ActivatableMixin[Model],
+    EnablableMixin[Model],
+    ValidateMixin[Model],
     GetMixin[Account],
     CollectionMixin[Account],
     Service[Account],
     AccountsServiceConfig,
 ):
     """Accounts service."""
-
-    @override
-    def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "account",
-        icon_key: str = "logo",
-    ) -> Account:
-        """
-        Create a new account with logo.
-
-        Args:
-            resource_data (ResourceData): Account data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: Key for the account data.
-            icon_key: Key for the logo.
-
-        Returns:
-            Account: The created account.
-        """
-        return super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "account",
-        icon_key: str = "logo",
-    ) -> Account:
-        """
-        Update an existing account with logo.
-
-        Args:
-            resource_id (str): The ID of the account to update.
-            resource_data (ResourceData): Account data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: Key for the account data.
-            icon_key: Key for the logo.
-
-        Returns:
-            Account: The updated account.
-        """
-        return super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
 
     def users(self, account_id: str) -> AccountsUsersService:
         """Return account users service."""
@@ -118,74 +59,17 @@ class AccountsService(
 
 
 class AsyncAccountsService(
-    AsyncCreateWithIconMixin[Account],
-    AsyncUpdateWithIconMixin[Account],
-    AsyncActivatableMixin[Account],
-    AsyncEnablableMixin[Account],
-    AsyncValidateMixin[Account],
+    AsyncCreateFileMixin[Model],
+    AsyncUpdateFileMixin[Model],
+    AsyncActivatableMixin[Model],
+    AsyncEnablableMixin[Model],
+    AsyncValidateMixin[Model],
     AsyncGetMixin[Account],
     AsyncCollectionMixin[Account],
     AsyncService[Account],
     AccountsServiceConfig,
 ):
     """Async Accounts service."""
-
-    @override
-    async def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "account",
-        icon_key: str = "logo",
-    ) -> Account:
-        """
-        Create a new account with logo.
-
-        Args:
-            resource_data (ResourceData): Account data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: Key for the account data.
-            icon_key: Key for the logo.
-
-        Returns:
-            Account: The created account.
-        """
-        return await super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    async def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "account",
-        icon_key: str = "logo",
-    ) -> Account:
-        """
-        Update an existing account with logo.
-
-        Args:
-            resource_id (str): The ID of the account to update.
-            resource_data (ResourceData): Account data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: Key for the account data.
-            icon_key: Key for the logo.
-
-        Returns:
-            Account: The updated account.
-        """
-        return await super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
 
     def users(self, account_id: str) -> AsyncAccountsUsersService:
         """Return account users service."""

--- a/mpt_api_client/resources/accounts/buyers.py
+++ b/mpt_api_client/resources/accounts/buyers.py
@@ -1,19 +1,16 @@
-from typing import override
-
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncCreateWithIconMixin,
+    AsyncCreateFileMixin,
     AsyncDeleteMixin,
     AsyncGetMixin,
-    AsyncUpdateWithIconMixin,
+    AsyncUpdateFileMixin,
     CollectionMixin,
-    CreateWithIconMixin,
+    CreateFileMixin,
     DeleteMixin,
     GetMixin,
-    UpdateWithIconMixin,
+    UpdateFileMixin,
 )
-from mpt_api_client.http.types import FileTypes
 from mpt_api_client.models import Model
 from mpt_api_client.models.model import ResourceData
 from mpt_api_client.resources.accounts.mixins import (
@@ -36,76 +33,23 @@ class BuyersServiceConfig:
     _endpoint = "/public/v1/accounts/buyers"
     _model_class = Buyer
     _collection_key = "data"
+    _upload_file_key = "logo"
+    _upload_data_key = "buyer"
 
 
 class BuyersService(
-    CreateWithIconMixin[Buyer],
-    UpdateWithIconMixin[Buyer],
+    CreateFileMixin[Model],
+    UpdateFileMixin[Model],
+    ActivatableMixin[Model],
+    EnablableMixin[Model],
+    ValidateMixin[Model],
     GetMixin[Buyer],
     DeleteMixin,
-    ActivatableMixin[Buyer],
-    EnablableMixin[Buyer],
-    ValidateMixin[Buyer],
     CollectionMixin[Buyer],
     Service[Buyer],
     BuyersServiceConfig,
 ):
     """Buyers Service."""
-
-    @override
-    def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "buyer",
-        icon_key: str = "logo",
-    ) -> Buyer:
-        """Create a buyer.
-
-        Args:
-            resource_data (ResourceData): Buyer data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the buyer data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Buyer: Created buyer
-        """
-        return super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "buyer",
-        icon_key: str = "logo",
-    ) -> Buyer:
-        """Update a buyer.
-
-        Args:
-            resource_id: Resource ID
-            resource_data (ResourceData): Buyer data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the buyer data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Buyer: Updated buyer
-        """
-        return super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
 
     def synchronize(self, resource_id: str, resource_data: ResourceData | None = None) -> Buyer:
         """Synchronize a buyer.
@@ -127,73 +71,18 @@ class BuyersService(
 
 
 class AsyncBuyersService(
-    AsyncCreateWithIconMixin[Buyer],
-    AsyncUpdateWithIconMixin[Buyer],
+    AsyncCreateFileMixin[Model],
+    AsyncUpdateFileMixin[Model],
+    AsyncActivatableMixin[Model],
+    AsyncEnablableMixin[Model],
+    AsyncValidateMixin[Model],
     AsyncGetMixin[Buyer],
     AsyncDeleteMixin,
-    AsyncActivatableMixin[Buyer],
-    AsyncEnablableMixin[Buyer],
-    AsyncValidateMixin[Buyer],
     AsyncCollectionMixin[Buyer],
     AsyncService[Buyer],
     BuyersServiceConfig,
 ):
     """Async Buyers Service."""
-
-    @override
-    async def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "buyer",
-        icon_key: str = "logo",
-    ) -> Buyer:
-        """Create a buyer.
-
-        Args:
-            resource_data (ResourceData): Buyer data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the buyer data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Buyer: Created buyer
-        """
-        return await super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    async def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "buyer",
-        icon_key: str = "logo",
-    ) -> Buyer:
-        """Update a buyer.
-
-        Args:
-            resource_id: Resource ID
-            resource_data (ResourceData): Buyer data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the buyer data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Buyer: Updated buyer
-        """
-        return await super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
 
     async def synchronize(
         self, resource_id: str, resource_data: ResourceData | None = None

--- a/mpt_api_client/resources/accounts/licensees.py
+++ b/mpt_api_client/resources/accounts/licensees.py
@@ -1,22 +1,21 @@
-from typing import override
-
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncCreateWithIconMixin,
+    AsyncCreateFileMixin,
     AsyncDeleteMixin,
     AsyncGetMixin,
-    AsyncUpdateWithIconMixin,
+    AsyncUpdateFileMixin,
     CollectionMixin,
-    CreateWithIconMixin,
+    CreateFileMixin,
     DeleteMixin,
     GetMixin,
-    UpdateWithIconMixin,
+    UpdateFileMixin,
 )
-from mpt_api_client.http.types import FileTypes
 from mpt_api_client.models import Model
-from mpt_api_client.models.model import ResourceData
-from mpt_api_client.resources.accounts.mixins import AsyncEnablableMixin, EnablableMixin
+from mpt_api_client.resources.accounts.mixins import (
+    AsyncEnablableMixin,
+    EnablableMixin,
+)
 
 
 class Licensee(Model):
@@ -29,139 +28,31 @@ class LicenseesServiceConfig:
     _endpoint = "/public/v1/accounts/licensees"
     _model_class = Licensee
     _collection_key = "data"
+    _upload_file_key = "logo"
+    _upload_data_key = "licensee"
 
 
 class LicenseesService(
-    CreateWithIconMixin[Licensee],
-    UpdateWithIconMixin[Licensee],
+    CreateFileMixin[Model],
+    UpdateFileMixin[Model],
+    EnablableMixin[Model],
     GetMixin[Licensee],
     DeleteMixin,
-    EnablableMixin[Licensee],
     CollectionMixin[Licensee],
     Service[Licensee],
     LicenseesServiceConfig,
 ):
     """Licensees Service."""
 
-    @override
-    def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "licensee",
-        icon_key: str = "logo",
-    ) -> Licensee:
-        """Create a licensee.
-
-        Args:
-            resource_data (ResourceData): Licensee data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the licensee data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Licensee: Created licensee
-        """
-        return super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "licensee",
-        icon_key: str = "logo",
-    ) -> Licensee:
-        """Update a licensee.
-
-        Args:
-            resource_id (str): Licensee ID.
-            resource_data (ResourceData): Licensee data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the licensee data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Licensee: Updated licensee
-        """
-        return super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
 
 class AsyncLicenseesService(
-    AsyncCreateWithIconMixin[Licensee],
-    AsyncUpdateWithIconMixin[Licensee],
+    AsyncCreateFileMixin[Model],
+    AsyncUpdateFileMixin[Model],
+    AsyncEnablableMixin[Model],
     AsyncGetMixin[Licensee],
     AsyncDeleteMixin,
-    AsyncEnablableMixin[Licensee],
     AsyncCollectionMixin[Licensee],
     AsyncService[Licensee],
     LicenseesServiceConfig,
 ):
     """Async Licensees Service."""
-
-    @override
-    async def create(
-        self,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "licensee",
-        icon_key: str = "logo",
-    ) -> Licensee:
-        """Create a licensee.
-
-        Args:
-            resource_data (ResourceData): Licensee data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the licensee data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Licensee: Created licensee
-        """
-        return await super().create(
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    async def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        logo: FileTypes,
-        data_key: str = "licensee",
-        icon_key: str = "logo",
-    ) -> Licensee:
-        """Update a licensee.
-
-        Args:
-            resource_id (str): Licensee ID.
-            resource_data (ResourceData): Licensee data.
-            logo: Logo image in jpg, png, GIF, etc.
-            data_key: The key for the licensee data.
-            icon_key: The key for the logo image.
-
-        Returns:
-            Licensee: Updated licensee
-        """
-        return await super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=logo,
-            data_key=data_key,
-            icon_key=icon_key,
-        )

--- a/mpt_api_client/resources/accounts/mixins.py
+++ b/mpt_api_client/resources/accounts/mixins.py
@@ -1,8 +1,5 @@
 from mpt_api_client.models import ResourceData
 
-# TODO: Consider reorganizing functions in mixins to reduce duplication and differences amongst
-#       different domains
-
 
 class ActivatableMixin[Model]:
     """Activatable mixin for activating, enabling, disabling and deactivating resources."""

--- a/mpt_api_client/resources/catalog/mixins.py
+++ b/mpt_api_client/resources/catalog/mixins.py
@@ -1,8 +1,9 @@
 from mpt_api_client.http.mixins import (
+    AsyncCreateFileMixin,
     AsyncDownloadFileMixin,
+    CreateFileMixin,
     DownloadFileMixin,
 )
-from mpt_api_client.http.types import FileTypes
 from mpt_api_client.models import ResourceData
 
 
@@ -81,70 +82,12 @@ class AsyncPublishableMixin[Model]:
         )
 
 
-class AsyncCreateFileMixin[Model]:
-    """Create file mixin."""
-
-    async def create(self, resource_data: ResourceData, file: FileTypes | None = None) -> Model:
-        """Create document.
-
-        Creates a document resource by specifying a `file` or an `url`.
-
-        Args:
-            resource_data: Resource data.
-            file: File to upload.
-
-        Returns:
-            Created resource.
-        """
-        files = {}
-        if file:
-            files[self._upload_file_key] = file  # type: ignore[attr-defined]
-        response = await self.http_client.request(  # type: ignore[attr-defined]
-            "post",
-            self.path,  # type: ignore[attr-defined]
-            json=resource_data,
-            files=files,
-            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
-            force_multipart=True,
-        )
-        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
-
-
 class AsyncDocumentMixin[Model](
     AsyncCreateFileMixin[Model],
     AsyncDownloadFileMixin[Model],
     AsyncPublishableMixin[Model],
 ):
     """Async document mixin."""
-
-
-class CreateFileMixin[Model]:
-    """Create file mixin."""
-
-    def create(self, resource_data: ResourceData, file: FileTypes | None = None) -> Model:
-        """Create document.
-
-        Creates a document resource by specifying a `file` or an `url`.
-
-        Args:
-            resource_data: Resource data.
-            file: File to upload.
-
-        Returns:
-            Created resource.
-        """
-        files = {}
-        if file:
-            files[self._upload_file_key] = file  # type: ignore[attr-defined]
-        response = self.http_client.request(  # type: ignore[attr-defined]
-            "post",
-            self.path,  # type: ignore[attr-defined]
-            json=resource_data,
-            files=files,
-            json_file_key=self._upload_data_key,  # type: ignore[attr-defined]
-            force_multipart=True,
-        )
-        return self._model_class.from_response(response)  # type: ignore[attr-defined, no-any-return]
 
 
 class DocumentMixin[Model](

--- a/mpt_api_client/resources/catalog/pricing_policy_attachments.py
+++ b/mpt_api_client/resources/catalog/pricing_policy_attachments.py
@@ -1,17 +1,15 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
+    AsyncCreateFileMixin,
     AsyncDownloadFileMixin,
     AsyncModifiableResourceMixin,
     CollectionMixin,
+    CreateFileMixin,
     DownloadFileMixin,
     ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
-from mpt_api_client.resources.catalog.mixins import (
-    AsyncCreateFileMixin,
-    CreateFileMixin,
-)
 
 
 class PricingPolicyAttachment(Model):

--- a/mpt_api_client/resources/catalog/product_term_variants.py
+++ b/mpt_api_client/resources/catalog/product_term_variants.py
@@ -1,17 +1,17 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
+    AsyncCreateFileMixin,
     AsyncDownloadFileMixin,
     AsyncModifiableResourceMixin,
     CollectionMixin,
+    CreateFileMixin,
     DownloadFileMixin,
     ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
 from mpt_api_client.resources.catalog.mixins import (
-    AsyncCreateFileMixin,
     AsyncPublishableMixin,
-    CreateFileMixin,
     PublishableMixin,
 )
 

--- a/mpt_api_client/resources/catalog/products.py
+++ b/mpt_api_client/resources/catalog/products.py
@@ -1,19 +1,16 @@
-from typing import override
-
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncCreateWithIconMixin,
+    AsyncCreateFileMixin,
     AsyncDeleteMixin,
     AsyncGetMixin,
-    AsyncUpdateWithIconMixin,
+    AsyncUpdateFileMixin,
     CollectionMixin,
-    CreateWithIconMixin,
+    CreateFileMixin,
     DeleteMixin,
     GetMixin,
-    UpdateWithIconMixin,
+    UpdateFileMixin,
 )
-from mpt_api_client.http.types import FileTypes
 from mpt_api_client.models import Model, ResourceData
 from mpt_api_client.resources.catalog.mixins import (
     AsyncPublishableMixin,
@@ -59,12 +56,14 @@ class ProductsServiceConfig:
     _endpoint = "/public/v1/catalog/products"
     _model_class = Product
     _collection_key = "data"
+    _upload_file_key = "icon"
+    _upload_data_key = "product"
 
 
 class ProductsService(
-    CreateWithIconMixin[Product],
-    UpdateWithIconMixin[Product],
-    PublishableMixin[Product],
+    CreateFileMixin[Model],
+    UpdateFileMixin[Model],
+    PublishableMixin[Model],
     GetMixin[Product],
     DeleteMixin,
     CollectionMixin[Product],
@@ -72,61 +71,6 @@ class ProductsService(
     ProductsServiceConfig,
 ):
     """Products service."""
-
-    @override
-    def create(
-        self,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str = "product",
-        icon_key: str = "icon",
-    ) -> Product:
-        """Create product with icon.
-
-        Args:
-            resource_data: Product data.
-            icon: Icon image in jpg, png, GIF, etc.
-            data_key: Key for the product data.
-            icon_key: Key for the icon.
-
-        Returns:
-            Created resource.
-        """
-        return super().create(
-            resource_data=resource_data,
-            icon=icon,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
-
-    @override
-    def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str = "product",
-        icon_key: str = "icon",
-    ) -> Product:
-        """Update product with icon.
-
-        Args:
-            resource_id: Product ID.
-            resource_data: Product data.
-            icon: Icon image in jpg, png, GIF, etc.
-            data_key: Key for the product data.
-            icon_key: Key for the icon.
-
-        Returns:
-            Updated resource.
-        """
-        return super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            icon=icon,
-            data_key=data_key,
-            icon_key=icon_key,
-        )
 
     def item_groups(self, product_id: str) -> ItemGroupsService:
         """Return item_groups service."""
@@ -174,9 +118,9 @@ class ProductsService(
 
 
 class AsyncProductsService(
-    AsyncCreateWithIconMixin[Product],
-    AsyncUpdateWithIconMixin[Product],
-    AsyncPublishableMixin[Product],
+    AsyncCreateFileMixin[Model],
+    AsyncUpdateFileMixin[Model],
+    AsyncPublishableMixin[Model],
     AsyncGetMixin[Product],
     AsyncDeleteMixin,
     AsyncCollectionMixin[Product],
@@ -184,61 +128,6 @@ class AsyncProductsService(
     ProductsServiceConfig,
 ):
     """Products service."""
-
-    @override
-    async def create(
-        self,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str = "product",
-        icon_key: str = "icon",
-    ) -> Product:
-        """Create product with icon.
-
-        Args:
-            resource_data: Product data.
-            icon: Icon image in jpg, png, GIF, etc.
-            data_key: Key for the product data.
-            icon_key: Key for the icon.
-
-        Returns:
-            Created resource.
-        """
-        return await super().create(
-            resource_data=resource_data,
-            data_key=data_key,
-            icon=icon,
-            icon_key=icon_key,
-        )
-
-    @override
-    async def update(
-        self,
-        resource_id: str,
-        resource_data: ResourceData,
-        icon: FileTypes,
-        data_key: str = "product",
-        icon_key: str = "icon",
-    ) -> Product:
-        """Update product with icon.
-
-        Args:
-            resource_id: Product ID.
-            resource_data: Product data.
-            icon: Icon image in jpg, png, GIF, etc.
-            data_key: Key for the product data.
-            icon_key: Key for the icon.
-
-        Returns:
-            Updated resource.
-        """
-        return await super().update(
-            resource_id=resource_id,
-            resource_data=resource_data,
-            data_key=data_key,
-            icon=icon,
-            icon_key=icon_key,
-        )
 
     def item_groups(self, product_id: str) -> AsyncItemGroupsService:
         """Return item_groups service."""

--- a/tests/e2e/accounts/account/test_async_account.py
+++ b/tests/e2e/accounts/account/test_async_account.py
@@ -8,9 +8,10 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 async def async_created_account(logger, async_mpt_ops, account_factory, account_icon):
+    """Fixture to create and yield an asynchronous account for testing."""
     account_data = account_factory()
 
-    res_account = await async_mpt_ops.accounts.accounts.create(account_data, logo=account_icon)
+    res_account = await async_mpt_ops.accounts.accounts.create(account_data, file=account_icon)
 
     yield res_account
 
@@ -21,6 +22,7 @@ async def async_created_account(logger, async_mpt_ops, account_factory, account_
 
 
 async def test_get_account_by_id_not_found(async_mpt_ops):
+    """Test fetching an account by an invalid ID raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.accounts.get("INVALID-ID")
 
@@ -32,6 +34,7 @@ async def test_get_account_by_id(async_mpt_ops, account_id):
 
 
 async def test_list_accounts(async_mpt_ops):
+    """Test listing accounts with a limit."""
     limit = 10
 
     result = await async_mpt_ops.accounts.accounts.fetch_page(limit=limit)
@@ -46,10 +49,11 @@ def test_create_account(async_created_account):
 
 
 async def test_update_account(async_mpt_ops, async_created_account, account_factory, account_icon):
+    """Test updating an account asynchronously."""
     updated_data = account_factory(name="Updated Account Name")
 
     result = await async_mpt_ops.accounts.accounts.update(
-        async_created_account.id, updated_data, logo=account_icon
+        async_created_account.id, updated_data, file=account_icon
     )
 
     assert result is not None
@@ -58,26 +62,29 @@ async def test_update_account(async_mpt_ops, async_created_account, account_fact
 async def test_update_account_invalid_data(
     async_mpt_ops, account_factory, async_created_account, account_icon
 ):
+    """Test updating an account with invalid data raises a 400 error."""
     updated_data = account_factory(name="")
 
     with pytest.raises(MPTAPIError, match=r"400 Bad Request"):
         await async_mpt_ops.accounts.accounts.update(
-            async_created_account.id, updated_data, logo=account_icon
+            async_created_account.id, updated_data, file=account_icon
         )
 
 
 async def test_update_account_not_found(
     async_mpt_ops, account_factory, invalid_account_id, account_icon
 ):
+    """Test updating a non-existent account raises a 404 error."""
     non_existent_account = account_factory(name="Non Existent Account")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.accounts.update(
-            invalid_account_id, non_existent_account, logo=account_icon
+            invalid_account_id, non_existent_account, file=account_icon
         )
 
 
-async def test_account_enable(async_mpt_ops, account_factory, async_created_account):
+async def test_account_enable(async_mpt_ops, async_created_account):
+    """Test enabling an account asynchronously."""
     await async_mpt_ops.accounts.accounts.disable(async_created_account.id)
 
     result = await async_mpt_ops.accounts.accounts.enable(async_created_account.id)
@@ -86,22 +93,26 @@ async def test_account_enable(async_mpt_ops, account_factory, async_created_acco
 
 
 async def test_account_enable_not_found(async_mpt_ops, invalid_account_id):
+    """Test enabling a non-existent account raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.accounts.enable(invalid_account_id)
 
 
 async def test_account_disable(async_mpt_ops, async_created_account):
+    """Test disabling an account asynchronously."""
     result = await async_mpt_ops.accounts.accounts.disable(async_created_account.id)
 
     assert result is not None
 
 
 async def test_account_disable_not_found(async_mpt_ops, invalid_account_id):
+    """Test disabling a non-existent account raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.accounts.disable(invalid_account_id)
 
 
 async def test_account_rql_filter(async_mpt_ops, account_id):
+    """Test filtering accounts using RQL asynchronously."""
     selected_fields = ["-address"]
     filtered_accounts = (
         async_mpt_ops.accounts.accounts.filter(RQLQuery(id=account_id))

--- a/tests/e2e/accounts/account/test_sync_account.py
+++ b/tests/e2e/accounts/account/test_sync_account.py
@@ -7,10 +7,11 @@ pytestmark = [pytest.mark.flaky]
 
 
 @pytest.fixture
-def created_account(logger, mpt_ops, account_factory, account_icon):
+def created_account(mpt_ops, account_factory, account_icon):
+    """Fixture to create and yield an account for testing."""
     account_data = account_factory()
 
-    res_account = mpt_ops.accounts.accounts.create(account_data, logo=account_icon)
+    res_account = mpt_ops.accounts.accounts.create(account_data, file=account_icon)
 
     yield res_account
 
@@ -21,6 +22,7 @@ def created_account(logger, mpt_ops, account_factory, account_icon):
 
 
 def test_get_account_by_id_not_found(mpt_ops):
+    """Test fetching an account by an invalid ID raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.accounts.get("INVALID-ID")
 
@@ -32,6 +34,7 @@ def test_get_account_by_id(mpt_ops, account_id):
 
 
 def test_list_accounts(mpt_ops):
+    """Test listing accounts with a limit."""
     limit = 10
 
     result = mpt_ops.accounts.accounts.fetch_page(limit=limit)
@@ -46,30 +49,34 @@ def test_create_account(created_account):
 
 
 def test_update_account(mpt_ops, created_account, account_factory, account_icon):
+    """Test updating an account synchronously."""
     updated_data = account_factory(name="Updated Account Name")
 
-    result = mpt_ops.accounts.accounts.update(created_account.id, updated_data, logo=account_icon)
+    result = mpt_ops.accounts.accounts.update(created_account.id, updated_data, file=account_icon)
 
     assert result is not None
 
 
 def test_update_account_invalid_data(mpt_ops, account_factory, created_account, account_icon):
+    """Test updating an account with invalid data raises a 400 error."""
     updated_data = account_factory(name="")
 
     with pytest.raises(MPTAPIError, match=r"400 Bad Request"):
-        mpt_ops.accounts.accounts.update(created_account.id, updated_data, logo=account_icon)
+        mpt_ops.accounts.accounts.update(created_account.id, updated_data, file=account_icon)
 
 
 def test_update_account_not_found(mpt_ops, account_factory, invalid_account_id, account_icon):
+    """Test updating a non-existent account raises a 404 error."""
     non_existent_account = account_factory(name="Non Existent Account")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.accounts.update(
-            invalid_account_id, non_existent_account, logo=account_icon
+            invalid_account_id, non_existent_account, file=account_icon
         )
 
 
-def test_account_enable(mpt_ops, account_factory, created_account):
+def test_account_enable(mpt_ops, created_account):
+    """Test enabling an account synchronously."""
     mpt_ops.accounts.accounts.disable(created_account.id)
 
     result = mpt_ops.accounts.accounts.enable(created_account.id)
@@ -78,6 +85,7 @@ def test_account_enable(mpt_ops, account_factory, created_account):
 
 
 def test_account_enable_not_found(mpt_ops, invalid_account_id):
+    """Test enabling a non-existent account raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.accounts.enable(invalid_account_id)
 
@@ -89,11 +97,13 @@ def test_account_disable(mpt_ops, created_account):
 
 
 def test_account_disable_not_found(mpt_ops, invalid_account_id):
+    """Test disabling a non-existent account raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.accounts.disable(invalid_account_id)
 
 
 def test_account_rql_filter(mpt_ops, account_id):
+    """Test filtering accounts using RQL synchronously."""
     selected_fields = ["-address"]
     filtered_accounts = (
         mpt_ops.accounts.accounts.filter(RQLQuery(id=account_id))

--- a/tests/e2e/accounts/api_tokens/test_async_api_tokens.py
+++ b/tests/e2e/accounts/api_tokens/test_async_api_tokens.py
@@ -8,6 +8,7 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 async def created_api_token(async_mpt_vendor, api_token_factory):
+    """Fixture to create and yield an asynchronous API token for testing."""
     new_api_token_request_data = api_token_factory()
     created_api_token = await async_mpt_vendor.accounts.api_tokens.create(
         new_api_token_request_data
@@ -28,6 +29,7 @@ async def test_get_api_token_by_id(async_mpt_vendor, api_token_id):
 
 
 async def test_list_api_tokens(async_mpt_vendor):
+    """Test listing API tokens with a limit."""
     limit = 10
 
     result = await async_mpt_vendor.accounts.api_tokens.fetch_page(limit=limit)
@@ -36,11 +38,13 @@ async def test_list_api_tokens(async_mpt_vendor):
 
 
 async def test_get_api_token_by_id_not_found(async_mpt_vendor, invalid_api_token_id):
+    """Test retrieving an API token by an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_vendor.accounts.api_tokens.get(invalid_api_token_id)
 
 
 async def test_filter_api_tokens(async_mpt_vendor, api_token_id):
+    """Test filtering API tokens with specific criteria."""
     select_fields = ["-description"]
     filtered_api_tokens = (
         async_mpt_vendor.accounts.api_tokens.filter(RQLQuery(id=api_token_id))
@@ -64,11 +68,13 @@ async def test_delete_api_token(async_mpt_vendor, created_api_token):
 
 
 async def test_delete_api_token_not_found(async_mpt_vendor, invalid_api_token_id):
+    """Test deleting an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_vendor.accounts.api_tokens.delete(invalid_api_token_id)
 
 
 async def test_update_api_token(async_mpt_vendor, api_token_factory, created_api_token):
+    """Test updating an API token."""
     updated_api_token_data = api_token_factory(name="E2E Updated API Token")
 
     result = await async_mpt_vendor.accounts.api_tokens.update(
@@ -81,6 +87,7 @@ async def test_update_api_token(async_mpt_vendor, api_token_factory, created_api
 async def test_update_api_token_not_found(
     async_mpt_vendor, api_token_factory, invalid_api_token_id
 ):
+    """Test updating an API token with an invalid ID, expecting a 404 error."""
     updated_api_token_data = api_token_factory(name="Nonexistent API Token")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
@@ -96,11 +103,13 @@ async def test_api_token_disable(async_mpt_vendor, created_api_token):
 
 
 async def test_api_token_disable_not_found(async_mpt_vendor, invalid_api_token_id):
+    """Test disabling an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_vendor.accounts.api_tokens.disable(invalid_api_token_id)
 
 
 async def test_api_token_enable(async_mpt_vendor, created_api_token):
+    """Test enabling an API token."""
     await async_mpt_vendor.accounts.api_tokens.disable(created_api_token.id)
 
     result = await async_mpt_vendor.accounts.api_tokens.enable(created_api_token.id)
@@ -109,5 +118,6 @@ async def test_api_token_enable(async_mpt_vendor, created_api_token):
 
 
 async def test_api_token_enable_not_found(async_mpt_vendor, invalid_api_token_id):
+    """Test enabling an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_vendor.accounts.api_tokens.enable(invalid_api_token_id)

--- a/tests/e2e/accounts/api_tokens/test_sync_api_tokens.py
+++ b/tests/e2e/accounts/api_tokens/test_sync_api_tokens.py
@@ -8,6 +8,7 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 def created_api_token(mpt_vendor, api_token_factory):
+    """Fixture to create and yield an API token for testing."""
     new_api_token_request_data = api_token_factory()
     created_api_token = mpt_vendor.accounts.api_tokens.create(new_api_token_request_data)
 
@@ -26,6 +27,7 @@ def test_get_api_token_by_id(mpt_vendor, api_token_id):
 
 
 def test_list_api_tokens(mpt_vendor):
+    """Test listing API tokens with a limit."""
     limit = 10
 
     result = mpt_vendor.accounts.api_tokens.fetch_page(limit=limit)
@@ -34,11 +36,13 @@ def test_list_api_tokens(mpt_vendor):
 
 
 def test_get_api_token_by_id_not_found(mpt_vendor, invalid_api_token_id):
+    """Test retrieving an API token by an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_vendor.accounts.api_tokens.get(invalid_api_token_id)
 
 
 def test_filter_api_tokens(mpt_vendor, api_token_id):
+    """Test filtering API tokens with specific criteria."""
     select_fields = ["-name"]
     filtered_api_tokens = (
         mpt_vendor.accounts.api_tokens.filter(RQLQuery(id=api_token_id))
@@ -62,11 +66,13 @@ def test_delete_api_token(mpt_vendor, created_api_token):
 
 
 def test_delete_api_token_not_found(mpt_vendor, invalid_api_token_id):
+    """Test deleting an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_vendor.accounts.api_tokens.delete(invalid_api_token_id)
 
 
 def test_update_api_token(mpt_vendor, api_token_factory, created_api_token):
+    """Test updating an API token."""
     updated_api_token_data = api_token_factory(name="E2E Updated API Token")
 
     result = mpt_vendor.accounts.api_tokens.update(created_api_token.id, updated_api_token_data)
@@ -75,6 +81,7 @@ def test_update_api_token(mpt_vendor, api_token_factory, created_api_token):
 
 
 def test_update_api_token_not_found(mpt_vendor, api_token_factory, invalid_api_token_id):
+    """Test updating an API token with an invalid ID, expecting a 404 error."""
     updated_api_token_data = api_token_factory(name="Nonexistent API Token")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
@@ -88,11 +95,13 @@ def test_api_token_disable(mpt_vendor, created_api_token):
 
 
 def test_api_token_disable_not_found(mpt_vendor, invalid_api_token_id):
+    """Test disabling an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_vendor.accounts.api_tokens.disable(invalid_api_token_id)
 
 
 def test_api_token_enable(mpt_vendor, created_api_token):
+    """Test enabling an API token."""
     mpt_vendor.accounts.api_tokens.disable(created_api_token.id)
 
     result = mpt_vendor.accounts.api_tokens.enable(created_api_token.id)
@@ -101,5 +110,6 @@ def test_api_token_enable(mpt_vendor, created_api_token):
 
 
 def test_api_token_enable_not_found(mpt_vendor, invalid_api_token_id):
+    """Test enabling an API token with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_vendor.accounts.api_tokens.enable(invalid_api_token_id)

--- a/tests/e2e/accounts/buyers/test_async_buyers.py
+++ b/tests/e2e/accounts/buyers/test_async_buyers.py
@@ -8,13 +8,14 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 async def async_created_buyer(async_mpt_ops, buyer_factory, buyer_account_id, account_icon):
+    """Fixture to create and yield an asynchronous buyer for testing."""
     new_buyer_request_data = buyer_factory(
         name="E2E Created Buyer",
         account_id=buyer_account_id,
     )
 
     new_buyer = await async_mpt_ops.accounts.buyers.create(
-        new_buyer_request_data, logo=account_icon
+        new_buyer_request_data, file=account_icon
     )
 
     yield new_buyer
@@ -32,6 +33,7 @@ async def test_get_buyer_by_id(async_mpt_ops, buyer_id):
 
 
 async def test_list_buyers(async_mpt_ops):
+    """Test listing buyers with a limit."""
     limit = 10
 
     result = await async_mpt_ops.accounts.buyers.fetch_page(limit=limit)
@@ -40,11 +42,13 @@ async def test_list_buyers(async_mpt_ops):
 
 
 async def test_get_buyer_by_id_not_found(async_mpt_ops, invalid_buyer_id):
+    """Test fetching a buyer by an invalid ID raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.buyers.get(invalid_buyer_id)
 
 
 async def test_filter_buyers(async_mpt_ops, buyer_id):
+    """Test filtering buyers using RQL asynchronously."""
     select_fields = ["-address"]
     async_filtered_buyers = (
         async_mpt_ops.accounts.buyers.filter(RQLQuery(id=buyer_id))
@@ -68,6 +72,7 @@ async def test_delete_buyer(async_mpt_ops, async_created_buyer):
 
 
 async def test_delete_buyer_not_found(async_mpt_ops, invalid_buyer_id):
+    """Test deleting a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.buyers.delete(invalid_buyer_id)
 
@@ -75,10 +80,11 @@ async def test_delete_buyer_not_found(async_mpt_ops, invalid_buyer_id):
 async def test_update_buyer(
     async_mpt_ops, buyer_factory, buyer_account_id, account_icon, async_created_buyer
 ):
+    """Test updating a buyer asynchronously."""
     updated_buyer_data = buyer_factory(name="E2E Updated Buyer", account_id=buyer_account_id)
 
     result = await async_mpt_ops.accounts.buyers.update(
-        async_created_buyer.id, updated_buyer_data, logo=account_icon
+        async_created_buyer.id, updated_buyer_data, file=account_icon
     )
 
     assert result is not None
@@ -87,11 +93,12 @@ async def test_update_buyer(
 async def test_update_buyer_not_found(
     async_mpt_ops, buyer_factory, buyer_account_id, account_icon, invalid_buyer_id
 ):
+    """Test updating a non-existent buyer raises a 404 error."""
     updated_buyer_data = buyer_factory(name="Nonexistent Buyer", account_id=buyer_account_id)
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.buyers.update(
-            invalid_buyer_id, updated_buyer_data, logo=account_icon
+            invalid_buyer_id, updated_buyer_data, file=account_icon
         )
 
 
@@ -102,11 +109,13 @@ async def test_buyer_disable(async_mpt_ops, async_created_buyer):
 
 
 async def test_buyer_disable_not_found(async_mpt_ops, invalid_buyer_id):
+    """Test disabling a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.buyers.disable(invalid_buyer_id)
 
 
 async def test_buyer_enable(async_mpt_ops, async_created_buyer):
+    """Test enabling a buyer asynchronously."""
     await async_mpt_ops.accounts.buyers.disable(async_created_buyer.id)
 
     result = await async_mpt_ops.accounts.buyers.enable(async_created_buyer.id)
@@ -115,5 +124,6 @@ async def test_buyer_enable(async_mpt_ops, async_created_buyer):
 
 
 async def test_buyer_enable_not_found(async_mpt_ops, invalid_buyer_id):
+    """Test enabling a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.buyers.enable(invalid_buyer_id)

--- a/tests/e2e/accounts/buyers/test_sync_buyers.py
+++ b/tests/e2e/accounts/buyers/test_sync_buyers.py
@@ -8,12 +8,13 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 def created_buyer(mpt_ops, buyer_factory, buyer_account_id, account_icon):
+    """Fixture to create and yield a buyer for testing."""
     new_buyer_request_data = buyer_factory(
         name="E2E Created Buyer",
         account_id=buyer_account_id,
     )
 
-    new_buyer = mpt_ops.accounts.buyers.create(new_buyer_request_data, logo=account_icon)
+    new_buyer = mpt_ops.accounts.buyers.create(new_buyer_request_data, file=account_icon)
 
     yield new_buyer
 
@@ -30,6 +31,7 @@ def test_get_buyer_by_id(mpt_ops, buyer_id):
 
 
 def test_list_buyers(mpt_ops):
+    """Test listing buyers with a limit."""
     limit = 10
 
     result = mpt_ops.accounts.buyers.fetch_page(limit=limit)
@@ -38,11 +40,13 @@ def test_list_buyers(mpt_ops):
 
 
 def test_get_buyer_by_id_not_found(mpt_ops, invalid_buyer_id):
+    """Test fetching a buyer by an invalid ID raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.buyers.get(invalid_buyer_id)
 
 
 def test_filter_buyers(mpt_ops, buyer_id):
+    """Test filtering buyers using RQL synchronously."""
     select_fields = ["-address"]
     filtered_buyers = (
         mpt_ops.accounts.buyers.filter(RQLQuery(id=buyer_id))
@@ -66,14 +70,16 @@ def test_delete_buyer(mpt_ops, created_buyer):
 
 
 def test_delete_buyer_not_found(mpt_ops, invalid_buyer_id):
+    """Test deleting a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.buyers.delete(invalid_buyer_id)
 
 
 def test_update_buyer(mpt_ops, buyer_factory, buyer_account_id, account_icon, created_buyer):
+    """Test updating a buyer synchronously."""
     updated_buyer_data = buyer_factory(name="E2E Updated Buyer", account_id=buyer_account_id)
 
-    result = mpt_ops.accounts.buyers.update(created_buyer.id, updated_buyer_data, logo=account_icon)
+    result = mpt_ops.accounts.buyers.update(created_buyer.id, updated_buyer_data, file=account_icon)
 
     assert result is not None
 
@@ -81,10 +87,11 @@ def test_update_buyer(mpt_ops, buyer_factory, buyer_account_id, account_icon, cr
 def test_update_buyer_not_found(
     mpt_ops, buyer_factory, buyer_account_id, account_icon, invalid_buyer_id
 ):
+    """Test updating a non-existent buyer raises a 404 error."""
     updated_buyer_data = buyer_factory(name="Nonexistent Buyer", account_id=buyer_account_id)
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
-        mpt_ops.accounts.buyers.update(invalid_buyer_id, updated_buyer_data, logo=account_icon)
+        mpt_ops.accounts.buyers.update(invalid_buyer_id, updated_buyer_data, file=account_icon)
 
 
 def test_buyer_disable(mpt_ops, created_buyer):
@@ -94,11 +101,13 @@ def test_buyer_disable(mpt_ops, created_buyer):
 
 
 def test_buyer_disable_not_found(mpt_ops, invalid_buyer_id):
+    """Test disabling a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.buyers.disable(invalid_buyer_id)
 
 
 def test_buyer_enable(mpt_ops, created_buyer):
+    """Test enabling a buyer synchronously."""
     mpt_ops.accounts.buyers.disable(created_buyer.id)
 
     result = mpt_ops.accounts.buyers.enable(created_buyer.id)
@@ -107,5 +116,6 @@ def test_buyer_enable(mpt_ops, created_buyer):
 
 
 def test_buyer_enable_not_found(mpt_ops, invalid_buyer_id):
+    """Test enabling a non-existent buyer raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.buyers.enable(invalid_buyer_id)

--- a/tests/e2e/accounts/licensees/test_async_licensees.py
+++ b/tests/e2e/accounts/licensees/test_async_licensees.py
@@ -8,10 +8,11 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 async def async_created_licensee(async_mpt_client, licensee_factory, account_icon):
+    """Fixture to create and yield an asynchronous licensee for testing."""
     new_licensee_request_data = licensee_factory(name="E2E Created licensee")
 
     new_licensee = await async_mpt_client.accounts.licensees.create(
-        new_licensee_request_data, logo=account_icon
+        new_licensee_request_data, file=account_icon
     )
 
     yield new_licensee
@@ -29,6 +30,7 @@ async def test_get_licensee_by_id(async_mpt_client, licensee_id):
 
 
 async def test_list_licensees(async_mpt_client):
+    """Test listing licensees with a limit."""
     limit = 10
 
     result = await async_mpt_client.accounts.licensees.fetch_page(limit=limit)
@@ -37,11 +39,13 @@ async def test_list_licensees(async_mpt_client):
 
 
 async def test_get_licensee_by_id_not_found(async_mpt_client, invalid_licensee_id):
+    """Test fetching a licensee by an invalid ID raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_client.accounts.licensees.get(invalid_licensee_id)
 
 
 async def test_filter_licensees(async_mpt_client, licensee_id):
+    """Test filtering licensees using RQL asynchronously."""
     select_fields = ["-address"]
     async_filtered_licensees = (
         async_mpt_client.accounts.licensees.filter(RQLQuery(id=licensee_id))
@@ -61,10 +65,12 @@ def test_create_licensee(async_created_licensee):
 
 
 async def test_delete_licensee(async_mpt_client, async_created_licensee):
+    """Test deleting a licensee asynchronously."""
     await async_mpt_client.accounts.licensees.delete(async_created_licensee.id)
 
 
 async def test_delete_licensee_not_found(async_mpt_client, invalid_licensee_id):
+    """Test deleting a non-existent licensee raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_client.accounts.licensees.delete(invalid_licensee_id)
 
@@ -72,10 +78,11 @@ async def test_delete_licensee_not_found(async_mpt_client, invalid_licensee_id):
 async def test_update_licensee(
     async_mpt_client, licensee_factory, account_icon, async_created_licensee
 ):
+    """Test updating a licensee asynchronously."""
     updated_licensee_data = licensee_factory(name="E2E Updated Licensee")
 
     result = await async_mpt_client.accounts.licensees.update(
-        async_created_licensee.id, updated_licensee_data, logo=account_icon
+        async_created_licensee.id, updated_licensee_data, file=account_icon
     )
 
     assert result is not None
@@ -84,11 +91,12 @@ async def test_update_licensee(
 async def test_update_licensee_not_found(
     async_mpt_client, licensee_factory, account_icon, invalid_licensee_id
 ):
+    """Test updating a non-existent licensee raises a 404 error."""
     updated_licensee_data = licensee_factory(name="Nonexistent Licensee")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_client.accounts.licensees.update(
-            invalid_licensee_id, updated_licensee_data, logo=account_icon
+            invalid_licensee_id, updated_licensee_data, file=account_icon
         )
 
 
@@ -99,11 +107,13 @@ async def test_licensee_disable(async_mpt_client, async_created_licensee):
 
 
 async def test_licensee_disable_not_found(async_mpt_client, invalid_licensee_id):
+    """Test disabling a non-existent licensee raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_client.accounts.licensees.disable(invalid_licensee_id)
 
 
 async def test_licensee_enable(async_mpt_client, async_created_licensee):
+    """Test enabling a licensee asynchronously."""
     await async_mpt_client.accounts.licensees.disable(async_created_licensee.id)
 
     result = await async_mpt_client.accounts.licensees.enable(async_created_licensee.id)
@@ -112,5 +122,6 @@ async def test_licensee_enable(async_mpt_client, async_created_licensee):
 
 
 async def test_licensee_enable_not_found(async_mpt_client, invalid_licensee_id):
+    """Test enabling a non-existent licensee raises a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_client.accounts.licensees.enable(invalid_licensee_id)

--- a/tests/e2e/accounts/licensees/test_sync_licensees.py
+++ b/tests/e2e/accounts/licensees/test_sync_licensees.py
@@ -11,7 +11,7 @@ def created_licensee(mpt_client, licensee_factory, account_icon):
     new_licensee_request_data = licensee_factory(name="E2E Created licensee")
 
     new_licensee = mpt_client.accounts.licensees.create(
-        new_licensee_request_data, logo=account_icon
+        new_licensee_request_data, file=account_icon
     )
 
     yield new_licensee
@@ -73,7 +73,7 @@ def test_update_licensee(mpt_client, licensee_factory, account_icon, created_lic
     updated_licensee_data = licensee_factory(name="E2E Updated Licensee")
 
     result = mpt_client.accounts.licensees.update(
-        created_licensee.id, updated_licensee_data, logo=account_icon
+        created_licensee.id, updated_licensee_data, file=account_icon
     )
 
     assert result is not None
@@ -84,7 +84,7 @@ def test_update_licensee_not_found(mpt_client, licensee_factory, account_icon, i
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_client.accounts.licensees.update(
-            invalid_licensee_id, updated_licensee_data, logo=account_icon
+            invalid_licensee_id, updated_licensee_data, file=account_icon
         )
 
 

--- a/tests/e2e/accounts/user_groups/test_async_user_groups.py
+++ b/tests/e2e/accounts/user_groups/test_async_user_groups.py
@@ -8,6 +8,7 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 async def created_user_group(async_mpt_ops, user_group_factory):
+    """Fixture to create and yield an asynchronous user group for testing."""
     new_user_group_request_data = user_group_factory()
     created_user_group = await async_mpt_ops.accounts.user_groups.create(
         new_user_group_request_data
@@ -22,11 +23,13 @@ async def created_user_group(async_mpt_ops, user_group_factory):
 
 
 async def test_get_user_group_by_id(async_mpt_ops, user_group_id):
+    """Test retrieving a user group by its ID."""
     user_group = await async_mpt_ops.accounts.user_groups.get(user_group_id)
     assert user_group is not None
 
 
 async def test_list_user_groups(async_mpt_ops):
+    """Test listing user groups with a limit."""
     limit = 10
 
     result = await async_mpt_ops.accounts.user_groups.fetch_page(limit=limit)
@@ -35,11 +38,13 @@ async def test_list_user_groups(async_mpt_ops):
 
 
 async def test_get_user_group_by_id_not_found(async_mpt_ops, invalid_user_group_id):
+    """Test retrieving a user group by an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.user_groups.get(invalid_user_group_id)
 
 
 async def test_filter_user_groups(async_mpt_ops, user_group_id):
+    """Test filtering user groups with specific criteria."""
     select_fields = ["-name"]
     filtered_user_groups = (
         async_mpt_ops.accounts.user_groups.filter(RQLQuery(id=user_group_id))
@@ -63,11 +68,13 @@ async def test_delete_user_group(async_mpt_ops, created_user_group):
 
 
 async def test_delete_user_group_not_found(async_mpt_ops, invalid_user_group_id):
+    """Test deleting a user group with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_mpt_ops.accounts.user_groups.delete(invalid_user_group_id)
 
 
 async def test_update_user_group(async_mpt_ops, user_group_factory, created_user_group):
+    """Test updating a user group."""
     updated_user_group_data = user_group_factory(name="E2E Updated User Group")
 
     result = await async_mpt_ops.accounts.user_groups.update(
@@ -80,6 +87,7 @@ async def test_update_user_group(async_mpt_ops, user_group_factory, created_user
 async def test_update_user_group_not_found(
     async_mpt_ops, user_group_factory, invalid_user_group_id
 ):
+    """Test updating a user group with an invalid ID, expecting a 404 error."""
     updated_user_group_data = user_group_factory(name="Nonexistent User Group")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):

--- a/tests/e2e/accounts/user_groups/test_sync_user_groups.py
+++ b/tests/e2e/accounts/user_groups/test_sync_user_groups.py
@@ -8,6 +8,7 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 def created_user_group(mpt_ops, user_group_factory):
+    """Fixture to create and yield a user group for testing."""
     new_user_group_request_data = user_group_factory()
     created_user_group = mpt_ops.accounts.user_groups.create(new_user_group_request_data)
 
@@ -26,6 +27,7 @@ def test_get_user_group_by_id(mpt_ops, user_group_id):
 
 
 def test_list_user_groups(mpt_ops):
+    """Test listing user groups with a limit."""
     limit = 10
 
     result = mpt_ops.accounts.user_groups.fetch_page(limit=limit)
@@ -34,11 +36,13 @@ def test_list_user_groups(mpt_ops):
 
 
 def test_get_user_group_by_id_not_found(mpt_ops, invalid_user_group_id):
+    """Test retrieving a user group by an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.user_groups.get(invalid_user_group_id)
 
 
 def test_filter_user_groups(mpt_ops, user_group_id):
+    """Test filtering user groups with specific criteria."""
     select_fields = ["-name"]
     filtered_user_groups = (
         mpt_ops.accounts.user_groups.filter(RQLQuery(id=user_group_id))
@@ -62,11 +66,13 @@ def test_delete_user_group(mpt_ops, created_user_group):
 
 
 def test_delete_user_group_not_found(mpt_ops, invalid_user_group_id):
+    """Test deleting a user group with an invalid ID, expecting a 404 error."""
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         mpt_ops.accounts.user_groups.delete(invalid_user_group_id)
 
 
 def test_update_user_group(mpt_ops, user_group_factory, created_user_group):
+    """Test updating a user group."""
     updated_user_group_data = user_group_factory(name="E2E Updated User Group")
 
     result = mpt_ops.accounts.user_groups.update(created_user_group.id, updated_user_group_data)
@@ -75,6 +81,7 @@ def test_update_user_group(mpt_ops, user_group_factory, created_user_group):
 
 
 def test_update_user_group_not_found(mpt_ops, user_group_factory, invalid_user_group_id):
+    """Test updating a user group with an invalid ID, expecting a 404 error."""
     updated_user_group_data = user_group_factory(name="Nonexistent User Group")
 
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):

--- a/tests/e2e/catalog/product/test_async_product.py
+++ b/tests/e2e/catalog/product/test_async_product.py
@@ -6,7 +6,7 @@ from mpt_api_client.exceptions import MPTAPIError
 
 @pytest.fixture
 async def async_created_product(async_mpt_vendor, product_data, logo_fd):
-    product = await async_mpt_vendor.catalog.products.create(product_data, icon=logo_fd)
+    product = await async_mpt_vendor.catalog.products.create(product_data, file=logo_fd)
 
     yield product
 
@@ -30,7 +30,7 @@ async def test_update_product(async_mpt_vendor, async_created_product, logo_fd):
     result = await async_mpt_vendor.catalog.products.update(
         async_created_product.id,
         update_data,
-        icon=logo_fd,
+        file=logo_fd,
     )
 
     assert result.name == update_data["name"]

--- a/tests/e2e/catalog/product/test_sync_product.py
+++ b/tests/e2e/catalog/product/test_sync_product.py
@@ -6,7 +6,7 @@ from mpt_api_client.exceptions import MPTAPIError
 
 @pytest.fixture
 def created_product(mpt_vendor, product_data, logo_fd):
-    product = mpt_vendor.catalog.products.create(product_data, icon=logo_fd)
+    product = mpt_vendor.catalog.products.create(product_data, file=logo_fd)
 
     yield product
 
@@ -27,7 +27,7 @@ def test_create_product(created_product, product_data):
 def test_update_product(mpt_vendor, created_product, logo_fd):
     update_data = {"name": "Updated Product"}
 
-    result = mpt_vendor.catalog.products.update(created_product.id, update_data, icon=logo_fd)
+    result = mpt_vendor.catalog.products.update(created_product.id, update_data, file=logo_fd)
 
     assert result.name == update_data["name"]
 

--- a/tests/unit/resources/accounts/test_account.py
+++ b/tests/unit/resources/accounts/test_account.py
@@ -89,7 +89,7 @@ def test_account_create(account_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.CREATED, json=account_data)
         )
 
-        result = account_service.create(account_data, logo=logo_file)
+        result = account_service.create(account_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -110,7 +110,7 @@ def test_account_update(account_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.OK, json={"id": account_id, **account_data})
         )
 
-        result = account_service.update(account_id, account_data, logo=logo_file)
+        result = account_service.update(account_id, account_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -131,7 +131,7 @@ async def test_async_account_create(async_account_service, tmp_path):  # noqa: W
             return_value=httpx.Response(httpx.codes.CREATED, json=account_data)
         )
 
-        result = await async_account_service.create(account_data, logo=logo_file)
+        result = await async_account_service.create(account_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -152,7 +152,7 @@ async def test_async_account_update(async_account_service, tmp_path):  # noqa: W
             return_value=httpx.Response(httpx.codes.OK, json={"id": account_id, **account_data})
         )
 
-        result = await async_account_service.update(account_id, account_data, logo=logo_file)
+        result = await async_account_service.update(account_id, account_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1

--- a/tests/unit/resources/accounts/test_buyers.py
+++ b/tests/unit/resources/accounts/test_buyers.py
@@ -177,7 +177,7 @@ def test_buyers_create(buyers_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.CREATED, json=buyer_data)
         )
 
-        result = buyers_service.create(buyer_data, logo=logo_file)
+        result = buyers_service.create(buyer_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -198,7 +198,7 @@ def test_buyers_update(buyers_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.OK, json={"id": buyer_id, **buyer_data})
         )
 
-        result = buyers_service.update(buyer_id, buyer_data, logo=logo_file)
+        result = buyers_service.update(buyer_id, buyer_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -219,7 +219,7 @@ async def test_async_buyers_create(async_buyers_service, tmp_path):  # noqa: WPS
             return_value=httpx.Response(httpx.codes.CREATED, json=buyer_data)
         )
 
-        result = await async_buyers_service.create(buyer_data, logo=logo_file)
+        result = await async_buyers_service.create(buyer_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -241,7 +241,7 @@ async def test_async_buyers_update(async_buyers_service, tmp_path):  # noqa: WPS
             return_value=httpx.Response(httpx.codes.OK, json={"id": buyer_id, **buyer_data})
         )
 
-        result = await async_buyers_service.update(buyer_id, buyer_data, logo=logo_file)
+        result = await async_buyers_service.update(buyer_id, buyer_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1

--- a/tests/unit/resources/accounts/test_licensees.py
+++ b/tests/unit/resources/accounts/test_licensees.py
@@ -47,7 +47,7 @@ def test_create_licensee(licensees_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.CREATED, json=licensee_data)
         )
 
-        result = licensees_service.create(licensee_data, logo=logo_file)
+        result = licensees_service.create(licensee_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -68,7 +68,7 @@ def test_update_licensees(licensees_service, tmp_path):  # noqa: WPS210
             return_value=httpx.Response(httpx.codes.OK, json={"id": licensee_id, **licensee_data})
         )
 
-        result = licensees_service.update(licensee_id, licensee_data, logo=logo_file)
+        result = licensees_service.update(licensee_id, licensee_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -89,7 +89,7 @@ async def test_async_create_licensees(async_licensees_service, tmp_path):  # noq
             return_value=httpx.Response(httpx.codes.CREATED, json=licensee_data)
         )
 
-        licensee = await async_licensees_service.create(licensee_data, logo=logo_file)
+        licensee = await async_licensees_service.create(licensee_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1
@@ -110,7 +110,7 @@ async def test_async_update_licensees(async_licensees_service, tmp_path):  # noq
             return_value=httpx.Response(httpx.codes.OK, json={"id": licensee_id, **licensee_data})
         )
 
-        licensee = await async_licensees_service.update(licensee_id, licensee_data, logo=logo_file)
+        licensee = await async_licensees_service.update(licensee_id, licensee_data, file=logo_file)
 
     request = mock_route.calls[0].request
     assert mock_route.call_count == 1

--- a/tests/unit/resources/accounts/test_mixins.py
+++ b/tests/unit/resources/accounts/test_mixins.py
@@ -3,6 +3,12 @@ import pytest
 import respx
 
 from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCreateFileMixin,
+    AsyncUpdateFileMixin,
+    CreateFileMixin,
+    UpdateFileMixin,
+)
 from mpt_api_client.resources.accounts.mixins import (
     ActivatableMixin,
     AsyncActivatableMixin,
@@ -108,6 +114,50 @@ class DummyAsyncInvitableService(
     _collection_key = "data"
 
 
+class DummyCreateFileService(
+    CreateFileMixin[DummyModel],
+    Service[DummyModel],
+):
+    _endpoint = "/public/v1/dummy/create-file/"
+    _model_class = DummyModel
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "resource"
+
+
+class AsyncDummyCreateFileService(
+    AsyncCreateFileMixin[DummyModel],
+    AsyncService[DummyModel],
+):
+    _endpoint = "/public/v1/dummy/create-file/"
+    _model_class = DummyModel
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "resource"
+
+
+class DummyUpdateFileService(
+    UpdateFileMixin[DummyModel],
+    Service[DummyModel],
+):
+    _endpoint = "/public/v1/dummy/update-file/"
+    _model_class = DummyModel
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "resource"
+
+
+class DummyAsyncUpdateFileService(
+    AsyncUpdateFileMixin[DummyModel],
+    AsyncService[DummyModel],
+):
+    _endpoint = "/public/v1/dummy/update-file/"
+    _model_class = DummyModel
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "resource"
+
+
 @pytest.fixture
 def activatable_service(http_client):
     return DummyActivatableService(http_client=http_client)
@@ -156,6 +206,26 @@ def invitable_service(http_client):
 @pytest.fixture
 def async_invitable_service(async_http_client):
     return DummyAsyncInvitableService(http_client=async_http_client)
+
+
+@pytest.fixture
+def create_file_service(http_client):
+    return DummyCreateFileService(http_client=http_client)
+
+
+@pytest.fixture
+def async_create_file_service(async_http_client):
+    return AsyncDummyCreateFileService(http_client=async_http_client)
+
+
+@pytest.fixture
+def update_file_service(http_client):
+    return DummyUpdateFileService(http_client=http_client)
+
+
+@pytest.fixture
+def async_update_file_service(async_http_client):
+    return DummyAsyncUpdateFileService(http_client=async_http_client)
 
 
 @pytest.mark.parametrize(
@@ -753,5 +823,177 @@ async def test_async_invitable_resource_actions_no_data(
         assert mock_route.call_count == 1
         request = mock_route.calls[0].request
         assert request.content == request_expected_content
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+def test_create_file_service(create_file_service, tmp_path):  # noqa: WPS210
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.post("https://api.example.com/public/v1/dummy/create-file/").mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        file_path = tmp_path / "file.png"
+        file_path.write_bytes(b"fake-file-data")
+
+        with file_path.open("rb") as file_file:
+            result = create_file_service.create(resource_data, file_file)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+def test_create_file_service_no_file(create_file_service):
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.post("https://api.example.com/public/v1/dummy/create-file/").mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+
+        result = create_file_service.create(resource_data, None)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+async def test_async_create_file_service(async_create_file_service, tmp_path):  # noqa: WPS210
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.post("https://api.example.com/public/v1/dummy/create-file/").mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        file_path = tmp_path / "file.png"
+        file_path.write_bytes(b"fake-file-data")
+
+        with file_path.open("rb") as file_file:
+            result = await async_create_file_service.create(resource_data, file_file)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+async def test_async_create_file_service_no_file(async_create_file_service):
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.post("https://api.example.com/public/v1/dummy/create-file/").mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        result = await async_create_file_service.create(resource_data, None)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+def test_update_file_service(update_file_service, tmp_path):  # noqa: WPS210
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.put(
+            "https://api.example.com/public/v1/dummy/update-file/OBJ-0000-0001"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        update_file_path = tmp_path / "file.png"
+        update_file_path.write_bytes(b"updated file content")
+
+        with update_file_path.open("rb") as update_file:
+            result = update_file_service.update("OBJ-0000-0001", resource_data, update_file)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+def test_update_file_service_no_file(update_file_service):
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.put(
+            "https://api.example.com/public/v1/dummy/update-file/OBJ-0000-0001"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+
+        result = update_file_service.update("OBJ-0000-0001", resource_data, None)
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+async def test_async_update_file_service(async_update_file_service, tmp_path):  # noqa: WPS210
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.put(
+            "https://api.example.com/public/v1/dummy/update-file/OBJ-0000-0001"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        update_file_path = tmp_path / "file.png"
+        update_file_path.write_bytes(b"updated file content")
+
+        with update_file_path.open("rb") as update_file:
+            result = await async_update_file_service.update(
+                "OBJ-0000-0001", resource_data, update_file
+            )
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+        assert isinstance(result, DummyModel)
+
+
+async def test_async_update_file_service_no_file(async_update_file_service):
+    resource_data = {"name": "Test File"}
+    response_expected_data = {"id": "OBJ-0000-0001", **resource_data}
+    with respx.mock:
+        mock_route = respx.put(
+            "https://api.example.com/public/v1/dummy/update-file/OBJ-0000-0001"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+        result = await async_update_file_service.update("OBJ-0000-0001", resource_data, None)
+
+        assert mock_route.call_count == 1
         assert result.to_dict() == response_expected_data
         assert isinstance(result, DummyModel)

--- a/tests/unit/resources/catalog/test_mixins.py
+++ b/tests/unit/resources/catalog/test_mixins.py
@@ -17,7 +17,7 @@ from mpt_api_client.resources.catalog.mixins import (
 from tests.unit.conftest import DummyModel
 
 
-class DummyPublishableService(  # noqa: WPS215
+class DummyPublishableService(
     PublishableMixin[DummyModel],
     Service[DummyModel],
 ):
@@ -26,7 +26,7 @@ class DummyPublishableService(  # noqa: WPS215
     _collection_key = "data"
 
 
-class DummyAsyncPublishableService(  # noqa: WPS215
+class DummyAsyncPublishableService(
     AsyncPublishableMixin[DummyModel],
     AsyncService[DummyModel],
 ):
@@ -35,7 +35,7 @@ class DummyAsyncPublishableService(  # noqa: WPS215
     _collection_key = "data"
 
 
-class DummyActivatableService(  # noqa: WPS215
+class DummyActivatableService(
     ActivatableMixin[DummyModel],
     Service[DummyModel],
 ):
@@ -44,7 +44,7 @@ class DummyActivatableService(  # noqa: WPS215
     _collection_key = "data"
 
 
-class DummyAsyncActivatableService(  # noqa: WPS215
+class DummyAsyncActivatableService(
     AsyncActivatableMixin[DummyModel],
     AsyncService[DummyModel],
 ):
@@ -53,7 +53,7 @@ class DummyAsyncActivatableService(  # noqa: WPS215
     _collection_key = "data"
 
 
-class DummyDocumentService(  # noqa: WPS215
+class DummyDocumentService(
     DocumentMixin[DummyModel],
     Service[DummyModel],
 ):
@@ -64,7 +64,7 @@ class DummyDocumentService(  # noqa: WPS215
     _upload_data_key = "document"
 
 
-class DummyAsyncDocumentService(  # noqa: WPS215
+class DummyAsyncDocumentService(
     AsyncDocumentMixin[DummyModel],
     AsyncService[DummyModel],
 ):

--- a/tests/unit/resources/catalog/test_products.py
+++ b/tests/unit/resources/catalog/test_products.py
@@ -148,7 +148,7 @@ def test_product_create(products_service, tmp_path):
             return_value=httpx.Response(httpx.codes.CREATED, json=expected_response)
         )
 
-        result = products_service.create(product_data, icon=icon_file)
+        result = products_service.create(product_data, file=icon_file)
 
     assert mock_route.call_count == 1
     request = mock_route.calls[0].request
@@ -168,7 +168,7 @@ async def test_async_product_create(async_products_service, tmp_path):
             return_value=httpx.Response(httpx.codes.CREATED, json=expected_response)
         )
 
-        result = await async_products_service.create(product_data, icon=icon_file)
+        result = await async_products_service.create(product_data, file=icon_file)
 
     assert mock_route.call_count == 1
     request = mock_route.calls[0].request
@@ -188,7 +188,11 @@ def test_sync_product_update(products_service, tmp_path):
             f"https://api.example.com/public/v1/catalog/products/{product_id}"
         ).mock(return_value=httpx.Response(httpx.codes.OK, json=expected_response))
 
-        result = products_service.update(product_id, update_data, icon=icon_file)
+        result = products_service.update(
+            product_id,
+            update_data,
+            file=icon_file,
+        )
 
     assert mock_route.call_count == 1
     request = mock_route.calls[0].request
@@ -208,7 +212,11 @@ async def test_async_product_update(async_products_service, tmp_path):
             f"https://api.example.com/public/v1/catalog/products/{product_id}"
         ).mock(return_value=httpx.Response(httpx.codes.OK, json=expected_response))
 
-        result = await async_products_service.update(product_id, update_data, icon=icon_file)
+        result = await async_products_service.update(
+            product_id,
+            update_data,
+            file=icon_file,
+        )
 
     assert mock_route.call_count == 1
     request = mock_route.calls[0].request


### PR DESCRIPTION
Update implementation of create and update mixin with file
Updated creating and updating product so previous create and update mixin with logo can be completely removed

https://softwareone.atlassian.net/browse/MPT-15606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized file-upload parameter (file=...) for create/update across accounts, buyers, licensees, products and related services; per-resource upload keys and multipart handling added.
* **Bug Fixes**
  * Removed legacy icon-specific variants and unified create/update flows to use file payloads, simplifying upload behavior.
* **Tests**
  * Updated tests to use file=..., added docstrings, expanded async and 404/not-found coverage.
* **Chores**
  * Small import and cosmetic cleanup across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->