### PR TITLE
MPT-18371 mark helpdesk chat tests as flaky

### DIFF
--- a/tests/e2e/helpdesk/chats/test_async_chats.py
+++ b/tests/e2e/helpdesk/chats/test_async_chats.py
@@ -2,6 +2,8 @@ import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
 
+pytestmark = [pytest.mark.flaky]
+
 
 async def test_get_chat(async_mpt_ops, chat_id):
     service = async_mpt_ops.helpdesk.chats

--- a/tests/e2e/helpdesk/chats/test_sync_chats.py
+++ b/tests/e2e/helpdesk/chats/test_sync_chats.py
@@ -2,6 +2,8 @@ import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
 
+pytestmark = [pytest.mark.flaky]
+
 
 def test_get_chat(mpt_ops, chat_id):
     service = mpt_ops.helpdesk.chats


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-18371](https://softwareone.atlassian.net/browse/MPT-18371)

- Mark all tests in `tests/e2e/helpdesk/chats/test_async_chats.py` as flaky by adding module-level `pytest.mark.flaky` marker
- Mark all tests in `tests/e2e/helpdesk/chats/test_sync_chats.py` as flaky by adding module-level `pytest.mark.flaky` marker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18371]: https://softwareone.atlassian.net/browse/MPT-18371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ