### PR TITLE
MPT-17125 Fix failure for dependabot in pyproject file - incorrect flake8-import-conventions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,11 +229,18 @@ ignore = [
 external = [ "AAA", "WPS" ]
 
 # Plugin configs:
-flake8-import-conventions.banned-from = [ "datetime" ]
-flake8-import-conventions.aliases = { datetime = "dt" }
-flake8-quotes.inline-quotes = "double"
-mccabe.max-complexity = 6
-pydocstyle.convention = "google"
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = ["ast", "datetime"]
+aliases = { datetime = "dt" }
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "double"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 6
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-17125](https://softwareone.atlassian.net/browse/MPT-17125)

## Release Notes

- Restructured `pyproject.toml` flake8 plugin configuration from flat top-level keys to nested sections under `[tool.ruff.lint.*]`
- Updated `flake8-import-conventions.banned-from` to include both "ast" and "datetime"
- Organized lint rules into dedicated nested sections:
  - `[tool.ruff.lint.flake8-import-conventions]` with banned-from and aliases
  - `[tool.ruff.lint.flake8-quotes]` with inline-quotes configuration
  - `[tool.ruff.lint.mccabe]` with max-complexity setting
  - `[tool.ruff.lint.pydocstyle]` with convention configuration
- Added `[tool.ruff.lint.per-file-ignores]` to preserve per-file ignore rules for tests
- Migrates configuration to structured Ruff format to resolve dependabot compatibility issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17125]: https://softwareone.atlassian.net/browse/MPT-17125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ