### PR TITLE
MPT-14938 Add audit records e2e

### DIFF
--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -11,6 +11,7 @@
   "accounts.seller.id": "SEL-7310-3075",
   "accounts.user.id": "USR-9673-3314",
   "accounts.user_group.id": "UGR-6822-0561",
+  "audit.record.id": "AUD-3748-4760-1006-3938",
   "billing.journal.id": "BJO-6562-0928",
   "catalog.authorization.id": "AUT-9288-6146",
   "catalog.listing.id": "LST-5489-0806",

--- a/tests/e2e/audit/records/conftest.py
+++ b/tests/e2e/audit/records/conftest.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def record_data(account_id: str) -> dict[str, Any]:
+    return {
+        "event": "extensions.e2e.test",
+        "object": {"id": account_id, "name": "e2e test account"},
+        "details": "e2e test details",
+        "summary": "e2e test summary",
+        "actor": {
+            "type": "system",
+            "id": "system",
+        },
+        "payload": {
+            "key": "value",
+        },
+    }
+
+
+@pytest.fixture
+def audit_record_id(e2e_config):
+    return e2e_config["audit.record.id"]

--- a/tests/e2e/audit/records/test_async_records.py
+++ b/tests/e2e/audit/records/test_async_records.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import pytest
+
+from mpt_api_client import AsyncMPTClient
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.resources.audit.records import Record
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+async def created_record(async_mpt_vendor: AsyncMPTClient, record_data: dict[str, Any]) -> Record:
+    service = async_mpt_vendor.audit.records
+    return await service.create(record_data)
+
+
+def test_create_record(created_record: Record, record_data: dict[str, Any]) -> None:  # noqa: AAA01
+    assert created_record.event == record_data["event"]
+    assert created_record.object.id == record_data["object"]["id"]
+
+
+async def test_get_record(async_mpt_vendor: AsyncMPTClient, audit_record_id: str) -> None:
+    service = async_mpt_vendor.audit.records
+    result = await service.get(audit_record_id)
+
+    assert result.id == audit_record_id
+
+
+async def test_iterate_records(async_mpt_vendor: AsyncMPTClient, product_id: str) -> None:
+    service = async_mpt_vendor.audit.records.filter(RQLQuery(object__id=product_id))
+    records = [record async for record in service.iterate()]
+
+    result = records[0]
+
+    assert result.object.id == product_id
+
+
+async def test_get_record_not_found(async_mpt_vendor: AsyncMPTClient) -> None:
+    service = async_mpt_vendor.audit.records
+
+    with pytest.raises(MPTAPIError):
+        await service.get("REC-000-000-000")

--- a/tests/e2e/audit/records/test_sync_records.py
+++ b/tests/e2e/audit/records/test_sync_records.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+import pytest
+
+from mpt_api_client import MPTClient
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.resources.audit.records import Record
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def created_record(mpt_vendor: MPTClient, record_data: dict[str, Any]) -> Record:
+    service = mpt_vendor.audit.records
+    return service.create(record_data)
+
+
+def test_create_record(created_record: Record, record_data: dict[str, Any]) -> None:  # noqa: AAA01
+    assert created_record.event == record_data["event"]
+    assert created_record.object.id == record_data["object"]["id"]
+
+
+def test_get_record(mpt_vendor: MPTClient, audit_record_id) -> None:
+    service = mpt_vendor.audit.records
+
+    result = service.get(audit_record_id)
+
+    assert result.id == audit_record_id
+
+
+def test_iterate_records(mpt_vendor: MPTClient, product_id) -> None:
+    service = mpt_vendor.audit.records.filter(RQLQuery(object__id=product_id))
+    records = list(service.iterate())
+
+    result = records[0]
+
+    assert result.object.id == product_id
+
+
+def test_get_record_not_found(mpt_vendor: MPTClient) -> None:
+    service = mpt_vendor.audit.records
+
+    with pytest.raises(MPTAPIError):
+        service.get("REC-000-000-000")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for audit records (sync and async) covering creation, retrieval by ID, filtered iteration, and not-found handling.
  * Added fixtures to produce consistent audit record data and to expose the configured audit record ID for tests.
* **Chores**
  * Updated test configuration to include a top-level audit.record.id value for e2e runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->