### PR TITLE
MPT-19124 mark chat tests as skipped pending MPT-19124 completion

### DIFF
--- a/tests/e2e/helpdesk/chats/attachment/test_async_attachment.py
+++ b/tests/e2e/helpdesk/chats/attachment/test_async_attachment.py
@@ -5,23 +5,27 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_chat_attachments(async_chat_attachments_service, async_created_chat_attachment):
     result = await async_chat_attachments_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_attachment(async_created_chat_attachment, chat_attachment_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_attachment(async_created_chat_attachment, chat_attachment_data):
     assert async_created_chat_attachment.id is not None
     assert async_created_chat_attachment.to_dict().get("name") == chat_attachment_data["name"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_chat_attachment(async_chat_attachments_service, async_created_chat_attachment):
     result = await async_chat_attachments_service.get(async_created_chat_attachment.id)
 
     assert result.id == async_created_chat_attachment.id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_attachment(
     async_chat_attachments_service, async_created_chat_attachment, short_uuid
 ):
@@ -36,6 +40,7 @@ async def test_update_chat_attachment(
     assert result.to_dict().get("name") == updated_name
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_download_chat_attachment(
     async_chat_attachments_service, async_created_chat_attachment
 ):
@@ -47,12 +52,14 @@ async def test_download_chat_attachment(
     assert result.file_contents is not None
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_attachment(async_chat_attachments_service, chat_attachment_data, pdf_fd):
     created = await async_chat_attachments_service.create(chat_attachment_data, file=pdf_fd)
 
     await async_chat_attachments_service.delete(created.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):
@@ -60,6 +67,7 @@ async def test_get_chat_attachment_not_found(
         await async_chat_attachments_service.get(invalid_chat_attachment_id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):
@@ -70,6 +78,7 @@ async def test_update_chat_attachment_not_found(
         )
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):

--- a/tests/e2e/helpdesk/chats/attachment/test_sync_attachment.py
+++ b/tests/e2e/helpdesk/chats/attachment/test_sync_attachment.py
@@ -5,23 +5,27 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_chat_attachments(chat_attachments_service, created_chat_attachment):
     result = chat_attachments_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_attachment(created_chat_attachment, chat_attachment_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_attachment(created_chat_attachment, chat_attachment_data):
     assert created_chat_attachment.id is not None
     assert created_chat_attachment.to_dict().get("name") == chat_attachment_data["name"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_chat_attachment(chat_attachments_service, created_chat_attachment):
     result = chat_attachments_service.get(created_chat_attachment.id)
 
     assert result.id == created_chat_attachment.id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_attachment(chat_attachments_service, created_chat_attachment, short_uuid):
     updated_name = f"e2e updated attachment - {short_uuid}"
 
@@ -34,23 +38,27 @@ def test_update_chat_attachment(chat_attachments_service, created_chat_attachmen
     assert result.to_dict().get("name") == updated_name
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_download_chat_attachment(chat_attachments_service, created_chat_attachment):
     result = chat_attachments_service.download(created_chat_attachment.id, accept="application/pdf")
 
     assert result.file_contents is not None
 
 
-def test_delete_chat_attachment(chat_attachments_service, chat_attachment_data, pdf_fd):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_delete_chat_attachment(chat_attachments_service, chat_attachment_data, pdf_fd):
     created = chat_attachments_service.create(chat_attachment_data, file=pdf_fd)
 
     chat_attachments_service.delete(created.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_attachments_service.get(invalid_chat_attachment_id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_attachments_service.update(
@@ -59,6 +67,7 @@ def test_update_chat_attachment_not_found(chat_attachments_service, invalid_chat
         )
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_attachments_service.delete(invalid_chat_attachment_id)

--- a/tests/e2e/helpdesk/chats/links/test_async_links.py
+++ b/tests/e2e/helpdesk/chats/links/test_async_links.py
@@ -5,17 +5,20 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_chat_links(async_chat_links_service):
     result = await async_chat_links_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_link(async_created_chat_link, chat_link_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_link(async_created_chat_link, chat_link_data):
     assert async_created_chat_link.id is not None
     assert async_created_chat_link.to_dict().get("uri") == chat_link_data["uri"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_link_name(async_chat_links_service, async_created_chat_link, short_uuid):
     new_name = f"e2e updated link - {short_uuid}"
 
@@ -28,12 +31,14 @@ async def test_update_chat_link_name(async_chat_links_service, async_created_cha
     assert result.to_dict().get("name") == new_name
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_link(async_chat_links_service, async_created_chat_link):
     result = async_created_chat_link
 
     await async_chat_links_service.delete(result.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_link_not_found(async_chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_chat_links_service.update(
@@ -42,6 +47,7 @@ async def test_update_chat_link_not_found(async_chat_links_service, invalid_chat
         )
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_link_not_found(async_chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_chat_links_service.delete(invalid_chat_link_id)

--- a/tests/e2e/helpdesk/chats/links/test_sync_links.py
+++ b/tests/e2e/helpdesk/chats/links/test_sync_links.py
@@ -5,17 +5,20 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_chat_links(chat_links_service):
     result = chat_links_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_link(created_chat_link, chat_link_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_link(created_chat_link, chat_link_data):
     assert created_chat_link.id is not None
     assert created_chat_link.to_dict().get("uri") == chat_link_data["uri"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_link_name(chat_links_service, created_chat_link, short_uuid):
     new_name = f"e2e updated link - {short_uuid}"
 
@@ -25,17 +28,20 @@ def test_update_chat_link_name(chat_links_service, created_chat_link, short_uuid
     assert result.to_dict().get("name") == new_name
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_link(chat_links_service, created_chat_link):
     result = created_chat_link
 
     chat_links_service.delete(result.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_link_not_found(chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_links_service.update(invalid_chat_link_id, {"name": "updated name"})
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_link_not_found(chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_links_service.delete(invalid_chat_link_id)

--- a/tests/e2e/helpdesk/chats/messages/test_async_messages.py
+++ b/tests/e2e/helpdesk/chats/messages/test_async_messages.py
@@ -5,17 +5,20 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_chat_messages(async_chat_messages_service):
     result = await async_chat_messages_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_message(async_created_chat_message, chat_message_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_message(async_created_chat_message, chat_message_data):
     assert async_created_chat_message.id is not None
     assert async_created_chat_message.to_dict().get("content") == chat_message_data["content"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_message_visibility(
     async_chat_messages_service, async_created_chat_message
 ):
@@ -27,12 +30,14 @@ async def test_update_chat_message_visibility(
     assert result.id == async_created_chat_message.id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_message(async_chat_messages_service, async_created_chat_message):
     result = async_created_chat_message
 
     await async_chat_messages_service.delete(result.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_message_not_found(async_chat_messages_service, invalid_chat_message_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_chat_messages_service.update(
@@ -41,6 +46,7 @@ async def test_update_chat_message_not_found(async_chat_messages_service, invali
         )
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_message_not_found(async_chat_messages_service, invalid_chat_message_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         await async_chat_messages_service.delete(invalid_chat_message_id)

--- a/tests/e2e/helpdesk/chats/messages/test_sync_messages.py
+++ b/tests/e2e/helpdesk/chats/messages/test_sync_messages.py
@@ -5,34 +5,40 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_chat_messages(chat_messages_service):
     result = chat_messages_service.fetch_page(limit=1)
 
     assert len(result) > 0
 
 
-def test_create_chat_message(created_chat_message, chat_message_data):  # noqa: AAA01
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")  # noqa: AAA01
+def test_create_chat_message(created_chat_message, chat_message_data):
     assert created_chat_message.id is not None
     assert created_chat_message.to_dict().get("content") == chat_message_data["content"]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_message_visibility(chat_messages_service, created_chat_message):
     result = chat_messages_service.update(created_chat_message.id, {"visibility": "Public"})
 
     assert result.id == created_chat_message.id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_message(chat_messages_service, created_chat_message):
     result = created_chat_message
 
     chat_messages_service.delete(result.id)
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_message_not_found(chat_messages_service, invalid_chat_message_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_messages_service.update(invalid_chat_message_id, {"visibility": "Public"})
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_message_not_found(chat_messages_service, invalid_chat_message_id):
     with pytest.raises(MPTAPIError, match=r"404 Not Found"):
         chat_messages_service.delete(invalid_chat_message_id)

--- a/tests/e2e/helpdesk/chats/test_async_chats.py
+++ b/tests/e2e/helpdesk/chats/test_async_chats.py
@@ -5,6 +5,7 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_chat(async_mpt_ops, chat_id):
     service = async_mpt_ops.helpdesk.chats
 
@@ -13,6 +14,7 @@ async def test_get_chat(async_mpt_ops, chat_id):
     assert result.id == chat_id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_chats(async_mpt_ops):
     service = async_mpt_ops.helpdesk.chats
 
@@ -21,6 +23,7 @@ async def test_list_chats(async_mpt_ops):
     assert len(result) > 0
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat(async_mpt_ops, chat_id, short_uuid):
     service = async_mpt_ops.helpdesk.chats
     new_description = f"e2e update {short_uuid}"

--- a/tests/e2e/helpdesk/chats/test_sync_chats.py
+++ b/tests/e2e/helpdesk/chats/test_sync_chats.py
@@ -5,6 +5,7 @@ from mpt_api_client.exceptions import MPTAPIError
 pytestmark = [pytest.mark.flaky]
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_chat(mpt_ops, chat_id):
     service = mpt_ops.helpdesk.chats
 
@@ -13,6 +14,7 @@ def test_get_chat(mpt_ops, chat_id):
     assert result.id == chat_id
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_chats(mpt_ops):
     service = mpt_ops.helpdesk.chats
 
@@ -21,6 +23,7 @@ def test_list_chats(mpt_ops):
     assert len(result) > 0
 
 
+@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat(mpt_ops, chat_id, short_uuid):
     service = mpt_ops.helpdesk.chats
     new_description = f"e2e update {short_uuid}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19124](https://softwareone.atlassian.net/browse/MPT-19124)

- Marked chat-related E2E tests as skipped pending completion of MPT-19124 across multiple test modules:
  - Chat attachment tests (both async and sync variants)
  - Chat links tests (both async and sync variants)
  - Chat messages tests (both async and sync variants)
  - Chat operations tests (both async and sync variants)
- Added `@pytest.mark.skip(reason="Unskip after MPT-19124 completed")` decorator to test functions
- Test logic and assertions remain unchanged; only execution behavior modified to skip these tests
- Affected test functions include: `test_list_chat_*`, `test_create_chat_*`, `test_get_chat*`, `test_update_chat_*`, `test_delete_chat_*`, and related error-case tests (`test_*_not_found`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19124]: https://softwareone.atlassian.net/browse/MPT-19124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ