### PR TITLE
WIP Parameter model

### DIFF
--- a/mpt_api_client/resources/catalog/products_parameters.py
+++ b/mpt_api_client/resources/catalog/products_parameters.py
@@ -1,3 +1,5 @@
+from typing import Any, ClassVar
+
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
@@ -10,6 +12,108 @@ from mpt_api_client.models import Model
 
 class Parameter(Model):
     """Parameter resource."""
+
+    _attribute_mapping: ClassVar[dict[str, str]] = {"externalId": "external_id"}
+
+    @property
+    def type_(self) -> str:
+        """Returns the parameter type."""
+        return str(self._box.get("type", ""))  # type: ignore[no-untyped-call]
+
+    @type_.setter
+    def type_(self, value: str) -> None:
+        """Sets the parameter type."""
+        self._box.type = value
+
+    @property
+    def scope(self) -> str:
+        """Returns the parameter scope."""
+        return str(self._box.get("scope", ""))  # type: ignore[no-untyped-call]
+
+    @scope.setter
+    def scope(self, value: str) -> None:
+        """Sets the parameter scope."""
+        self._box.scope = value
+
+    @property
+    def phase(self) -> str:
+        """Returns the parameter phase."""
+        return str(self._box.get("phase", ""))  # type: ignore[no-untyped-call]
+
+    @phase.setter
+    def phase(self, value: str) -> None:
+        """Sets the parameter phase."""
+        self._box.phase = value
+
+    @property
+    def context(self) -> str:
+        """Returns the parameter context."""
+        return str(self._box.get("context", ""))  # type: ignore[no-untyped-call]
+
+    @context.setter
+    def context(self, value: str) -> None:
+        """Sets the parameter context."""
+        self._box.context = value
+
+    @property
+    def options(self) -> dict[str, Any]:
+        """Returns the parameter options."""
+        return self._box.get("options", {})  # type: ignore[no-any-return, no-untyped-call]
+
+    @options.setter
+    def options(self, value: dict[str, Any]) -> None:
+        """Sets the parameter options."""
+        self._box.options = value
+
+    @property
+    def multiple(self) -> bool:
+        """Returns whether the parameter allows multiple values."""
+        return bool(self._box.get("multiple", False))  # type: ignore[no-untyped-call]
+
+    @multiple.setter
+    def multiple(self, value: bool) -> None:
+        """Sets whether the parameter allows multiple values."""
+        self._box.multiple = value
+
+    @property
+    def constraints(self) -> dict[str, Any]:
+        """Returns the parameter constraints."""
+        return self._box.get("constraints", {})  # type: ignore[no-any-return, no-untyped-call]
+
+    @constraints.setter
+    def constraints(self, value: dict[str, Any]) -> None:
+        """Sets the parameter constraints."""
+        self._box.constraints = value
+
+    @property
+    def group(self) -> dict[str, Any]:
+        """Returns the parameter group."""
+        return self._box.get("group", {})  # type: ignore[no-any-return,no-untyped-call]
+
+    @group.setter
+    def group(self, value: dict[str, Any]) -> None:
+        """Sets the parameter group."""
+        self._box.group = value
+
+    @property
+    def external_id(self) -> str:
+        """Returns the parameter external ID."""
+        return str(self._box.get("external_id", ""))  # type: ignore[no-untyped-call]
+
+    @external_id.setter
+    def external_id(self, value: str) -> None:
+        """Sets the parameter external ID."""
+        self._box.external_id = value
+
+    @property
+    def status(self) -> str:
+        """Returns the parameter status."""
+        return str(self._box.get("status", ""))  # type: ignore[no-untyped-call]
+
+    @status.setter
+    def status(self, value: str) -> None:
+        """Sets the parameter status."""
+        self._box.status = value
 
 
 class ParametersServiceConfig:

--- a/tests/unit/resources/catalog/test_parameter_properties.py
+++ b/tests/unit/resources/catalog/test_parameter_properties.py
@@ -1,0 +1,76 @@
+from mpt_api_client.resources.catalog.products_parameters import Parameter
+
+
+def test_parameter_properties_getters():  # noqa: WPS218
+    parameter_data = {
+        "id": "PAR-1",
+        "scope": "Order",
+        "phase": "Order",
+        "context": "Purchase",
+        "options": {"label": "Email"},
+        "multiple": True,
+        "constraints": {"required": True},
+        "group": {"id": "GRP-1"},
+        "externalId": "ext-1",
+        "status": "Active",
+    }
+
+    result = Parameter(parameter_data)
+
+    assert result.id == "PAR-1"
+    assert result.scope == "Order"
+    assert result.phase == "Order"
+    assert result.context == "Purchase"
+    assert result.options == {"label": "Email"}
+    assert result.multiple is True
+    assert result.constraints == {"required": True}
+    assert result.group == {"id": "GRP-1"}
+    assert result.external_id == "ext-1"
+    assert result.status == "Active"
+
+
+def test_parameter_properties_setters():  # noqa: WPS218
+    parameter = Parameter()
+    parameter.scope = "Agreement"
+    parameter.phase = "Configuration"
+    parameter.context = "None"
+    parameter.type_ = "Text"
+    parameter.options = {"label": "Name"}
+    parameter.multiple = False
+    parameter.constraints = {"required": False}
+    parameter.group = {"id": "GRP-2"}
+    parameter.external_id = "ext-2"
+    parameter.status = "Inactive"
+
+    result = parameter
+
+    assert result.scope == "Agreement"
+    assert result.phase == "Configuration"
+    assert result.context == "None"
+    assert result.type_ == "Text"
+    assert result.options == {"label": "Name"}
+    assert result.multiple is False
+    assert result.constraints == {"required": False}
+    assert result.group == {"id": "GRP-2"}
+    assert result.external_id == "ext-2"
+    assert result.status == "Inactive"
+    result_dict = result.to_dict()
+    assert result_dict["scope"] == "Agreement"
+    assert result_dict["externalId"] == "ext-2"
+    assert result_dict["scope"] == "Agreement"
+    assert result_dict["externalId"] == "ext-2"
+
+
+def test_parameter_default_values():  # noqa: WPS218
+    result = Parameter()
+
+    assert not result.id
+    assert not result.scope
+    assert not result.phase
+    assert not result.context
+    assert result.options == {}
+    assert result.multiple is False
+    assert result.constraints == {}
+    assert result.group == {}
+    assert not result.external_id
+    assert not result.status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Parameter Model Improvements

- Enhanced internal attribute mapping: MptBox now copies attribute_mapping on init to prevent external mutations.
- Key normalization and mapping fixes: _prep_key avoids overwriting existing mappings, returns already-mapped keys, caches camelCase mappings from _camel_killer; __setitem__ and __setattr__ store values under prepared/mapped keys; to_dict falls back to original keys when reverse mapping is missing.
- Model attribute behavior: Model.__setattr__ now respects class descriptors (properties with setters) and invokes them instead of delegating to the box.
- Parameter API model additions: Added Parameter._attribute_mapping = {"externalId": "external_id"} and new typed properties on Parameter — type_, scope, phase, context, options, multiple, constraints, group, external_id, and status — backed by the internal model box.
- Tests: Added unit tests covering Parameter getters, setters, default values, and to_dict output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->