### PR TITLE
MPT-14935 add E2E tests for notifications messages endpoint

### DIFF
--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -20,5 +20,6 @@
   "catalog.product.template.id": "TPL-7255-3950-0001",
   "catalog.product.terms.id": "TCS-7255-3950-0001",
   "catalog.product.terms.variant.id": "TCV-7255-3950-0001-0001",
-  "catalog.unit.id": "UNT-1229"
+  "catalog.unit.id": "UNT-1229",
+  "notifications.message.id": "MSG-0000-6215-1019-0139"
 }

--- a/tests/e2e/notifications/messages/conftest.py
+++ b/tests/e2e/notifications/messages/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.fixture
+def message_data(short_uuid, account_id):
+    return {
+        "title": "e2e - please delete",
+        "content": "This is an e2e test message - please delete",
+        "category": "general",
+        "priority": "normal",
+        "account": {
+            "id": account_id,
+        },
+        "externalIds": {"test": f"e2e-delete-{short_uuid}"},
+    }
+
+
+@pytest.fixture
+def message_id(e2e_config):
+    return e2e_config.get("notifications.message.id")
+
+
+@pytest.fixture
+def invalid_message_id(e2e_config):
+    return "MSG-000-000-000-000"

--- a/tests/e2e/notifications/messages/test_async_messages.py
+++ b/tests/e2e/notifications/messages/test_async_messages.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [pytest.mark.flaky]
+
+
+async def test_get_message(async_mpt_client, message_id):
+    service = async_mpt_client.notifications.messages
+
+    result = await service.get(message_id)
+
+    assert result.id == message_id
+
+
+async def test_list_messages(async_mpt_ops):
+    service = async_mpt_ops.notifications.messages
+
+    result = await service.fetch_page(limit=1)
+
+    assert len(result) > 0
+
+
+async def test_not_found(async_mpt_client, invalid_message_id):
+    service = async_mpt_client.notifications.messages
+
+    with pytest.raises(MPTAPIError):
+        await service.get(invalid_message_id)

--- a/tests/e2e/notifications/messages/test_sync_messages.py
+++ b/tests/e2e/notifications/messages/test_sync_messages.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [pytest.mark.flaky]
+
+
+def test_get_message(mpt_client, message_id):
+    service = mpt_client.notifications.messages
+
+    result = service.get(message_id)
+
+    assert result.id == message_id
+
+
+def test_list_messages(mpt_ops):
+    service = mpt_ops.notifications.messages
+
+    result = service.fetch_page(limit=1)
+
+    assert len(result) > 0
+
+
+def test_not_found(mpt_client, invalid_message_id):
+    service = mpt_client.notifications.messages
+
+    with pytest.raises(MPTAPIError):
+        service.get(invalid_message_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end sync and async tests for message retrieval, listing (pagination) and not-found error handling.
  * Introduced test fixtures supplying message data, valid/invalid message IDs, and related helpers; some tests marked flaky to reflect intermittency.

* **Chores**
  * Updated notification configuration with a new message identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->