### PR TITLE
[MPT-14923] Added e2e tests for commerce credit memos

### DIFF
--- a/tests/e2e/billing/credit_memo/conftest.py
+++ b/tests/e2e/billing/credit_memo/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def invalid_credit_memo_id():
+    return "CRD-0000-0000-0000-0000"

--- a/tests/e2e/billing/credit_memo/test_async_credit_memo.py
+++ b/tests/e2e/billing/credit_memo/test_async_credit_memo.py
@@ -1,0 +1,59 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+async def credit_memos(async_mpt_ops):
+    limit = 1
+    return await async_mpt_ops.billing.credit_memos.fetch_page(limit=limit)
+
+
+@pytest.fixture
+def credit_memo(credit_memos):
+    if credit_memos:
+        return credit_memos[0]
+    return None
+
+
+async def test_get_credit_memo_by_id(async_mpt_ops, credit_memo):
+    if credit_memo is None:
+        pytest.skip("No credit memos available to test retrieval by ID.")
+    credit_memo_id = credit_memo.id
+
+    result = await async_mpt_ops.billing.credit_memos.get(credit_memo_id)
+
+    assert result is not None
+
+
+async def test_get_credit_memo_by_id_not_found(async_mpt_ops, invalid_credit_memo_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await async_mpt_ops.billing.credit_memos.get(invalid_credit_memo_id)
+
+
+async def test_list_credit_memos(async_mpt_ops):
+    limit = 10
+
+    result = await async_mpt_ops.billing.credit_memos.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_filter_credit_memos(async_mpt_ops, credit_memo):
+    if credit_memo is None:
+        pytest.skip("No credit memos available to test filtering.")
+    credit_memo_id = credit_memo.id
+    credit_memo_status = credit_memo.status
+    select_fields = ["-vendor"]
+    filtered_credit_memos = (
+        async_mpt_ops.billing.credit_memos.filter(RQLQuery(id=credit_memo_id))
+        .filter(RQLQuery(status=credit_memo_status))
+        .select(*select_fields)
+    )
+
+    result = [credit_memo async for credit_memo in filtered_credit_memos.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/credit_memo/test_sync_credit_memo.py
+++ b/tests/e2e/billing/credit_memo/test_sync_credit_memo.py
@@ -1,0 +1,59 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def credit_memos(mpt_ops):
+    limit = 1
+    return mpt_ops.billing.credit_memos.fetch_page(limit=limit)
+
+
+@pytest.fixture
+def credit_memo(credit_memos):
+    if credit_memos:
+        return credit_memos[0]
+    return None
+
+
+def test_get_credit_memo_by_id(mpt_ops, credit_memo):
+    if credit_memo is None:
+        pytest.skip("No credit memos available to test retrieval by ID.")
+    credit_memo_id = credit_memo.id
+
+    result = mpt_ops.billing.credit_memos.get(credit_memo_id)
+
+    assert result is not None
+
+
+def test_get_credit_memo_by_id_not_found(mpt_ops, invalid_credit_memo_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        mpt_ops.billing.credit_memos.get(invalid_credit_memo_id)
+
+
+def test_list_credit_memos(mpt_ops):
+    limit = 10
+
+    result = mpt_ops.billing.credit_memos.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_filter_credit_memos(mpt_ops, credit_memo):
+    if credit_memo is None:
+        pytest.skip("No credit memos available to test filtering.")
+    credit_memo_id = credit_memo.id
+    credit_memo_status = credit_memo.status
+    select_fields = ["-vendor"]
+    filtered_credit_memos = (
+        mpt_ops.billing.credit_memos.filter(RQLQuery(id=credit_memo_id))
+        .filter(RQLQuery(status=credit_memo_status))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_credit_memos.iterate())
+
+    assert len(result) == 1


### PR DESCRIPTION
Added e2e tests for commerce credit memos
Data can't be seeded because it comes from Nav, but operations have data already there. Not ideal, but it's something.
https://softwareone.atlassian.net/browse/MPT-14923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-14923](https://softwareone.atlassian.net/browse/MPT-14923)

- Add end-to-end tests for commerce credit memos in billing
- Add async credit memo test module (tests/e2e/billing/credit_memo/test_async_credit_memo.py) with tests for: get by ID, 404 not-found, list (fetch_page), and filter + iterate using RQLQuery
- Add sync credit memo test module (tests/e2e/billing/credit_memo/test_sync_credit_memo.py) with tests for: get by ID, 404 not-found, list (fetch_page), and filter + iterate using RQLQuery
- Add fixture invalid_credit_memo_id in tests/e2e/billing/credit_memo/conftest.py returning "CRD-0000-0000-0000-0000"
- Add fixtures credit_memos and credit_memo to fetch sample data for tests
- Mark credit memo tests as flaky; tests rely on existing data present in the system (no seed data)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-14923]: https://softwareone.atlassian.net/browse/MPT-14923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ