### PR TITLE
MPT-18902 E2E API client exception with the seller tests

### DIFF
--- a/tests/e2e/accounts/conftest.py
+++ b/tests/e2e/accounts/conftest.py
@@ -23,7 +23,10 @@ def account_icon(logo_fd):
 
 @pytest.fixture
 def currencies():
-    return ["USD", "EUR"]
+    return [
+        {"value": "EUR", "billingEnabled": False, "isDefault": False},
+        {"value": "USD", "billingEnabled": True, "isDefault": True},
+    ]
 
 
 @pytest.fixture

--- a/tests/e2e/accounts/sellers/conftest.py
+++ b/tests/e2e/accounts/sellers/conftest.py
@@ -22,7 +22,7 @@ def seller_factory(currencies):
                 "postCode": "12345",
                 "country": "US",
             },
-            "currencies": currencies,
+            "currency": currencies,
             "externalId": external_id,
         }
 


### PR DESCRIPTION
https://softwareone.atlassian.net/wiki/spaces/mpt/pages/5243175002/Seller+Object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18902](https://softwareone.atlassian.net/browse/MPT-18902)

- tests/e2e/accounts/conftest.py: currencies fixture now returns a list of currency objects (dicts with keys value, billingEnabled, isDefault) instead of a simple list of strings.
- tests/e2e/accounts/sellers/conftest.py: seller_factory's inner _seller sets the seller dictionary key "currency" (singular) to the provided currencies value; the factory parameter remains named currencies but the returned data shape changed from a "currencies" key to "currency" containing the structured list.
- No changes to fixture names or function signatures; only the returned data structures were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18902]: https://softwareone.atlassian.net/browse/MPT-18902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ