### PR TITLE
[MPT-18998] Increased workflow timeout to 90 minutes

### DIFF
--- a/.github/workflows/cron-main-e2e.yml
+++ b/.github/workflows/cron-main-e2e.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
     - name: "Checkout"
       uses: actions/checkout@v6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/push-release-branch.yml
+++ b/.github/workflows/push-release-branch.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - name: "Checkout"


### PR DESCRIPTION
This pull request increases the build job timeout from 60 minutes to 90 minutes across several GitHub Actions workflow files. This change ensures that longer-running builds have sufficient time to complete, reducing the likelihood of jobs failing due to timeout.

**CI/CD workflow updates:**

* Increased the `timeout-minutes` value from 60 to 90 for the `build` job in the following workflow files:
  - `.github/workflows/cron-main-e2e.yml`
  - `.github/workflows/pull-request.yml`
  - `.github/workflows/push-release-branch.yml`
  - `.github/workflows/release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-18998](https://softwareone.atlassian.net/browse/MPT-18998)

- Increased GitHub Actions workflow `build` job timeout from 60 to 90 minutes across all workflow files
- Updated workflows:
  - `.github/workflows/cron-main-e2e.yml`
  - `.github/workflows/pull-request.yml`
  - `.github/workflows/push-release-branch.yml`
  - `.github/workflows/release.yml`
- Allows longer-running builds sufficient time to complete and reduces job failures due to timeouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18998]: https://softwareone.atlassian.net/browse/MPT-18998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ