### PR TITLE
MPT-16824 Rename report portal launch and move to use attributes

### DIFF
--- a/.github/workflows/push-release-branch.yml
+++ b/.github/workflows/push-release-branch.yml
@@ -39,11 +39,12 @@ jobs:
       run: make check-all
 
     - name: "Run E2E test"
-      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT"
+      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT -o rp_launch_attributes=\"$RP_LAUNCH_ATTR\""
       env:
-        RP_LAUNCH: github-e2e-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_number }}
+        RP_LAUNCH: mpt-api-client-e2e
         RP_ENDPOINT: ${{ secrets.RP_ENDPOINT }}
         RP_API_KEY: ${{ secrets.RP_API_KEY }}
+        RP_LAUNCH_ATTR: ref:${{ github.ref }} event_name:${{ github.event_name }}
 
     - name: "Run SonarCloud Scan"
       uses: SonarSource/sonarqube-scan-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,12 @@ jobs:
         MPT_API_TOKEN_VENDOR: ${{ secrets.MPT_API_TOKEN_VENDOR }}
 
     - name: "Run E2E test"
-      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT"
+      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT -o rp_launch_attributes=\"$RP_LAUNCH_ATTR\""
       env:
-        RP_LAUNCH: github-e2e-release-${{ github.ref_name }}
+        RP_LAUNCH: mpt-api-client-e2e
         RP_ENDPOINT: ${{ secrets.RP_ENDPOINT }}
         RP_API_KEY: ${{ secrets.RP_API_KEY }}
+        RP_LAUNCH_ATTR: ref:${{ github.ref }} event_name:${{ github.event_name }}
 
     - name: "Set up Python"
       uses: actions/setup-python@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-16824](https://softwareone.atlassian.net/browse/MPT-16824)

- Renamed Report Portal launch naming from dynamic values to a fixed value (`mpt-api-client-e2e`) across CI/CD workflows
- Introduced `RP_LAUNCH_ATTR` environment variable to capture launch attributes (ref and event name metadata)
- Updated E2E test invocations to pass launch attributes via `-o rp_launch_attributes` option
- Applied consistent changes to both `push-release-branch.yml` and `release.yml` workflow files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16824]: https://softwareone.atlassian.net/browse/MPT-16824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ