### PR TITLE
[MPT-14865] Added Accounts account by id users endpoints e2e tests

### DIFF
--- a/.github/workflows/pr-build-merge.yml
+++ b/.github/workflows/pr-build-merge.yml
@@ -41,7 +41,7 @@ jobs:
       run: docker compose run --service-ports app_test
 
     - name: "Run E2E test"
-      run: docker compose run --service-ports e2e bash -c "pytest -v -p no:randomly --no-cov --reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT --junitxml=e2e-report.xml tests/e2e"
+      run: docker compose run --service-ports e2e bash -c "pytest -v -p no:randomly --no-cov --junitxml=e2e-report.xml tests/e2e"
       env:
         RP_LAUNCH: github-e2e-test
         RP_ENDPOINT: ${{ secrets.RP_ENDPOINT }}

--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -9,6 +9,7 @@
   "accounts.module.id": "MOD-1756",
   "accounts.module.name": "Access Management",
   "accounts.seller.id": "SEL-7310-3075",
+  "accounts.user.id": "USR-9673-3314",
   "accounts.user_group.id": "UGR-6822-0561",
   "catalog.product.item.id": "ITM-7255-3950-0751",
   "catalog.product.document.id": "PDC-7255-3950-0001",

--- a/mpt_api_client/resources/accounts/accounts_user_groups.py
+++ b/mpt_api_client/resources/accounts/accounts_user_groups.py
@@ -1,11 +1,16 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncManagedResourceMixin,
+    AsyncCreateMixin,
+    AsyncDeleteMixin,
+    AsyncGetMixin,
     CollectionMixin,
-    ManagedResourceMixin,
+    CreateMixin,
+    DeleteMixin,
+    GetMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.models.model import ResourceData
 
 
 class AccountsUserGroup(Model):
@@ -21,18 +26,48 @@ class AccountsUserGroupsServiceConfig:
 
 
 class AccountsUserGroupsService(
-    ManagedResourceMixin[AccountsUserGroup],
+    GetMixin[AccountsUserGroup],
+    CreateMixin[AccountsUserGroup],
+    DeleteMixin,
     CollectionMixin[AccountsUserGroup],
     Service[AccountsUserGroup],
     AccountsUserGroupsServiceConfig,
 ):
     """Account User Groups Service."""
 
+    def update(self, resource_data: ResourceData) -> AccountsUserGroup:
+        """Update Account User Group.
+
+        Args:
+            resource_data (ResourceData): Resource data to update.
+
+        Returns:
+            AccountsUserGroup: Updated Account User Group.
+        """
+        response = self.http_client.request("put", self.path, json=resource_data)
+
+        return self._model_class.from_response(response)
+
 
 class AsyncAccountsUserGroupsService(
-    AsyncManagedResourceMixin[AccountsUserGroup],
+    AsyncGetMixin[AccountsUserGroup],
+    AsyncCreateMixin[AccountsUserGroup],
+    AsyncDeleteMixin,
     AsyncCollectionMixin[AccountsUserGroup],
     AsyncService[AccountsUserGroup],
     AccountsUserGroupsServiceConfig,
 ):
     """Asynchronous Account User Groups Service."""
+
+    async def update(self, resource_data: ResourceData) -> AccountsUserGroup:
+        """Update Account User Group.
+
+        Args:
+            resource_data (ResourceData): Resource data to update.
+
+        Returns:
+            AccountsUserGroup: Updated Account User Group.
+        """
+        response = await self.http_client.request("put", self.path, json=resource_data)
+
+        return self._model_class.from_response(response)

--- a/tests/e2e/accounts/accounts_users/conftest.py
+++ b/tests/e2e/accounts/accounts_users/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.fixture
+def invalid_user_id():
+    return "USR-0000-0000"
+
+
+@pytest.fixture
+def account_user_factory(account_id, user_group_id, uuid_str):
+    def _account_user(  # noqa: WPS430
+        email: str | None = None,  # Must be unique in Marketplace
+        first_name: str = "E2E Created",
+        last_name: str = "Account User",
+    ):
+        if not email:
+            email = f"e2e_{uuid_str}@dummy.com"
+
+        return {
+            "user": {
+                "firstName": first_name,
+                "lastName": last_name,
+                "email": email,
+            },
+            "account": {
+                "id": account_id,
+            },
+            "groups": [
+                {"id": user_group_id},
+            ],
+            "invitation": {
+                "status": "Invited",
+            },
+        }
+
+    return _account_user

--- a/tests/e2e/accounts/accounts_users/test_async_accounts_users.py
+++ b/tests/e2e/accounts/accounts_users/test_async_accounts_users.py
@@ -1,0 +1,199 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def users(async_mpt_vendor, account_id):
+    return async_mpt_vendor.accounts.accounts.users(account_id=account_id)  # noqa: WPS204
+
+
+@pytest.fixture
+async def created_account_user(async_mpt_vendor, account_user_factory, account_id):
+    """Fixture to create and teardown an account user."""
+    ret_account_user = None
+
+    async def _created_account_user(
+        first_name: str = "E2E Created",
+        last_name: str = "Account User",
+    ):
+        """Create an account user with the given first and last name."""
+        nonlocal ret_account_user  # noqa: WPS420
+        account_user_data = account_user_factory(
+            first_name=first_name,
+            last_name=last_name,
+        )
+        users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+        ret_account_user = await users_obj.create(account_user_data)
+        return ret_account_user
+
+    yield _created_account_user
+
+    if ret_account_user:
+        users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+        try:
+            await users_obj.delete(ret_account_user.id)
+        except MPTAPIError as error:
+            print(  # noqa: WPS421
+                f"TEARDOWN - Unable to delete account user {ret_account_user.id}: "
+                f"{getattr(error, 'title', str(error))}"
+            )
+
+
+@pytest.fixture
+async def created_user_group(async_mpt_ops, user_group_factory):
+    """Fixture to create and teardown a user group."""
+    new_user_group_request_data = user_group_factory()
+    created_user_group = await async_mpt_ops.accounts.user_groups.create(
+        new_user_group_request_data
+    )
+
+    yield created_user_group
+
+    try:
+        await async_mpt_ops.accounts.user_groups.delete(created_user_group.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete user group: {getattr(error, 'title', str(error))}")  # noqa: WPS421
+
+
+@pytest.fixture
+async def created_account_user_group(  # noqa: WPS210
+    async_mpt_vendor, created_account_user, created_user_group, account_id
+):
+    """Fixture to create and teardown an account user group."""
+    created_account_user_data = await created_account_user()
+    user_group_data = created_user_group
+    create_user_group_data = {"id": user_group_data.id}
+    users = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    created_account_user_group = await users.groups(user_id=created_account_user_data.id).create(
+        create_user_group_data
+    )
+    yield created_account_user_group
+
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    try:
+        await users_obj.groups(user_id=created_account_user_data.id).delete(user_group_data.id)
+    except MPTAPIError as error:
+        print(  # noqa: WPS421
+            f"TEARDOWN - Unable to delete account user group: {getattr(error, 'title', str(error))}"
+        )
+
+
+async def test_get_account_user_by_id(async_mpt_vendor, user_id, account_id):
+    """Test retrieving an account user by ID."""
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    account_user = await users_obj.get(user_id)
+    assert account_user is not None
+
+
+async def test_list_account_users(async_mpt_vendor, account_id):
+    """Test listing account users."""
+    limit = 10
+
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    account_users = await users_obj.fetch_page(limit=limit)
+
+    assert len(account_users) > 0
+
+
+async def test_get_account_user_by_id_not_found(async_mpt_vendor, invalid_user_id, account_id):
+    """Test retrieving an account user by invalid ID."""
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await users_obj.get(invalid_user_id)
+
+
+async def test_filter_account_users(async_mpt_vendor, user_id, account_id):
+    """Test filtering account users."""
+    select_fields = ["-name"]
+
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    filtered_account_users = users_obj.filter(RQLQuery(id=user_id)).select(*select_fields)
+    account_users = [user async for user in filtered_account_users.iterate()]
+
+    assert len(account_users) == 1
+
+
+async def test_create_account_user(created_account_user):
+    """Test creating an account user."""
+    account_user_data = await created_account_user()
+    assert account_user_data is not None
+
+
+async def test_delete_account_user(async_mpt_vendor, created_account_user, account_id):
+    """Test deleting an account user."""
+    account_user_data = await created_account_user()
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    await users_obj.delete(account_user_data.id)
+
+
+async def test_update_account_user(
+    async_mpt_vendor,
+    account_user_factory,
+    created_account_user,
+    account_id,
+):
+    """Test updating an account user."""
+    account_user_data = await created_account_user()
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    updated_account_user_data = account_user_factory(
+        first_name="E2E Updated",
+        last_name="Account User",
+    )
+    updated_account_user = await users_obj.update(
+        account_user_data.id,
+        updated_account_user_data,
+    )
+    assert updated_account_user is not None
+
+
+async def test_account_user_resend_invite(
+    async_mpt_vendor,
+    created_account_user,
+    account_id,
+):
+    """Test resending an invite to an account user."""
+    account_user_data = await created_account_user()
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    resend_invite = await users_obj.resend_invite(account_user_data.id)
+    assert resend_invite is not None
+
+
+def test_account_user_group_post(created_account_user_group):  # noqa: AAA01
+    """Test creating an account user group."""
+    created_account_user_group_data = created_account_user_group
+    assert created_account_user_group_data is not None
+
+
+async def test_account_user_group_update(
+    async_mpt_vendor,
+    created_account_user,
+    created_user_group,
+    account_id,
+):
+    """Test updating an account user group."""
+    created_account_user_data = await created_account_user()
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    update_user_group_data = [{"id": created_user_group.id}]
+    updated_account_user_group = await users_obj.groups(
+        user_id=created_account_user_data.id
+    ).update(update_user_group_data)
+    assert updated_account_user_group is not None
+
+
+async def test_account_user_group_delete(
+    async_mpt_vendor,
+    created_account_user,
+    created_user_group,
+    account_id,
+):
+    """Test deleting an account user group."""
+    created_account_user_data = await created_account_user()
+    users_obj = async_mpt_vendor.accounts.accounts.users(account_id=account_id)
+    create_user_group_data = {"id": created_user_group.id}
+    await users_obj.groups(user_id=created_account_user_data.id).create(create_user_group_data)
+    await users_obj.groups(user_id=created_account_user_data.id).delete(created_user_group.id)

--- a/tests/e2e/accounts/accounts_users/test_sync_accounts_users.py
+++ b/tests/e2e/accounts/accounts_users/test_sync_accounts_users.py
@@ -1,0 +1,203 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def users(mpt_vendor, account_id):
+    return mpt_vendor.accounts.accounts.users(account_id=account_id)  # noqa: WPS204
+
+
+@pytest.fixture
+def created_account_user(mpt_vendor, account_user_factory, account_id):
+    """Fixture to create and teardown an account user."""
+    ret_account_user = None
+
+    def _created_account_user(
+        first_name: str = "E2E Created",
+        last_name: str = "Account User",
+    ):
+        """Create an account user with the given first and last name."""
+        nonlocal ret_account_user  # noqa: WPS420
+        account_user_data = account_user_factory(
+            first_name=first_name,
+            last_name=last_name,
+        )
+        users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+        ret_account_user = users_obj.create(account_user_data)
+        return ret_account_user
+
+    yield _created_account_user
+
+    if ret_account_user:
+        users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+        try:
+            users_obj.delete(ret_account_user.id)
+        except MPTAPIError:
+            print(  # noqa: WPS421
+                f"TEARDOWN - Unable to delete account user {ret_account_user.id}",
+            )
+
+
+@pytest.fixture
+def created_user_group(mpt_ops, user_group_factory):
+    """Fixture to create and teardown a user group."""
+    new_user_group_request_data = user_group_factory()
+    created_user_group = mpt_ops.accounts.user_groups.create(new_user_group_request_data)
+
+    yield created_user_group
+
+    try:
+        mpt_ops.accounts.user_groups.delete(created_user_group.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete user group: {error.title}")  # noqa: WPS421
+
+
+@pytest.fixture
+def created_account_user_group(mpt_vendor, created_account_user, created_user_group, account_id):  # noqa: WPS210
+    """Fixture to create and teardown an account user group."""
+    created_account_user_data = created_account_user()
+    user_group_data = created_user_group
+    create_user_group_data = {"id": user_group_data.id}
+    users = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    created_account_user_group = users.groups(user_id=created_account_user_data.id).create(
+        create_user_group_data
+    )
+    yield created_account_user_group
+
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    try:
+        users_obj.groups(user_id=created_account_user_data.id).delete(user_group_data.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete account user group: {error.title}")  # noqa: WPS421
+
+
+def test_get_account_user_by_id(mpt_vendor, user_id, account_id):
+    """Test retrieving an account user by ID."""
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    result = users_obj.get(user_id)
+
+    assert result is not None
+
+
+def test_list_account_users(mpt_vendor, account_id):
+    """Test listing account users."""
+    limit = 10
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    result = users_obj.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_get_account_user_by_id_not_found(mpt_vendor, invalid_user_id, account_id):
+    """Test retrieving an account user by invalid ID."""
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        users_obj.get(invalid_user_id)
+
+
+def test_filter_account_users(mpt_vendor, user_id, account_id):
+    """Test filtering account users."""
+    select_fields = ["-name"]
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    filtered_account_users = users_obj.filter(RQLQuery(id=user_id)).select(*select_fields)
+
+    result = list(filtered_account_users.iterate())
+
+    assert len(result) == 1
+
+
+def test_create_account_user(created_account_user):
+    """Test creating an account user."""
+    result = created_account_user()
+
+    assert result is not None
+
+
+def test_delete_account_user(mpt_vendor, created_account_user, account_id):
+    """Test deleting an account user."""
+    account_user_data = created_account_user()
+
+    result = mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    result.delete(account_user_data.id)
+
+
+def test_update_account_user(
+    mpt_vendor,
+    account_user_factory,
+    created_account_user,
+    account_id,
+):
+    """Test updating an account user."""
+    account_user_data = created_account_user()
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    updated_account_user_data = account_user_factory(
+        first_name="E2E Updated",
+        last_name="Account User",
+    )
+
+    result = users_obj.update(
+        account_user_data.id,
+        updated_account_user_data,
+    )
+
+    assert result is not None
+
+
+def test_account_user_resend_invite(
+    mpt_vendor,
+    created_account_user,
+    account_id,
+):
+    """Test resending an invite to an account user."""
+    account_user_data = created_account_user()
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+
+    result = users_obj.resend_invite(account_user_data.id)
+
+    assert result is not None
+
+
+def test_account_user_group_post(created_account_user_group):
+    """Test creating an account user group."""
+    result = created_account_user_group
+
+    assert result is not None
+
+
+def test_account_user_group_update(
+    mpt_vendor,
+    created_account_user,
+    created_user_group,
+    account_id,
+):
+    """Test updating an account user group."""
+    created_account_user_data = created_account_user()
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    update_user_group_data = [{"id": created_user_group.id}]
+
+    result = users_obj.groups(user_id=created_account_user_data.id).update(update_user_group_data)
+
+    assert result is not None
+
+
+def test_account_user_group_delete(
+    mpt_vendor,
+    created_account_user,
+    created_user_group,
+    account_id,
+):
+    """Test deleting an account user group."""
+    created_account_user_data = created_account_user()
+    users_obj = mpt_vendor.accounts.accounts.users(account_id=account_id)
+    create_user_group_data = {"id": created_user_group.id}
+    users_obj.groups(user_id=created_account_user_data.id).create(create_user_group_data)
+
+    users_obj.groups(user_id=created_account_user_data.id).delete(created_user_group.id)  # act

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -103,6 +103,16 @@ def short_uuid():
 
 
 @pytest.fixture
+def uuid_str():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
 def logo_fd():
     file_path = pathlib.Path(__file__).parent / "logo.png"
     return pathlib.Path.open(file_path, "rb")
+
+
+@pytest.fixture
+def user_id(e2e_config):
+    return e2e_config["accounts.user.id"]


### PR DESCRIPTION
Added Accounts account by id users endpoints e2e tests

https://softwareone.atlassian.net/browse/MPT-14865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update capability for account user groups.

* **Tests**
  * Expanded end-to-end async and sync test coverage for account users and groups (create, retrieve, list, filter, update, delete, resend invite, and group associations).
  * Added unit tests verifying account-user-group update flows.
  * New test fixtures for UUIDs, user IDs, and account-user creation helpers.

* **Chores**
  * Test configuration updated with a test user identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->