### PR TITLE
MPT-16824 Update e2e cronjob report portal setup

### DIFF
--- a/.github/workflows/cron-main-e2e.yml
+++ b/.github/workflows/cron-main-e2e.yml
@@ -26,11 +26,12 @@ jobs:
         MPT_API_TOKEN_VENDOR: ${{ secrets.MPT_API_TOKEN_VENDOR }}
 
     - name: "Run E2E test"
-      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT"
+      run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT -o rp_launch_attributes=\"$RP_LAUNCH_ATTR\""
       env:
-        RP_LAUNCH: github-e2e-cron-${{ github.ref_name }}
+        RP_LAUNCH: mpt-api-client-e2e
         RP_ENDPOINT: ${{ secrets.RP_ENDPOINT }}
         RP_API_KEY: ${{ secrets.RP_API_KEY }}
+        RP_LAUNCH_ATTR: ref:${{ github.ref }} event_name:${{ github.event_name }}
 
     - name: "Stop containers"
       if: always()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-16824](https://softwareone.atlassian.net/browse/MPT-16824)

- Updated e2e cronjob GitHub workflow to configure Report Portal launch attributes
- Added Report Portal launch attributes argument to e2e command: `-o rp_launch_attributes="$RP_LAUNCH_ATTR"`
- Changed RP_LAUNCH from dynamic github-ref-based value to static value: `mpt-api-client-e2e`
- Introduced new environment variable RP_LAUNCH_ATTR containing ref and event name: `ref:${{ github.ref }} event_name:${{ github.event_name }}`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-16824]: https://softwareone.atlassian.net/browse/MPT-16824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ