### PR TITLE
[MPT-16678] Added missing billing statement attachments endpoints

### DIFF
--- a/mpt_api_client/resources/billing/credit_memo_attachments.py
+++ b/mpt_api_client/resources/billing/credit_memo_attachments.py
@@ -1,13 +1,10 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncFilesOperationsMixin,
-    AsyncModifiableResourceMixin,
     CollectionMixin,
-    FilesOperationsMixin,
-    ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
 
 
 class CreditMemoAttachment(Model):
@@ -20,11 +17,12 @@ class CreditMemoAttachmentsServiceConfig:
     _endpoint = "/public/v1/billing/credit-memos/{credit_memo_id}/attachments"
     _model_class = CreditMemoAttachment
     _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "attachment"
 
 
 class CreditMemoAttachmentsService(
-    FilesOperationsMixin[CreditMemoAttachment],
-    ModifiableResourceMixin[CreditMemoAttachment],
+    AttachmentMixin[CreditMemoAttachment],
     CollectionMixin[CreditMemoAttachment],
     Service[CreditMemoAttachment],
     CreditMemoAttachmentsServiceConfig,
@@ -33,8 +31,7 @@ class CreditMemoAttachmentsService(
 
 
 class AsyncCreditMemoAttachmentsService(
-    AsyncFilesOperationsMixin[CreditMemoAttachment],
-    AsyncModifiableResourceMixin[CreditMemoAttachment],
+    AsyncAttachmentMixin[CreditMemoAttachment],
     AsyncCollectionMixin[CreditMemoAttachment],
     AsyncService[CreditMemoAttachment],
     CreditMemoAttachmentsServiceConfig,

--- a/mpt_api_client/resources/billing/custom_ledger_attachments.py
+++ b/mpt_api_client/resources/billing/custom_ledger_attachments.py
@@ -1,13 +1,10 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncFilesOperationsMixin,
-    AsyncModifiableResourceMixin,
     CollectionMixin,
-    FilesOperationsMixin,
-    ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
 
 
 class CustomLedgerAttachment(Model):
@@ -20,11 +17,12 @@ class CustomLedgerAttachmentsServiceConfig:
     _endpoint = "/public/v1/billing/custom-ledgers/{custom_ledger_id}/attachments"
     _model_class = CustomLedgerAttachment
     _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "attachment"
 
 
 class CustomLedgerAttachmentsService(
-    FilesOperationsMixin[CustomLedgerAttachment],
-    ModifiableResourceMixin[CustomLedgerAttachment],
+    AttachmentMixin[CustomLedgerAttachment],
     CollectionMixin[CustomLedgerAttachment],
     Service[CustomLedgerAttachment],
     CustomLedgerAttachmentsServiceConfig,
@@ -33,8 +31,7 @@ class CustomLedgerAttachmentsService(
 
 
 class AsyncCustomLedgerAttachmentsService(
-    AsyncFilesOperationsMixin[CustomLedgerAttachment],
-    AsyncModifiableResourceMixin[CustomLedgerAttachment],
+    AsyncAttachmentMixin[CustomLedgerAttachment],
     AsyncCollectionMixin[CustomLedgerAttachment],
     AsyncService[CustomLedgerAttachment],
     CustomLedgerAttachmentsServiceConfig,

--- a/mpt_api_client/resources/billing/invoice_attachments.py
+++ b/mpt_api_client/resources/billing/invoice_attachments.py
@@ -1,13 +1,10 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncFilesOperationsMixin,
-    AsyncModifiableResourceMixin,
     CollectionMixin,
-    FilesOperationsMixin,
-    ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
 
 
 class InvoiceAttachment(Model):
@@ -20,11 +17,12 @@ class InvoiceAttachmentsServiceConfig:
     _endpoint = "/public/v1/billing/invoices/{invoice_id}/attachments"
     _model_class = InvoiceAttachment
     _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "attachment"
 
 
 class InvoiceAttachmentsService(
-    FilesOperationsMixin[InvoiceAttachment],
-    ModifiableResourceMixin[InvoiceAttachment],
+    AttachmentMixin[InvoiceAttachment],
     CollectionMixin[InvoiceAttachment],
     Service[InvoiceAttachment],
     InvoiceAttachmentsServiceConfig,
@@ -33,8 +31,7 @@ class InvoiceAttachmentsService(
 
 
 class AsyncInvoiceAttachmentsService(
-    AsyncFilesOperationsMixin[InvoiceAttachment],
-    AsyncModifiableResourceMixin[InvoiceAttachment],
+    AsyncAttachmentMixin[InvoiceAttachment],
     AsyncCollectionMixin[InvoiceAttachment],
     AsyncService[InvoiceAttachment],
     InvoiceAttachmentsServiceConfig,

--- a/mpt_api_client/resources/billing/journal_attachments.py
+++ b/mpt_api_client/resources/billing/journal_attachments.py
@@ -1,19 +1,10 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncCreateFileMixin,
-    AsyncDeleteMixin,
-    AsyncDownloadFileMixin,
-    AsyncGetMixin,
-    AsyncUpdateMixin,
     CollectionMixin,
-    CreateFileMixin,
-    DeleteMixin,
-    DownloadFileMixin,
-    GetMixin,
-    UpdateMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
 
 
 class JournalAttachment(Model):
@@ -31,11 +22,7 @@ class JournalAttachmentsServiceConfig:
 
 
 class JournalAttachmentsService(
-    CreateFileMixin[JournalAttachment],
-    UpdateMixin[JournalAttachment],
-    DownloadFileMixin[JournalAttachment],
-    DeleteMixin,
-    GetMixin[JournalAttachment],
+    AttachmentMixin[JournalAttachment],
     CollectionMixin[JournalAttachment],
     Service[JournalAttachment],
     JournalAttachmentsServiceConfig,
@@ -44,11 +31,7 @@ class JournalAttachmentsService(
 
 
 class AsyncJournalAttachmentsService(
-    AsyncCreateFileMixin[JournalAttachment],
-    AsyncUpdateMixin[JournalAttachment],
-    AsyncDownloadFileMixin[JournalAttachment],
-    AsyncDeleteMixin,
-    AsyncGetMixin[JournalAttachment],
+    AsyncAttachmentMixin[JournalAttachment],
     AsyncCollectionMixin[JournalAttachment],
     AsyncService[JournalAttachment],
     JournalAttachmentsServiceConfig,

--- a/mpt_api_client/resources/billing/ledger_attachments.py
+++ b/mpt_api_client/resources/billing/ledger_attachments.py
@@ -1,13 +1,10 @@
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
-    AsyncFilesOperationsMixin,
-    AsyncModifiableResourceMixin,
     CollectionMixin,
-    FilesOperationsMixin,
-    ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
 
 
 class LedgerAttachment(Model):
@@ -20,11 +17,12 @@ class LedgerAttachmentsServiceConfig:
     _endpoint = "/public/v1/billing/ledgers/{ledger_id}/attachments"
     _model_class = LedgerAttachment
     _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "attachment"
 
 
 class LedgerAttachmentsService(
-    FilesOperationsMixin[LedgerAttachment],
-    ModifiableResourceMixin[LedgerAttachment],
+    AttachmentMixin[LedgerAttachment],
     CollectionMixin[LedgerAttachment],
     Service[LedgerAttachment],
     LedgerAttachmentsServiceConfig,
@@ -33,8 +31,7 @@ class LedgerAttachmentsService(
 
 
 class AsyncLedgerAttachmentsService(
-    AsyncFilesOperationsMixin[LedgerAttachment],
-    AsyncModifiableResourceMixin[LedgerAttachment],
+    AsyncAttachmentMixin[LedgerAttachment],
     AsyncCollectionMixin[LedgerAttachment],
     AsyncService[LedgerAttachment],
     LedgerAttachmentsServiceConfig,

--- a/mpt_api_client/resources/billing/mixins.py
+++ b/mpt_api_client/resources/billing/mixins.py
@@ -1,3 +1,15 @@
+from mpt_api_client.http.mixins import (
+    AsyncCreateFileMixin,
+    AsyncDeleteMixin,
+    AsyncDownloadFileMixin,
+    AsyncGetMixin,
+    AsyncUpdateMixin,
+    CreateFileMixin,
+    DeleteMixin,
+    DownloadFileMixin,
+    GetMixin,
+    UpdateMixin,
+)
 from mpt_api_client.models import ResourceData
 
 
@@ -392,3 +404,23 @@ class AsyncAcceptableMixin[Model]:
         return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
             resource_id, "POST", "queue", json=resource_data
         )
+
+
+class AttachmentMixin[Model](
+    CreateFileMixin[Model],
+    UpdateMixin[Model],
+    DeleteMixin,
+    DownloadFileMixin[Model],
+    GetMixin[Model],
+):
+    """Attachment mixin."""
+
+
+class AsyncAttachmentMixin[Model](
+    AsyncCreateFileMixin[Model],
+    AsyncUpdateMixin[Model],
+    AsyncDeleteMixin,
+    AsyncDownloadFileMixin[Model],
+    AsyncGetMixin[Model],
+):
+    """Async Attachment mixin."""

--- a/mpt_api_client/resources/billing/statement_attachments.py
+++ b/mpt_api_client/resources/billing/statement_attachments.py
@@ -1,0 +1,39 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    CollectionMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.resources.billing.mixins import AsyncAttachmentMixin, AttachmentMixin
+
+
+class StatementAttachment(Model):
+    """Statement Attachment resource."""
+
+
+class StatementAttachmentsServiceConfig:
+    """Statement Attachments service configuration."""
+
+    _endpoint = "/public/v1/billing/statements/{statement_id}/attachments"
+    _model_class = StatementAttachment
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "attachment"
+
+
+class StatementAttachmentsService(
+    AttachmentMixin[StatementAttachment],
+    CollectionMixin[StatementAttachment],
+    Service[StatementAttachment],
+    StatementAttachmentsServiceConfig,
+):
+    """Statement Attachments service."""
+
+
+class AsyncStatementAttachmentsService(
+    AsyncAttachmentMixin[StatementAttachment],
+    AsyncCollectionMixin[StatementAttachment],
+    AsyncService[StatementAttachment],
+    StatementAttachmentsServiceConfig,
+):
+    """Statement Attachments service."""

--- a/mpt_api_client/resources/billing/statements.py
+++ b/mpt_api_client/resources/billing/statements.py
@@ -9,6 +9,10 @@ from mpt_api_client.http.mixins import (
 )
 from mpt_api_client.models import Model
 from mpt_api_client.resources.billing.mixins import AsyncIssuableMixin, IssuableMixin
+from mpt_api_client.resources.billing.statement_attachments import (
+    AsyncStatementAttachmentsService,
+    StatementAttachmentsService,
+)
 from mpt_api_client.resources.billing.statement_charges import (
     AsyncStatementChargesService,
     StatementChargesService,
@@ -44,6 +48,13 @@ class StatementsService(
             endpoint_params={"statement_id": statement_id},
         )
 
+    def attachments(self, statement_id: str) -> StatementAttachmentsService:
+        """Return statement attachments service."""
+        return StatementAttachmentsService(
+            http_client=self.http_client,
+            endpoint_params={"statement_id": statement_id},
+        )
+
 
 class AsyncStatementsService(
     AsyncUpdateMixin[Statement],
@@ -58,6 +69,13 @@ class AsyncStatementsService(
     def charges(self, statement_id: str) -> AsyncStatementChargesService:
         """Return statement charges service."""
         return AsyncStatementChargesService(
+            http_client=self.http_client,
+            endpoint_params={"statement_id": statement_id},
+        )
+
+    def attachments(self, statement_id: str) -> AsyncStatementAttachmentsService:
+        """Return statement attachments service."""
+        return AsyncStatementAttachmentsService(
             http_client=self.http_client,
             endpoint_params={"statement_id": statement_id},
         )

--- a/tests/unit/resources/billing/test_credit_memo_attachments.py
+++ b/tests/unit/resources/billing/test_credit_memo_attachments.py
@@ -38,14 +38,14 @@ def test_async_endpoint(async_credit_memo_attachments_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_methods_present(credit_memo_attachments_service, method: str):
     result = hasattr(credit_memo_attachments_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_async_methods_present(async_credit_memo_attachments_service, method: str):
     result = hasattr(async_credit_memo_attachments_service, method)
 

--- a/tests/unit/resources/billing/test_custom_ledger_attachments.py
+++ b/tests/unit/resources/billing/test_custom_ledger_attachments.py
@@ -36,14 +36,14 @@ def test_async_endpoint(async_custom_ledger_attachments_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_methods_present(custom_ledger_attachments_service, method: str):
     result = hasattr(custom_ledger_attachments_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_async_methods_present(async_custom_ledger_attachments_service, method: str):
     result = hasattr(async_custom_ledger_attachments_service, method)
 

--- a/tests/unit/resources/billing/test_invoice_attachments.py
+++ b/tests/unit/resources/billing/test_invoice_attachments.py
@@ -37,14 +37,14 @@ def test_async_endpoint(async_invoice_attachments_service):
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_methods_present(invoice_attachments_service, method: str):
     result = hasattr(invoice_attachments_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_async_methods_present(async_invoice_attachments_service, method: str):
     result = hasattr(async_invoice_attachments_service, method)
 

--- a/tests/unit/resources/billing/test_ledger_attachments.py
+++ b/tests/unit/resources/billing/test_ledger_attachments.py
@@ -37,14 +37,14 @@ def test_async_endpoint(async_ledger_attachments_service) -> None:
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_methods_present(ledger_attachments_service, method: str) -> None:
     result = hasattr(ledger_attachments_service, method)
 
     assert result is True
 
 
-@pytest.mark.parametrize("method", ["get", "create", "update", "delete"])
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
 def test_async_methods_present(async_ledger_attachments_service, method: str) -> None:
     result = hasattr(async_ledger_attachments_service, method)
 

--- a/tests/unit/resources/billing/test_statement_attachments.py
+++ b/tests/unit/resources/billing/test_statement_attachments.py
@@ -1,0 +1,52 @@
+import pytest
+
+from mpt_api_client.resources.billing.statement_attachments import (
+    AsyncStatementAttachmentsService,
+    StatementAttachmentsService,
+)
+
+
+@pytest.fixture
+def statement_attachments_service(http_client) -> StatementAttachmentsService:
+    return StatementAttachmentsService(
+        http_client=http_client, endpoint_params={"statement_id": "STM-0000-0001"}
+    )
+
+
+@pytest.fixture
+def async_statement_attachments_service(async_http_client) -> AsyncStatementAttachmentsService:
+    return AsyncStatementAttachmentsService(
+        http_client=async_http_client, endpoint_params={"statement_id": "STM-0000-0001"}
+    )
+
+
+def test_endpoint(statement_attachments_service) -> None:
+    result = (
+        statement_attachments_service.path
+        == "/public/v1/billing/statements/STM-0000-0001/attachments"
+    )
+
+    assert result is True
+
+
+def test_async_endpoint(async_statement_attachments_service) -> None:
+    result = (
+        async_statement_attachments_service.path
+        == "/public/v1/billing/statements/STM-0000-0001/attachments"
+    )
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
+def test_methods_present(statement_attachments_service, method: str) -> None:
+    result = hasattr(statement_attachments_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "download"])
+def test_async_methods_present(async_statement_attachments_service, method: str) -> None:
+    result = hasattr(async_statement_attachments_service, method)
+
+    assert result is True

--- a/tests/unit/resources/billing/test_statements.py
+++ b/tests/unit/resources/billing/test_statements.py
@@ -1,5 +1,9 @@
 import pytest
 
+from mpt_api_client.resources.billing.statement_attachments import (
+    AsyncStatementAttachmentsService,
+    StatementAttachmentsService,
+)
 from mpt_api_client.resources.billing.statement_charges import (
     AsyncStatementChargesService,
     StatementChargesService,
@@ -19,7 +23,19 @@ def async_statements_service(async_http_client):
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "update", "issue", "cancel", "error", "pending", "queue", "retry", "recalculate"],
+    [
+        "get",
+        "update",
+        "issue",
+        "cancel",
+        "error",
+        "pending",
+        "queue",
+        "retry",
+        "recalculate",
+        "attachments",
+        "charges",
+    ],
 )
 def test_mixins_present(statements_service, method):
     result = hasattr(statements_service, method)
@@ -29,7 +45,19 @@ def test_mixins_present(statements_service, method):
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "update", "issue", "cancel", "error", "pending", "queue", "retry", "recalculate"],
+    [
+        "get",
+        "update",
+        "issue",
+        "cancel",
+        "error",
+        "pending",
+        "queue",
+        "retry",
+        "recalculate",
+        "attachments",
+        "charges",
+    ],
 )
 def test_async_mixins_present(async_statements_service, method):
     result = hasattr(async_statements_service, method)
@@ -41,6 +69,7 @@ def test_async_mixins_present(async_statements_service, method):
     ("service_method", "expected_service_class"),
     [
         ("charges", StatementChargesService),
+        ("attachments", StatementAttachmentsService),
     ],
 )
 def test_property_services(statements_service, service_method, expected_service_class):
@@ -54,6 +83,7 @@ def test_property_services(statements_service, service_method, expected_service_
     ("service_method", "expected_service_class"),
     [
         ("charges", AsyncStatementChargesService),
+        ("attachments", AsyncStatementAttachmentsService),
     ],
 )
 def test_async_property_services(async_statements_service, service_method, expected_service_class):


### PR DESCRIPTION
Added missing billing statement attachments endpoints
Even though mixins will be re-organized, I added an attachment mixin because there's almost half a dozen of attachment resources.

https://softwareone.atlassian.net/browse/MPT-16678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added statement attachments support with upload/download and create/list/get/delete operations (sync and async).
  * Added attachments accessors on statements to obtain per-statement attachment services.

* **Refactor**
  * Replaced multiple per-operation attachment mixins with unified attachment mixins for consistent behavior across attachment services.

* **Tests**
  * Expanded unit tests for statement attachments and added iterate/download checks across attachment services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->