### PR TITLE
[MPT-18174] Fix any and all with multiple nested conditions for a collection

### DIFF
--- a/tests/unit/rql/query_builder/test_rql_all_any.py
+++ b/tests/unit/rql/query_builder/test_rql_all_any.py
@@ -2,16 +2,36 @@ from mpt_api_client.rql import RQLQuery
 
 
 def test_all():
-    query = RQLQuery(saleDetails__orderQty__gt=1).all()
+    query = RQLQuery(orderQty__gt=1).all("saleDetails")
 
     result = str(query)
 
-    assert result == "all(gt(saleDetails.orderQty,1))"
+    assert result == "all(saleDetails,gt(orderQty,1))"
 
 
 def test_any():
-    query = RQLQuery(saleDetails__orderQty__gt=1).any()
+    query = RQLQuery(orderQty__gt=1).any("saleDetails")
 
     result = str(query)
 
-    assert result == "any(gt(saleDetails.orderQty,1))"
+    assert result == "any(saleDetails,gt(orderQty,1))"
+
+
+def test_all_multiple_conditions():
+    order_qty_query = RQLQuery(orderQty__gt=1)
+    price_query = RQLQuery(price__lt=100)
+    query = (order_qty_query & price_query).all("saleDetails")
+
+    result = str(query)
+
+    assert result == "all(saleDetails,and(gt(orderQty,1),lt(price,100)))"
+
+
+def test_any_multiple_conditions():
+    order_qty_query = RQLQuery(orderQty__gt=1)
+    price_query = RQLQuery(price__lt=100)
+    query = (order_qty_query & price_query).any("saleDetails")
+
+    result = str(query)
+
+    assert result == "any(saleDetails,and(gt(orderQty,1),lt(price,100)))"


### PR DESCRIPTION
Any and all are treating nested conditions incorrectly. It wraps entire set of conditions, instead of properly using collection name: 

Collection Name is used because inferring possible collections in query values is complex and prone to inference errors. Simplest and safest way I can think of is using collection name.

https://softwareone.atlassian.net/browse/MPT-18174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18174](https://softwareone.atlassian.net/browse/MPT-18174)

- Fix nested condition handling for any() and all(): these methods now require an explicit collection_name and build nested expressions using that collection instead of wrapping the entire condition set.
- Public API changed: RQLQuery.any(collection_name) and RQLQuery.all(collection_name) now require a collection/path argument (no-argument forms removed).
- Added internal _nest helper to compose collection-scoped nested expressions (e.g., any(saleDetails,gt(orderQty,1))).
- Multi-condition queries now format correctly for collections (e.g., all(saleDetails,and(gt(orderQty,1),lt(price,100)))).
- Tests updated to validate explicit collection-name usage and multiple nested condition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18174]: https://softwareone.atlassian.net/browse/MPT-18174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ