### PR TITLE
[MPT-18215] Fix failing unauthorised e2e test

### DIFF
--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -1,14 +1,14 @@
 import pytest
 
 from mpt_api_client import MPTClient
-from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.exceptions import MPTHttpError
 
 
 @pytest.mark.flaky
 def test_unauthorised(base_url):
     client = MPTClient.from_config(api_token="TKN-invalid", base_url=base_url)  # noqa: S106
 
-    with pytest.raises(MPTAPIError, match=r"401 Unauthorized"):
+    with pytest.raises(MPTHttpError, match=r"401 Unauthorized"):
         client.catalog.products.fetch_page()
 
 


### PR DESCRIPTION
Fix failing unauthorised e2e test

https://softwareone.atlassian.net/browse/MPT-18215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18215](https://softwareone.atlassian.net/browse/MPT-18215)

- Fixed failing unauthorised e2e test by updating import from MPTAPIError to MPTHttpError
- Updated test assertion in test_unauthorised to expect MPTHttpError matching "401 Unauthorized"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18215]: https://softwareone.atlassian.net/browse/MPT-18215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ