### PR TITLE
MPT-14898 E2E for catalog units of measure

### DIFF
--- a/tests/e2e/catalog/units_of_measure/conftest.py
+++ b/tests/e2e/catalog/units_of_measure/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def units_of_measure_service(mpt_ops):
+    return mpt_ops.catalog.units_of_measure
+
+
+@pytest.fixture
+def unit_of_measure_id(e2e_config):
+    return e2e_config["catalog.unit.id"]

--- a/tests/e2e/catalog/units_of_measure/test_async_units_of_measure.py
+++ b/tests/e2e/catalog/units_of_measure/test_async_units_of_measure.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from tests.e2e.helper import assert_async_service_filter_with_iterate
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def async_units_of_measure_service(async_mpt_ops):
+    return async_mpt_ops.catalog.units_of_measure
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+async def test_create(async_units_of_measure_service, short_uuid):
+    await async_units_of_measure_service.create({
+        "name": f"e2e-delete {short_uuid}",
+        "description": "e2e-delete",
+    })  # act
+
+
+async def test_get_unit_of_measure(async_units_of_measure_service, unit_of_measure_id):
+    result = await async_units_of_measure_service.get(unit_of_measure_id)
+
+    assert result.id == unit_of_measure_id
+
+
+async def test_filter_units_of_measure(async_units_of_measure_service, unit_of_measure_id):
+    await assert_async_service_filter_with_iterate(
+        async_units_of_measure_service, unit_of_measure_id, ["-description"]
+    )  # act
+
+
+async def test_get_unit_of_measure_not_found(async_units_of_measure_service):
+    bogus_id = "UOM-0000-NOTFOUND"
+
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await async_units_of_measure_service.get(bogus_id)
+
+
+async def test_update_unit_of_measure(
+    async_units_of_measure_service, unit_of_measure_id, short_uuid
+):
+    name = f"e2e-seeded-{short_uuid}"
+
+    result = await async_units_of_measure_service.update(
+        unit_of_measure_id, {"name": name, "description": name}
+    )
+
+    assert result.name == name

--- a/tests/e2e/catalog/units_of_measure/test_sync_units_of_measure.py
+++ b/tests/e2e/catalog/units_of_measure/test_sync_units_of_measure.py
@@ -1,0 +1,45 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from tests.e2e.helper import assert_service_filter_with_iterate
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_create(units_of_measure_service, short_uuid):
+    units_of_measure_service.create({
+        "name": f"e2e-delete {short_uuid}",
+        "description": "e2e-delete",
+    })  # act
+
+
+def test_get_unit_of_measure(units_of_measure_service, unit_of_measure_id):
+    result = units_of_measure_service.get(unit_of_measure_id)
+
+    assert result.id == unit_of_measure_id
+
+
+def test_filter_units_of_measure(units_of_measure_service, unit_of_measure_id):
+    assert_service_filter_with_iterate(
+        units_of_measure_service,
+        unit_of_measure_id,
+        ["-description"],
+    )  # act
+
+
+def test_get_unit_of_measure_not_found(units_of_measure_service):
+    bogus_id = "UOM-0000-NOTFOUND"
+
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        units_of_measure_service.get(bogus_id)
+
+
+def test_update_unit_of_measure(units_of_measure_service, unit_of_measure_id, short_uuid):
+    name = f"e2e-seeded-{short_uuid}"
+
+    result = units_of_measure_service.update(
+        unit_of_measure_id, {"name": name, "description": name}
+    )
+
+    assert result.name == name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for units-of-measure in the catalog: synchronous and asynchronous tests for retrieval, filtering, update, create (placeholder/skipped) and not-found error handling; module-level flaky markers applied.
  * Added pytest fixtures to expose the units-of-measure service and a configured unit ID for tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->