### PR TITLE
MPT-16242 Add `iterate` in expected methods for catalog resources

### DIFF
--- a/tests/unit/resources/catalog/test_authorizations.py
+++ b/tests/unit/resources/catalog/test_authorizations.py
@@ -16,14 +16,14 @@ def async_authorizations_service(async_http_client):
     return AsyncAuthorizationsService(http_client=async_http_client)
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_mixins_present(authorizations_service, method):
     result = hasattr(authorizations_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_async_mixins_present(async_authorizations_service, method):
     result = hasattr(async_authorizations_service, method)
 

--- a/tests/unit/resources/catalog/test_items.py
+++ b/tests/unit/resources/catalog/test_items.py
@@ -14,7 +14,17 @@ def async_items_service(async_http_client):
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "update", "delete", "review", "publish", "unpublish"]
+    "method",
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "review",
+        "publish",
+        "unpublish",
+        "iterate",
+    ],
 )
 def test_mixins_present(items_service, method):
     result = hasattr(items_service, method)
@@ -23,7 +33,17 @@ def test_mixins_present(items_service, method):
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "update", "delete", "review", "publish", "unpublish"]
+    "method",
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "review",
+        "publish",
+        "unpublish",
+        "iterate",
+    ],
 )
 def test_async_mixins_present(async_items_service, method):
     result = hasattr(async_items_service, method)

--- a/tests/unit/resources/catalog/test_listings.py
+++ b/tests/unit/resources/catalog/test_listings.py
@@ -16,14 +16,14 @@ def async_listings_service(async_http_client):
     return AsyncListingsService(http_client=async_http_client)
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_mixins_present(listings_service, method):
     result = hasattr(listings_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_async_mixins_present(async_listings_service, method):
     result = hasattr(async_listings_service, method)
 

--- a/tests/unit/resources/catalog/test_price_list_items.py
+++ b/tests/unit/resources/catalog/test_price_list_items.py
@@ -36,14 +36,14 @@ def async_test_endpoint(async_price_list_items_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "update"])
+@pytest.mark.parametrize("method", ["get", "update", "iterate"])
 def test_methods_present(price_list_items_service, method):
     result = hasattr(price_list_items_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "update"])
+@pytest.mark.parametrize("method", ["get", "update", "iterate"])
 def test_async_methods_present(async_price_list_items_service, method):
     result = hasattr(async_price_list_items_service, method)
 

--- a/tests/unit/resources/catalog/test_price_lists.py
+++ b/tests/unit/resources/catalog/test_price_lists.py
@@ -20,14 +20,14 @@ def async_price_lists_service(http_client):
     return AsyncPriceListsService(http_client=http_client)
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_mixins_present(price_lists_service, method):
     result = hasattr(price_lists_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_async_mixins_present(async_price_lists_service, method):
     result = hasattr(async_price_lists_service, method)
 

--- a/tests/unit/resources/catalog/test_pricing_policies.py
+++ b/tests/unit/resources/catalog/test_pricing_policies.py
@@ -144,7 +144,7 @@ def test_async_property_services(
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "activate", "disable"],
+    ["get", "create", "update", "delete", "activate", "disable", "iterate"],
 )
 def test_mixins_present(pricing_policies_service, method):
     result = hasattr(pricing_policies_service, method)
@@ -154,7 +154,7 @@ def test_mixins_present(pricing_policies_service, method):
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "activate", "disable"],
+    ["get", "create", "update", "delete", "activate", "disable", "iterate"],
 )
 def test_async_mixins_present(async_pricing_policies_service, method):
     result = hasattr(async_pricing_policies_service, method)

--- a/tests/unit/resources/catalog/test_pricing_policy_attachments.py
+++ b/tests/unit/resources/catalog/test_pricing_policy_attachments.py
@@ -40,14 +40,14 @@ def test_async_endpoint(async_pricing_policy_attachments_service) -> None:
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "download"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "download", "iterate"])
 def test_methods_present(pricing_policy_attachments_service, method: str) -> None:
     result = hasattr(pricing_policy_attachments_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "download"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "download", "iterate"])
 def test_async_methods_present(async_pricing_policy_attachments_service, method: str) -> None:
     result = hasattr(async_pricing_policy_attachments_service, method)
 

--- a/tests/unit/resources/catalog/test_product_term_variants.py
+++ b/tests/unit/resources/catalog/test_product_term_variants.py
@@ -41,7 +41,8 @@ def test_async_endpoint(async_term_variant_service: AsyncTermVariantService) -> 
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_methods_present(term_variant_service: TermVariantService, method: str) -> None:
     result = hasattr(term_variant_service, method)
@@ -50,7 +51,8 @@ def test_methods_present(term_variant_service: TermVariantService, method: str) 
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_async_methods_present(
     async_term_variant_service: AsyncTermVariantService, method: str

--- a/tests/unit/resources/catalog/test_product_terms.py
+++ b/tests/unit/resources/catalog/test_product_terms.py
@@ -37,7 +37,7 @@ def test_async_endpoint(async_term_service: AsyncTermService) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "review", "publish", "unpublish"]
+    "method", ["get", "create", "delete", "update", "review", "publish", "unpublish", "iterate"]
 )
 def test_methods_present(term_service: TermService, method: str) -> None:
     result = hasattr(term_service, method)
@@ -46,7 +46,7 @@ def test_methods_present(term_service: TermService, method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "review", "publish", "unpublish"]
+    "method", ["get", "create", "delete", "update", "review", "publish", "unpublish", "iterate"]
 )
 def test_async_methods_present(async_term_service: AsyncTermService, method: str) -> None:
     result = hasattr(async_term_service, method)

--- a/tests/unit/resources/catalog/test_products.py
+++ b/tests/unit/resources/catalog/test_products.py
@@ -49,7 +49,17 @@ def async_products_service(async_http_client):
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "review", "publish", "unpublish", "update_settings"],
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "review",
+        "publish",
+        "unpublish",
+        "update_settings",
+        "iterate",
+    ],
 )
 def test_mixins_present(products_service, method):
     result = hasattr(products_service, method)
@@ -59,7 +69,17 @@ def test_mixins_present(products_service, method):
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "review", "publish", "unpublish", "update_settings"],
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "review",
+        "publish",
+        "unpublish",
+        "update_settings",
+        "iterate",
+    ],
 )
 def test_async_mixins_present(async_products_service, method):
     result = hasattr(async_products_service, method)

--- a/tests/unit/resources/catalog/test_products_documents.py
+++ b/tests/unit/resources/catalog/test_products_documents.py
@@ -31,7 +31,8 @@ def test_async_endpoint(async_document_service) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_methods_present(document_service, method: str) -> None:
     result = hasattr(document_service, method)
@@ -40,7 +41,8 @@ def test_methods_present(document_service, method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_async_methods_present(async_document_service, method: str) -> None:
     result = hasattr(async_document_service, method)

--- a/tests/unit/resources/catalog/test_products_item_groups.py
+++ b/tests/unit/resources/catalog/test_products_item_groups.py
@@ -30,14 +30,14 @@ def test_async_endpoint(async_item_groups_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_methods_present(item_groups_service, method):
     result = hasattr(item_groups_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_async_methods_present(async_item_groups_service, method):
     result = hasattr(async_item_groups_service, method)
 

--- a/tests/unit/resources/catalog/test_products_media.py
+++ b/tests/unit/resources/catalog/test_products_media.py
@@ -31,7 +31,8 @@ def test_async_endpoint(async_media_service) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_methods_present(media_service, method: str) -> None:
     result = hasattr(media_service, method)
@@ -40,7 +41,8 @@ def test_methods_present(media_service, method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method", ["get", "create", "delete", "update", "download", "review", "publish", "unpublish"]
+    "method",
+    ["get", "create", "delete", "update", "download", "review", "publish", "unpublish", "iterate"],
 )
 def test_async_methods_present(async_media_service, method: str) -> None:
     result = hasattr(async_media_service, method)

--- a/tests/unit/resources/catalog/test_products_parameter_groups.py
+++ b/tests/unit/resources/catalog/test_products_parameter_groups.py
@@ -35,14 +35,14 @@ def test_async_endpoint(async_parameter_groups_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_methods_present(parameter_groups_service, method):
     result = hasattr(parameter_groups_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_async_methods_present(async_parameter_groups_service, method):
     result = hasattr(async_parameter_groups_service, method)
 

--- a/tests/unit/resources/catalog/test_products_parameters.py
+++ b/tests/unit/resources/catalog/test_products_parameters.py
@@ -30,14 +30,14 @@ def test_async_endpoint(async_parameters_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_methods_present(parameters_service, method):
     result = hasattr(parameters_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "delete", "update"])
+@pytest.mark.parametrize("method", ["get", "create", "delete", "update", "iterate"])
 def test_async_methods_present(async_parameters_service, method):
     result = hasattr(async_parameters_service, method)
 

--- a/tests/unit/resources/catalog/test_units_of_measure.py
+++ b/tests/unit/resources/catalog/test_units_of_measure.py
@@ -16,14 +16,14 @@ def async_units_of_measure_service(async_http_client):
     return AsyncUnitsOfMeasureService(http_client=async_http_client)
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_mixins_present(units_of_measure_service, method):
     result = hasattr(units_of_measure_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate"])
 def test_async_mixins_present(async_units_of_measure_service, method):
     result = hasattr(async_units_of_measure_service, method)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded parameterized tests across multiple catalog resource modules to verify the presence of an "iterate" method on both synchronous and asynchronous service variants, broadening method-presence coverage in many test cases. No production API signatures or runtime behavior were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->