### PR TITLE
[MPT-14918] Added e2e tests for billing statements and statement charges

### DIFF
--- a/.github/workflows/cron-main-e2e.yml
+++ b/.github/workflows/cron-main-e2e.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
     - name: "Checkout"
       uses: actions/checkout@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/push-release-branch.yml
+++ b/.github/workflows/push-release-branch.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
     - name: "Checkout"

--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -21,6 +21,8 @@
   "billing.ledger.attachment.id": "LEA-4971-4321",
   "billing.ledger.charge.id": "CHG-2589-1434-0000-0000-0200",
   "billing.ledger.id": "BLE-2589-1434-7310-3075",
+  "billing.statement.charge.id": "CHG-2589-1434-0000-0000-0200",
+  "billing.statement.id": "SOM-7311-9982-9805-9250",
   "catalog.authorization.id": "AUT-9288-6146",
   "catalog.listing.id": "LST-5489-0806",
   "catalog.price_list.id": "PRC-7255-3950-0245",

--- a/tests/e2e/billing/statement/charge/conftest.py
+++ b/tests/e2e/billing/statement/charge/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def statement_charge_id(e2e_config):
+    return e2e_config["billing.statement.charge.id"]
+
+
+@pytest.fixture
+def invalid_statement_charge_id():
+    return "CHG-0000-0000-0000-0000-0000"

--- a/tests/e2e/billing/statement/charge/test_async_statement_charge.py
+++ b/tests/e2e/billing/statement/charge/test_async_statement_charge.py
@@ -1,0 +1,43 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def statement_charges(async_mpt_ops, statement_id):
+    return async_mpt_ops.billing.statements.charges(statement_id)
+
+
+async def test_get_statement_charge_by_id(statement_charges, statement_charge_id):
+    result = await statement_charges.get(statement_charge_id)
+
+    assert result is not None
+
+
+async def test_get_statement_charge_by_id_not_found(statement_charges, invalid_statement_charge_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await statement_charges.get(invalid_statement_charge_id)
+
+
+async def test_list_statement_charges(statement_charges):
+    limit = 10
+
+    result = await statement_charges.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_filter_statement_charges(statement_charges, statement_charge_id):
+    select_fields = ["-price"]
+    filtered_charges = (
+        statement_charges.filter(RQLQuery(id=statement_charge_id))
+        .filter(RQLQuery(externalIds__invoice="INV12345"))
+        .select(*select_fields)
+    )
+
+    result = [statement async for statement in filtered_charges.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/statement/charge/test_sync_statement_charge.py
+++ b/tests/e2e/billing/statement/charge/test_sync_statement_charge.py
@@ -1,0 +1,43 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def statement_charges(mpt_ops, statement_id):
+    return mpt_ops.billing.statements.charges(statement_id)
+
+
+def test_get_statement_charge_by_id(statement_charges, statement_charge_id):
+    result = statement_charges.get(statement_charge_id)
+
+    assert result is not None
+
+
+def test_get_statement_charge_by_id_not_found(statement_charges, invalid_statement_charge_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        statement_charges.get(invalid_statement_charge_id)
+
+
+def test_list_statement_charges(statement_charges):
+    limit = 10
+
+    result = statement_charges.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_filter_statement_charges(statement_charges, statement_charge_id):
+    select_fields = ["-price"]
+    filtered_charges = (
+        statement_charges.filter(RQLQuery(id=statement_charge_id))
+        .filter(RQLQuery(externalIds__invoice="INV12345"))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_charges.iterate())
+
+    assert len(result) == 1

--- a/tests/e2e/billing/statement/conftest.py
+++ b/tests/e2e/billing/statement/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def statement_id(e2e_config):
+    return e2e_config["billing.statement.id"]
+
+
+@pytest.fixture
+def invalid_statement_id():
+    return "SOM-0000-0000-0000-0000"

--- a/tests/e2e/billing/statement/test_async_statement.py
+++ b/tests/e2e/billing/statement/test_async_statement.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+async def test_get_statement_by_id(async_mpt_ops, statement_id):
+    result = await async_mpt_ops.billing.statements.get(statement_id)
+
+    assert result is not None
+
+
+async def test_list_statements(async_mpt_ops):
+    limit = 10
+
+    result = await async_mpt_ops.billing.statements.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_get_statement_by_id_not_found(async_mpt_ops, invalid_statement_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await async_mpt_ops.billing.statements.get(invalid_statement_id)
+
+
+async def test_filter_statements(async_mpt_ops, statement_id):
+    select_fields = ["-client"]
+    filtered_statements = (
+        async_mpt_ops.billing.statements.filter(RQLQuery(id=statement_id))
+        .filter(RQLQuery(type="Debit"))
+        .select(*select_fields)
+    )
+
+    result = [statement async for statement in filtered_statements.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/statement/test_sync_statement.py
+++ b/tests/e2e/billing/statement/test_sync_statement.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+def test_get_statement_by_id(mpt_ops, statement_id):
+    result = mpt_ops.billing.statements.get(statement_id)
+
+    assert result is not None
+
+
+def test_list_statements(mpt_ops):
+    limit = 10
+
+    result = mpt_ops.billing.statements.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_get_statement_by_id_not_found(mpt_ops, invalid_statement_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        mpt_ops.billing.statements.get(invalid_statement_id)
+
+
+def test_filter_statements(mpt_ops, statement_id):
+    select_fields = ["-client"]
+    filtered_statements = (
+        mpt_ops.billing.statements.filter(RQLQuery(id=statement_id))
+        .filter(RQLQuery(type="Debit"))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_statements.iterate())
+
+    assert len(result) == 1


### PR DESCRIPTION
Added e2e tests for billing statements and statement charges

https://softwareone.atlassian.net/browse/MPT-14918
https://softwareone.atlassian.net/browse/MPT-14919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-14918](https://softwareone.atlassian.net/browse/MPT-14918)

- Added comprehensive end-to-end tests for billing statements, including retrieval, listing, filtering, and error handling for both synchronous and asynchronous operations
- Added comprehensive end-to-end tests for billing statement charges, including retrieval, listing, and filtering for both synchronous and asynchronous operations
- Added test configuration entries for billing statement and charge IDs to `e2e_config.test.json`
- Added PyTest fixtures for statement IDs and charge IDs in separate conftest modules
- Increased job timeout from 45 to 60 minutes across all GitHub Actions workflows (cron-main-e2e, pull-request, push-release-branch, and release) to accommodate longer test execution times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-14918]: https://softwareone.atlassian.net/browse/MPT-14918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ