### PR TITLE
[MPT-18516] Update workflow e2e test step to continue on failure to not block actions

### DIFF
--- a/.github/workflows/push-release-branch.yml
+++ b/.github/workflows/push-release-branch.yml
@@ -39,6 +39,7 @@ jobs:
       run: make check-all
 
     - name: "Run E2E test"
+      continue-on-error: true
       run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT -o rp_launch_attributes=\"$RP_LAUNCH_ATTR\""
       env:
         RP_LAUNCH: mpt-api-client-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         MPT_API_TOKEN_VENDOR: ${{ secrets.MPT_API_TOKEN_VENDOR }}
 
     - name: "Run E2E test"
+      continue-on-error: true
       run: make e2e args="--reportportal --rp-launch=$RP_LAUNCH --rp-api-key=$RP_API_KEY --rp-endpoint=$RP_ENDPOINT -o rp_launch_attributes=\"$RP_LAUNCH_ATTR\""
       env:
         RP_LAUNCH: mpt-api-client-e2e


### PR DESCRIPTION
This pull request makes a minor adjustment to the CI workflow configuration for end-to-end (E2E) tests. The main change is allowing E2E test steps to continue on error rather than fail the entire workflow.

Most important changes:

Workflow reliability improvements:

* `.github/workflows/push-release-branch.yml` and `.github/workflows/release.yml`: Added `continue-on-error: true` to the "Run E2E test" job steps to prevent workflow failure if E2E tests fail. [[1]](diffhunk://#diff-a26565069232a0b016134d37fa85c531b26a0e2ec5ab6d87fb751c5a01081318R42) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18516](https://softwareone.atlassian.net/browse/MPT-18516)

- Add `continue-on-error: true` to the "Run E2E test" step in `.github/workflows/push-release-branch.yml` so the workflow continues if E2E tests fail
- Add `continue-on-error: true` to the "Run E2E test" step in `.github/workflows/release.yml` so the workflow continues if E2E tests fail
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18516]: https://softwareone.atlassian.net/browse/MPT-18516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ