### PR TITLE
[MPT-14926] Added e2e tests for billing overrides

### DIFF
--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -21,6 +21,7 @@
   "billing.ledger.attachment.id": "LEA-4971-4321",
   "billing.ledger.charge.id": "CHG-2589-1434-0000-0000-0200",
   "billing.ledger.id": "BLE-2589-1434-7310-3075",
+  "billing.override.id": "BOV-7202-7714",
   "billing.statement.charge.id": "CHG-2589-1434-0000-0000-0200",
   "billing.statement.id": "SOM-7311-9982-9805-9250",
   "catalog.authorization.id": "AUT-9288-6146",

--- a/tests/e2e/billing/override/conftest.py
+++ b/tests/e2e/billing/override/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def billing_override_id(e2e_config):
+    return e2e_config["billing.override.id"]
+
+
+@pytest.fixture
+def invalid_billing_override_id():
+    return "BOV-0000-0000"

--- a/tests/e2e/billing/override/test_async_override.py
+++ b/tests/e2e/billing/override/test_async_override.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+async def test_get_billing_override_by_id(async_mpt_ops, billing_override_id):
+    result = await async_mpt_ops.billing.manual_overrides.get(billing_override_id)
+
+    assert result is not None
+
+
+async def test_list_billing_overrides(async_mpt_ops):
+    limit = 10
+
+    result = await async_mpt_ops.billing.manual_overrides.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_get_billing_override_by_id_not_found(async_mpt_ops, invalid_billing_override_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await async_mpt_ops.billing.manual_overrides.get(invalid_billing_override_id)
+
+
+async def test_filter_billing_overrides(async_mpt_ops, billing_override_id):
+    select_fields = ["-client"]
+    filtered_billing_overrides = (
+        async_mpt_ops.billing.manual_overrides.filter(RQLQuery(id=billing_override_id))
+        .filter(RQLQuery(externalId="e2e-seeded-override"))
+        .select(*select_fields)
+    )
+
+    result = [override async for override in filtered_billing_overrides.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/override/test_sync_override.py
+++ b/tests/e2e/billing/override/test_sync_override.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+def test_get_billing_override_by_id(mpt_ops, billing_override_id):
+    result = mpt_ops.billing.manual_overrides.get(billing_override_id)
+
+    assert result is not None
+
+
+def test_list_billing_overrides(mpt_ops):
+    limit = 10
+
+    result = mpt_ops.billing.manual_overrides.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_get_billing_override_by_id_not_found(mpt_ops, invalid_billing_override_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        mpt_ops.billing.manual_overrides.get(invalid_billing_override_id)
+
+
+def test_filter_billing_overrides(mpt_ops, billing_override_id):
+    select_fields = ["-client"]
+    filtered_billing_overrides = (
+        mpt_ops.billing.manual_overrides.filter(RQLQuery(id=billing_override_id))
+        .filter(RQLQuery(externalId="e2e-seeded-override"))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_billing_overrides.iterate())
+
+    assert len(result) == 1


### PR DESCRIPTION
Added e2e tests for billing overrides

https://softwareone.atlassian.net/browse/MPT-14926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-14926](https://softwareone.atlassian.net/browse/MPT-14926)

- Add e2e test config entry `billing.override.id = "BOV-7202-7714"` in `e2e_config.test.json`
- Add pytest fixtures in `tests/e2e/billing/override/conftest.py`:
  - `billing_override_id(e2e_config)` (reads `billing.override.id`)
  - `invalid_billing_override_id()` returns `"BOV-0000-0000"`
- Add async e2e tests `tests/e2e/billing/override/test_async_override.py`:
  - test get by id, list (fetch_page), not-found (404) and filter (id + externalId) with select & iteration
  - marked flaky
- Add sync e2e tests `tests/e2e/billing/override/test_sync_override.py`:
  - test get by id, list (fetch_page), not-found (404) and filter (id + externalId) with select & iteration
  - marked flaky
- Tests cover pagination, filtering by id and externalId, field selection, iteration, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-14926]: https://softwareone.atlassian.net/browse/MPT-14926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ