### PR TITLE
Fix handle non-string elements in iterable for query builder

### DIFF
--- a/mpt_api_client/rql/query_builder.py
+++ b/mpt_api_client/rql/query_builder.py
@@ -107,7 +107,7 @@ def rql_encode(op: str, value: Any) -> str:
     if op not in constants.LIST and isinstance(value, QueryValue):
         return query_value_str(value)
     if op in constants.LIST and isinstance(value, list | tuple | set):
-        return ",".join(value)
+        return ",".join(str(el) for el in value)
 
     raise TypeError(f"the `{op}` operator doesn't support the {type(value)} type.")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the LIST operator in query building to properly handle lists, tuples, and sets containing mixed data types. Previously, non-string elements would cause processing errors. The operator now converts all elements to strings before joining them, ensuring queries execute reliably regardless of element types in list-based values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->