### PR TITLE
[MPT-16914] Removed e2e test step from pr build and merge

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,13 +36,6 @@ jobs:
     - name: "Run validation & test"
       run: make check-all
 
-    - name: "Run E2E test"
-      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT"
-      env:
-        RP_LAUNCH: github-e2e-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_number }}
-        RP_ENDPOINT: ${{ secrets.RP_ENDPOINT }}
-        RP_API_KEY: ${{ secrets.RP_API_KEY }}
-
     - name: "Run SonarCloud Scan"
       uses: SonarSource/sonarqube-scan-action@master
       env:


### PR DESCRIPTION
Removed e2e test step from pr build and merge
https://softwareone.atlassian.net/browse/MPT-16914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-16914](https://softwareone.atlassian.net/browse/MPT-16914)

- Removed the "Run E2E test" step from the pull-request build workflow (`.github/workflows/pull-request.yml`)
- The E2E test invocation (`make e2e --reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT`) is no longer executed during PR builds
- Validation tests and SonarCloud scanning steps remain intact in the workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16914]: https://softwareone.atlassian.net/browse/MPT-16914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ