### PR TITLE
Support `set` type in query builder operator handling

### DIFF
--- a/mpt_api_client/rql/query_builder.py
+++ b/mpt_api_client/rql/query_builder.py
@@ -106,7 +106,7 @@ def rql_encode(op: str, value: Any) -> str:
     """
     if op not in constants.LIST and isinstance(value, QueryValue):
         return query_value_str(value)
-    if op in constants.LIST and isinstance(value, list | tuple):
+    if op in constants.LIST and isinstance(value, list | tuple | set):
         return ",".join(value)
 
     raise TypeError(f"the `{op}` operator doesn't support the {type(value)} type.")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended RQL list operators to accept sets as parameter values in addition to lists and tuples, offering increased flexibility when constructing queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->