### PR TITLE
[MPT-14912] Add e2e tests for billing journal sellers

### DIFF
--- a/tests/e2e/billing/journal/seller/test_async_journal_seller.py
+++ b/tests/e2e/billing/journal/seller/test_async_journal_seller.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def journal_sellers(async_mpt_vendor, billing_journal_id):
+    # Note: relies on seeded e2e config for `billing_journal_id`
+    # (see e2e_config.test.json). Update seeds if this changes.
+    return async_mpt_vendor.billing.journals.sellers(billing_journal_id)
+
+
+async def test_list_journal_sellers(journal_sellers):
+    limit = 10
+
+    result = await journal_sellers.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_filter_journal_sellers(journal_sellers, seller_id):
+    select_fields = ["-period"]
+    filtered_sellers = (
+        journal_sellers.filter(RQLQuery(id=seller_id))
+        .filter(RQLQuery(name="E2E Seeded Seller"))
+        .select(*select_fields)
+    )
+
+    result = [seller async for seller in filtered_sellers.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/journal/seller/test_sync_journal_seller.py
+++ b/tests/e2e/billing/journal/seller/test_sync_journal_seller.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def journal_sellers(mpt_vendor, billing_journal_id):
+    # Note: relies on seeded e2e config for `billing_journal_id`
+    # (see e2e_config.test.json). Update seeds if this changes.
+    return mpt_vendor.billing.journals.sellers(billing_journal_id)
+
+
+def test_list_journal_sellers(journal_sellers):
+    limit = 10
+
+    result = journal_sellers.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_filter_journal_sellers(journal_sellers, seller_id):
+    select_fields = ["-period"]
+    filtered_sellers = (
+        journal_sellers.filter(RQLQuery(id=seller_id))
+        .filter(RQLQuery(name="E2E Seeded Seller"))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_sellers.iterate())
+
+    assert len(result) == 1


### PR DESCRIPTION
Add e2e tests for billing journal sellers
https://softwareone.atlassian.net/browse/MPT-14912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-14912](https://softwareone.atlassian.net/browse/MPT-14912)

## Release Notes

- Add end-to-end test suite for billing journal sellers with both synchronous and asynchronous implementations
- Add `test_list_journal_sellers` (sync & async) to verify listing sellers with pagination (limit=10) and non-empty results
- Add `test_filter_journal_sellers` (sync & async) to verify filtering by seller ID and name, selecting fields (excludes `period` via "-period"), and asserting exactly one match
- Add `journal_sellers` fixture (sync & async variants) exposing the sellers resource for a given billing journal (relies on seeded e2e config)
- Mark modules with pytest flaky marker to handle intermittent test instability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-14912]: https://softwareone.atlassian.net/browse/MPT-14912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ