### PR TITLE
MPT-18457 MPT API Client - Missing type for `in` RQL query

### DIFF
--- a/mpt_api_client/rql/query_builder.py
+++ b/mpt_api_client/rql/query_builder.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from collections.abc import Iterable
 from decimal import Decimal
 from typing import Any, Self, override
 
@@ -46,7 +47,7 @@ class RQLValue:
         return str(self.value)
 
 
-def parse_kwargs(query_dict: dict[str, QueryValue]) -> list[str]:  # noqa: WPS231
+def parse_kwargs(query_dict: dict[str, QueryValue | Iterable[QueryValue]]) -> list[str]:  # noqa: WPS231
     """
     Parse keyword arguments into RQL query expressions.
 
@@ -186,7 +187,7 @@ class RQLQuery:
     def __init__(  # noqa: WPS211
         self,
         namespace_: str | None = None,  # noqa: WPS120
-        **kwargs: QueryValue,
+        **kwargs: QueryValue | Iterable[QueryValue],
     ) -> None:
         self.op: str = self.OP_EXPRESSION
         self.children: list[RQLQuery] = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18457](https://softwareone.atlassian.net/browse/MPT-18457)

- Import Iterable from collections.abc and add Iterable to the public QueryValue type alias.
- Accept iterable-backed values (e.g., list/tuple/set and other Iterable) as QueryValue for RQL encoding.
- rql_encode: for non-list operators, treat QueryValue/RQLValue/RQLProperty via query_value_str; for list operators, join list/tuple/set elements with commas to build list-style RQL expressions.
- parse_kwargs: continue to map list operators (e.g., in) to op(field,(...)) using rql_encode for element encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18457]: https://softwareone.atlassian.net/browse/MPT-18457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ