### PR TITLE
[MPT-14920] Added e2e tests for invoice

### DIFF
--- a/tests/e2e/billing/invoice/conftest.py
+++ b/tests/e2e/billing/invoice/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def invalid_invoice_id():
+    return "INV-0000-0000-0000-0000"

--- a/tests/e2e/billing/invoice/test_async_invoice.py
+++ b/tests/e2e/billing/invoice/test_async_invoice.py
@@ -1,0 +1,59 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+async def invoices(async_mpt_ops):
+    limit = 1
+    return await async_mpt_ops.billing.invoices.fetch_page(limit=limit)
+
+
+@pytest.fixture
+def invoice(invoices):
+    if invoices:
+        return invoices[0]
+    return None
+
+
+async def test_get_invoice_by_id(async_mpt_ops, invoice):
+    if invoice is None:
+        pytest.skip("No invoice available for get by id test.")
+    invoice_id = invoice.id
+
+    result = await async_mpt_ops.billing.invoices.get(invoice_id)
+
+    assert result is not None
+
+
+async def test_get_invoice_by_id_not_found(async_mpt_ops, invalid_invoice_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        await async_mpt_ops.billing.invoices.get(invalid_invoice_id)
+
+
+async def test_list_invoices(async_mpt_ops):
+    limit = 10
+
+    result = await async_mpt_ops.billing.invoices.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+async def test_filter_invoices(async_mpt_ops, invoice):
+    if invoice is None:
+        pytest.skip("No invoice available to test filtering.")
+    invoice_id = invoice.id
+    invoice_status = invoice.status
+    select_fields = ["-buyer"]
+    filtered_invoices = (
+        async_mpt_ops.billing.invoices.filter(RQLQuery(id=invoice_id))
+        .filter(RQLQuery(status=invoice_status))
+        .select(*select_fields)
+    )
+
+    result = [invoice async for invoice in filtered_invoices.iterate()]
+
+    assert len(result) == 1

--- a/tests/e2e/billing/invoice/test_sync_invoice.py
+++ b/tests/e2e/billing/invoice/test_sync_invoice.py
@@ -1,0 +1,59 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.rql.query_builder import RQLQuery
+
+pytestmark = [pytest.mark.flaky]
+
+
+@pytest.fixture
+def invoices(mpt_ops):
+    limit = 1
+    return mpt_ops.billing.invoices.fetch_page(limit=limit)
+
+
+@pytest.fixture
+def invoice(invoices):
+    if invoices:
+        return invoices[0]
+    return None
+
+
+def test_get_invoice_by_id(mpt_ops, invoice):
+    if invoice is None:
+        pytest.skip("No invoice available for get by id test.")
+    invoice_id = invoice.id
+
+    result = mpt_ops.billing.invoices.get(invoice_id)
+
+    assert result is not None
+
+
+def test_get_invoice_by_id_not_found(mpt_ops, invalid_invoice_id):
+    with pytest.raises(MPTAPIError, match=r"404 Not Found"):
+        mpt_ops.billing.invoices.get(invalid_invoice_id)
+
+
+def test_list_invoices(mpt_ops):
+    limit = 10
+
+    result = mpt_ops.billing.invoices.fetch_page(limit=limit)
+
+    assert len(result) > 0
+
+
+def test_filter_invoices(mpt_ops, invoice):
+    if invoice is None:
+        pytest.skip("No invoice available for filtering test.")
+    invoice_id = invoice.id
+    invoice_status = invoice.status
+    select_fields = ["-buyer"]
+    filtered_invoices = (
+        mpt_ops.billing.invoices.filter(RQLQuery(id=invoice_id))
+        .filter(RQLQuery(status=invoice_status))
+        .select(*select_fields)
+    )
+
+    result = list(filtered_invoices.iterate())
+
+    assert len(result) == 1


### PR DESCRIPTION
Added e2e tests for invoice
Data can't be seeded because it comes from Nav.

https://softwareone.atlassian.net/browse/MPT-14920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-14920](https://softwareone.atlassian.net/browse/MPT-14920)

## Changes

- Added invoice e2e test fixture `invalid_invoice_id` in `conftest.py` to provide a consistent invalid invoice identifier for testing error cases
- Added asynchronous e2e tests for invoice operations:
  - Retrieval of invoice by ID
  - 404 handling for invalid invoice IDs
  - Listing invoices with limit
  - Filtering invoices by ID and status with field selection
- Added synchronous e2e tests for invoice operations:
  - CRUD-like behavior tests for invoice retrieval
  - Error handling for non-existent invoices (404 Not Found)
  - Pagination and listing with limits
  - Advanced filtering using RQLQuery with field exclusion
  - Tests marked as flaky with conditional skip when test data unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-14920]: https://softwareone.atlassian.net/browse/MPT-14920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ