### PR TITLE
MPT-18372 Add helpdesk parameter groups API services with unit and e2e test coverage

### DIFF
--- a/mpt_api_client/resources/helpdesk/helpdesk.py
+++ b/mpt_api_client/resources/helpdesk/helpdesk.py
@@ -1,6 +1,10 @@
 from mpt_api_client.http import AsyncHTTPClient, HTTPClient
 from mpt_api_client.resources.helpdesk.cases import AsyncCasesService, CasesService
 from mpt_api_client.resources.helpdesk.chats import AsyncChatsService, ChatsService
+from mpt_api_client.resources.helpdesk.parameter_groups import (
+    AsyncParameterGroupsService,
+    ParameterGroupsService,
+)
 from mpt_api_client.resources.helpdesk.parameters import (
     AsyncParametersService,
     ParametersService,
@@ -34,6 +38,11 @@ class Helpdesk:
         """Parameters service."""
         return ParametersService(http_client=self.http_client)
 
+    @property
+    def parameter_groups(self) -> ParameterGroupsService:
+        """Parameter groups service."""
+        return ParameterGroupsService(http_client=self.http_client)
+
 
 class AsyncHelpdesk:
     """Async Helpdesk MPT API Module."""
@@ -60,3 +69,8 @@ class AsyncHelpdesk:
     def parameters(self) -> AsyncParametersService:  # noqa: WPS110
         """Async parameters service."""
         return AsyncParametersService(http_client=self.http_client)
+
+    @property
+    def parameter_groups(self) -> AsyncParameterGroupsService:
+        """Async parameter groups service."""
+        return AsyncParameterGroupsService(http_client=self.http_client)

--- a/mpt_api_client/resources/helpdesk/parameter_group_parameters.py
+++ b/mpt_api_client/resources/helpdesk/parameter_group_parameters.py
@@ -1,0 +1,38 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncManagedResourceMixin,
+    CollectionMixin,
+    ManagedResourceMixin,
+)
+from mpt_api_client.models import Model
+
+
+class ParameterGroupParameter(Model):
+    """Helpdesk parameter group parameter resource."""
+
+
+class ParameterGroupParametersServiceConfig:
+    """Helpdesk parameter group parameters service configuration."""
+
+    _endpoint = "/public/v1/helpdesk/parameter-groups/{group_id}/parameters"
+    _model_class = ParameterGroupParameter
+    _collection_key = "data"
+
+
+class ParameterGroupParametersService(
+    ManagedResourceMixin[ParameterGroupParameter],
+    CollectionMixin[ParameterGroupParameter],
+    Service[ParameterGroupParameter],
+    ParameterGroupParametersServiceConfig,
+):
+    """Helpdesk parameter group parameters service."""
+
+
+class AsyncParameterGroupParametersService(
+    AsyncManagedResourceMixin[ParameterGroupParameter],
+    AsyncCollectionMixin[ParameterGroupParameter],
+    AsyncService[ParameterGroupParameter],
+    ParameterGroupParametersServiceConfig,
+):
+    """Async helpdesk parameter group parameters service."""

--- a/mpt_api_client/resources/helpdesk/parameter_groups.py
+++ b/mpt_api_client/resources/helpdesk/parameter_groups.py
@@ -1,0 +1,54 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncManagedResourceMixin,
+    CollectionMixin,
+    ManagedResourceMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.resources.helpdesk.parameter_group_parameters import (
+    AsyncParameterGroupParametersService,
+    ParameterGroupParametersService,
+)
+
+
+class ParameterGroup(Model):
+    """Helpdesk parameter group resource."""
+
+
+class ParameterGroupsServiceConfig:
+    """Helpdesk parameter groups service configuration."""
+
+    _endpoint = "/public/v1/helpdesk/parameter-groups"
+    _model_class = ParameterGroup
+    _collection_key = "data"
+
+
+class ParameterGroupsService(
+    ManagedResourceMixin[ParameterGroup],
+    CollectionMixin[ParameterGroup],
+    Service[ParameterGroup],
+    ParameterGroupsServiceConfig,
+):
+    """Helpdesk parameter groups service."""
+
+    def parameters(self, group_id: str) -> ParameterGroupParametersService:  # noqa: WPS110
+        """Return parameter group parameters service."""
+        return ParameterGroupParametersService(
+            http_client=self.http_client, endpoint_params={"group_id": group_id}
+        )
+
+
+class AsyncParameterGroupsService(
+    AsyncManagedResourceMixin[ParameterGroup],
+    AsyncCollectionMixin[ParameterGroup],
+    AsyncService[ParameterGroup],
+    ParameterGroupsServiceConfig,
+):
+    """Async helpdesk parameter groups service."""
+
+    def parameters(self, group_id: str) -> AsyncParameterGroupParametersService:  # noqa: WPS110
+        """Return async parameter group parameters service."""
+        return AsyncParameterGroupParametersService(
+            http_client=self.http_client, endpoint_params={"group_id": group_id}
+        )

--- a/tests/e2e/helpdesk/parameter_groups/conftest.py
+++ b/tests/e2e/helpdesk/parameter_groups/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+
+from tests.e2e.helper import (
+    async_create_fixture_resource_and_delete,
+    create_fixture_resource_and_delete,
+)
+
+
+@pytest.fixture
+def parameter_group_data(short_uuid):
+    return {
+        "name": f"E2E Helpdesk Parameter Group {short_uuid}",
+        "label": f"E2E Label {short_uuid}",
+        "description": "E2E Created Helpdesk Parameter Group",
+    }
+
+
+@pytest.fixture
+def invalid_parameter_group_id():
+    return "PGR-0000-0000"
+
+
+@pytest.fixture
+def parameter_groups_service(mpt_ops):
+    return mpt_ops.helpdesk.parameter_groups
+
+
+@pytest.fixture
+def async_parameter_groups_service(async_mpt_ops):
+    return async_mpt_ops.helpdesk.parameter_groups
+
+
+@pytest.fixture
+def created_parameter_group(parameter_groups_service, parameter_group_data):
+    with create_fixture_resource_and_delete(
+        parameter_groups_service, parameter_group_data
+    ) as parameter_group:
+        yield parameter_group
+
+
+@pytest.fixture
+async def async_created_parameter_group(async_parameter_groups_service, parameter_group_data):
+    async with async_create_fixture_resource_and_delete(
+        async_parameter_groups_service, parameter_group_data
+    ) as parameter_group:
+        yield parameter_group

--- a/tests/e2e/helpdesk/parameter_groups/parameters/conftest.py
+++ b/tests/e2e/helpdesk/parameter_groups/parameters/conftest.py
@@ -1,0 +1,91 @@
+import pytest
+
+from tests.e2e.helper import (
+    async_create_fixture_resource_and_delete,
+    create_fixture_resource_and_delete,
+)
+
+
+@pytest.fixture
+def parameter_data(short_uuid):
+    return {
+        "name": f"E2E Helpdesk Group Parameter {short_uuid}",
+        "description": "E2E Created Helpdesk Group Parameter",
+        "scope": "Case",
+        "phase": "Request",
+        "type": "String",
+        "multiple": False,
+        "constraints": {
+            "required": False,
+            "readonly": False,
+            "hidden": False,
+            "visibility": "All",
+        },
+    }
+
+
+@pytest.fixture
+def created_parameter_definition(mpt_ops, parameter_data):
+    with create_fixture_resource_and_delete(
+        mpt_ops.helpdesk.parameters, parameter_data
+    ) as parameter_definition:
+        yield parameter_definition
+
+
+@pytest.fixture
+async def async_created_parameter_definition(async_mpt_ops, parameter_data):
+    async with async_create_fixture_resource_and_delete(
+        async_mpt_ops.helpdesk.parameters, parameter_data
+    ) as parameter_definition:
+        yield parameter_definition
+
+
+@pytest.fixture
+def parameter_group_parameters_service(mpt_ops, created_parameter_group):
+    return mpt_ops.helpdesk.parameter_groups.parameters(created_parameter_group.id)
+
+
+@pytest.fixture
+def parameter_group_parameter_data(created_parameter_definition):
+    return {
+        "parameterId": created_parameter_definition.id,
+        "displayOrder": 100,
+    }
+
+
+@pytest.fixture
+def created_parameter_group_parameter(
+    parameter_group_parameters_service, parameter_group_parameter_data
+):
+    with create_fixture_resource_and_delete(
+        parameter_group_parameters_service, parameter_group_parameter_data
+    ) as parameter_group_parameter:
+        yield parameter_group_parameter
+
+
+@pytest.fixture
+def invalid_parameter_group_parameter_id():
+    return "PAR-0000-0000"
+
+
+@pytest.fixture
+def async_parameter_group_parameters_service(async_mpt_ops, async_created_parameter_group):
+    return async_mpt_ops.helpdesk.parameter_groups.parameters(async_created_parameter_group.id)
+
+
+@pytest.fixture
+def async_parameter_group_parameter_data(async_created_parameter_definition):
+    return {
+        "parameterId": async_created_parameter_definition.id,
+        "displayOrder": 100,
+    }
+
+
+@pytest.fixture
+async def async_created_parameter_group_parameter(
+    async_parameter_group_parameters_service, async_parameter_group_parameter_data
+):
+    async with async_create_fixture_resource_and_delete(
+        async_parameter_group_parameters_service, async_parameter_group_parameter_data
+    ) as parameter_group_parameter:
+        yield parameter_group_parameter

--- a/tests/e2e/helpdesk/parameter_groups/parameters/test_async_parameters.py
+++ b/tests/e2e/helpdesk/parameter_groups/parameters/test_async_parameters.py
@@ -1,0 +1,61 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.skip(reason="Skipped per MPT-18373 request"),
+]
+
+
+async def test_get_parameter_group_parameter(
+    async_parameter_group_parameters_service, async_created_parameter_group_parameter
+):
+    result = await async_parameter_group_parameters_service.get(
+        async_created_parameter_group_parameter.id
+    )
+
+    assert result.id == async_created_parameter_group_parameter.id
+
+
+async def test_list_parameter_group_parameters(
+    async_parameter_group_parameters_service, async_created_parameter_group_parameter
+):
+    result = await async_parameter_group_parameters_service.fetch_page(limit=20)
+
+    assert any(parameter.id == async_created_parameter_group_parameter.id for parameter in result)
+
+
+def test_create_parameter_group_parameter(async_created_parameter_group_parameter):
+    result = async_created_parameter_group_parameter
+
+    assert result is not None
+
+
+async def test_update_parameter_group_parameter(
+    async_parameter_group_parameters_service, async_created_parameter_group_parameter
+):
+    update_data = {"displayOrder": 101}
+
+    result = await async_parameter_group_parameters_service.update(
+        async_created_parameter_group_parameter.id,
+        update_data,
+    )
+
+    assert result.id == async_created_parameter_group_parameter.id
+    assert result.to_dict().get("displayOrder") == update_data["displayOrder"]
+
+
+async def test_delete_parameter_group_parameter(
+    async_parameter_group_parameters_service, async_created_parameter_group_parameter
+):
+    await async_parameter_group_parameters_service.delete(
+        async_created_parameter_group_parameter.id
+    )  # act
+
+
+async def test_not_found(
+    async_parameter_group_parameters_service, invalid_parameter_group_parameter_id
+):
+    with pytest.raises(MPTAPIError):
+        await async_parameter_group_parameters_service.get(invalid_parameter_group_parameter_id)

--- a/tests/e2e/helpdesk/parameter_groups/parameters/test_sync_parameters.py
+++ b/tests/e2e/helpdesk/parameter_groups/parameters/test_sync_parameters.py
@@ -1,0 +1,54 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.skip(reason="Skipped per MPT-18373 request"),
+]
+
+
+def test_get_parameter_group_parameter(
+    parameter_group_parameters_service, created_parameter_group_parameter
+):
+    result = parameter_group_parameters_service.get(created_parameter_group_parameter.id)
+
+    assert result.id == created_parameter_group_parameter.id
+
+
+def test_list_parameter_group_parameters(
+    parameter_group_parameters_service, created_parameter_group_parameter
+):
+    result = parameter_group_parameters_service.fetch_page(limit=20)
+
+    assert any(parameter.id == created_parameter_group_parameter.id for parameter in result)
+
+
+def test_create_parameter_group_parameter(created_parameter_group_parameter):
+    result = created_parameter_group_parameter
+
+    assert result is not None
+
+
+def test_update_parameter_group_parameter(
+    parameter_group_parameters_service, created_parameter_group_parameter
+):
+    update_data = {"displayOrder": 101}
+
+    result = parameter_group_parameters_service.update(
+        created_parameter_group_parameter.id, update_data
+    )
+
+    assert result.id == created_parameter_group_parameter.id
+    assert result.to_dict().get("displayOrder") == update_data["displayOrder"]
+
+
+def test_delete_parameter_group_parameter(
+    parameter_group_parameters_service, created_parameter_group_parameter
+):
+    parameter_group_parameters_service.delete(created_parameter_group_parameter.id)  # act
+
+
+def test_not_found(parameter_group_parameters_service, invalid_parameter_group_parameter_id):
+    with pytest.raises(MPTAPIError):
+        parameter_group_parameters_service.get(invalid_parameter_group_parameter_id)

--- a/tests/e2e/helpdesk/parameter_groups/test_async_parameter_groups.py
+++ b/tests/e2e/helpdesk/parameter_groups/test_async_parameter_groups.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.skip(reason="Skipped per MPT-18373 request"),
+]
+
+
+async def test_get_parameter_group(async_parameter_groups_service, async_created_parameter_group):
+    result = await async_parameter_groups_service.get(async_created_parameter_group.id)
+
+    assert result.id == async_created_parameter_group.id
+
+
+async def test_list_parameter_groups(async_parameter_groups_service):
+    result = await async_parameter_groups_service.fetch_page(limit=1)
+
+    assert len(result) > 0
+
+
+def test_create_parameter_group(async_created_parameter_group):
+    result = async_created_parameter_group
+
+    assert result is not None
+
+
+async def test_update_parameter_group(
+    async_parameter_groups_service, async_created_parameter_group, short_uuid
+):
+    update_data = {"description": f"e2e update {short_uuid}"}
+
+    result = await async_parameter_groups_service.update(
+        async_created_parameter_group.id, update_data
+    )
+
+    assert result.id == async_created_parameter_group.id
+    assert result.to_dict().get("description") == update_data["description"]
+
+
+async def test_delete_parameter_group(
+    async_parameter_groups_service, async_created_parameter_group
+):
+    await async_parameter_groups_service.delete(async_created_parameter_group.id)  # act
+
+
+async def test_not_found(async_parameter_groups_service, invalid_parameter_group_id):
+    with pytest.raises(MPTAPIError):
+        await async_parameter_groups_service.get(invalid_parameter_group_id)

--- a/tests/e2e/helpdesk/parameter_groups/test_sync_parameter_groups.py
+++ b/tests/e2e/helpdesk/parameter_groups/test_sync_parameter_groups.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.skip(reason="Skipped per MPT-18373 request"),
+]
+
+
+def test_get_parameter_group(parameter_groups_service, created_parameter_group):
+    result = parameter_groups_service.get(created_parameter_group.id)
+
+    assert result.id == created_parameter_group.id
+
+
+def test_list_parameter_groups(parameter_groups_service):
+    result = parameter_groups_service.fetch_page(limit=1)
+
+    assert len(result) > 0
+
+
+def test_create_parameter_group(created_parameter_group):
+    result = created_parameter_group
+
+    assert result is not None
+
+
+def test_update_parameter_group(parameter_groups_service, created_parameter_group, short_uuid):
+    update_data = {"description": f"e2e update {short_uuid}"}
+
+    result = parameter_groups_service.update(created_parameter_group.id, update_data)
+
+    assert result.id == created_parameter_group.id
+    assert result.to_dict().get("description") == update_data["description"]
+
+
+def test_delete_parameter_group(parameter_groups_service, created_parameter_group):
+    parameter_groups_service.delete(created_parameter_group.id)  # act
+
+
+def test_not_found(parameter_groups_service, invalid_parameter_group_id):
+    with pytest.raises(MPTAPIError):
+        parameter_groups_service.get(invalid_parameter_group_id)

--- a/tests/unit/resources/helpdesk/test_helpdesk.py
+++ b/tests/unit/resources/helpdesk/test_helpdesk.py
@@ -3,6 +3,10 @@ import pytest
 from mpt_api_client.resources.helpdesk import AsyncHelpdesk, Helpdesk
 from mpt_api_client.resources.helpdesk.cases import AsyncCasesService, CasesService
 from mpt_api_client.resources.helpdesk.chats import AsyncChatsService, ChatsService
+from mpt_api_client.resources.helpdesk.parameter_groups import (
+    AsyncParameterGroupsService,
+    ParameterGroupsService,
+)
 from mpt_api_client.resources.helpdesk.parameters import (
     AsyncParametersService,
     ParametersService,
@@ -31,6 +35,7 @@ def test_async_helpdesk_init(async_http_client):
         ("cases", CasesService),
         ("queues", QueuesService),
         ("parameters", ParametersService),
+        ("parameter_groups", ParameterGroupsService),
     ],
 )
 def test_helpdesk_properties(http_client, attr_name, expected):
@@ -48,6 +53,7 @@ def test_helpdesk_properties(http_client, attr_name, expected):
         ("cases", AsyncCasesService),
         ("queues", AsyncQueuesService),
         ("parameters", AsyncParametersService),
+        ("parameter_groups", AsyncParameterGroupsService),
     ],
 )
 def test_async_helpdesk_properties(async_http_client, attr_name, expected):

--- a/tests/unit/resources/helpdesk/test_parameter_group_parameters.py
+++ b/tests/unit/resources/helpdesk/test_parameter_group_parameters.py
@@ -1,0 +1,58 @@
+import pytest
+
+from mpt_api_client.resources.helpdesk.parameter_group_parameters import (
+    AsyncParameterGroupParametersService,
+    ParameterGroupParametersService,
+)
+
+
+@pytest.fixture
+def parameter_group_parameters_service(http_client):
+    return ParameterGroupParametersService(
+        http_client=http_client, endpoint_params={"group_id": "PGR-0000-0000"}
+    )
+
+
+@pytest.fixture
+def async_parameter_group_parameters_service(async_http_client):
+    return AsyncParameterGroupParametersService(
+        http_client=async_http_client, endpoint_params={"group_id": "PGR-0000-0000"}
+    )
+
+
+def test_endpoint(parameter_group_parameters_service):
+    result = (
+        parameter_group_parameters_service.path
+        == "/public/v1/helpdesk/parameter-groups/PGR-0000-0000/parameters"
+    )
+
+    assert result is True
+
+
+def test_async_endpoint(async_parameter_group_parameters_service):
+    result = (
+        async_parameter_group_parameters_service.path
+        == "/public/v1/helpdesk/parameter-groups/PGR-0000-0000/parameters"
+    )
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "fetch_page", "iterate"],
+)
+def test_methods_present(parameter_group_parameters_service, method):
+    result = hasattr(parameter_group_parameters_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "fetch_page", "iterate"],
+)
+def test_async_methods_present(async_parameter_group_parameters_service, method):
+    result = hasattr(async_parameter_group_parameters_service, method)
+
+    assert result is True

--- a/tests/unit/resources/helpdesk/test_parameter_groups.py
+++ b/tests/unit/resources/helpdesk/test_parameter_groups.py
@@ -1,0 +1,66 @@
+import pytest
+
+from mpt_api_client.resources.helpdesk.parameter_group_parameters import (
+    AsyncParameterGroupParametersService,
+    ParameterGroupParametersService,
+)
+from mpt_api_client.resources.helpdesk.parameter_groups import (
+    AsyncParameterGroupsService,
+    ParameterGroupsService,
+)
+
+
+@pytest.fixture
+def parameter_groups_service(http_client):
+    return ParameterGroupsService(http_client=http_client)
+
+
+@pytest.fixture
+def async_parameter_groups_service(async_http_client):
+    return AsyncParameterGroupsService(http_client=async_http_client)
+
+
+def test_endpoint(parameter_groups_service):
+    result = parameter_groups_service.path == "/public/v1/helpdesk/parameter-groups"
+
+    assert result is True
+
+
+def test_async_endpoint(async_parameter_groups_service):
+    result = async_parameter_groups_service.path == "/public/v1/helpdesk/parameter-groups"
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "fetch_page", "iterate", "parameters"],
+)
+def test_methods_present(parameter_groups_service, method):
+    result = hasattr(parameter_groups_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "fetch_page", "iterate", "parameters"],
+)
+def test_async_methods_present(async_parameter_groups_service, method):
+    result = hasattr(async_parameter_groups_service, method)
+
+    assert result is True
+
+
+def test_parameters_service(parameter_groups_service):
+    result = parameter_groups_service.parameters("PGR-0000-0000")
+
+    assert isinstance(result, ParameterGroupParametersService)
+    assert result.endpoint_params == {"group_id": "PGR-0000-0000"}
+
+
+def test_async_parameters_service(async_parameter_groups_service):
+    result = async_parameter_groups_service.parameters("PGR-0000-0000")
+
+    assert isinstance(result, AsyncParameterGroupParametersService)
+    assert result.endpoint_params == {"group_id": "PGR-0000-0000"}


### PR DESCRIPTION
## Summary
- Add sync/async Helpdesk Parameter Groups services for `/public/v1/helpdesk/parameter-groups`
- Add sync/async nested Parameter Group Parameters services for `/public/v1/helpdesk/parameter-groups/{group_id}/parameters`
- Expose new `helpdesk.parameter_groups` entrypoint on sync and async Helpdesk clients
- Add unit tests for service wiring, endpoint paths, mixin methods, and nested `.parameters(group_id)` factory
- Add e2e test suites for parameter groups and nested group parameters (sync/async), marked flaky and skipped

## Testing
- `make check-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-18372](https://softwareone.atlassian.net/browse/MPT-18372)

## Release Notes

- Added synchronous and asynchronous Helpdesk Parameter Groups services for endpoint `/public/v1/helpdesk/parameter-groups` with full CRUD operations and pagination support
- Added synchronous and asynchronous nested Parameter Group Parameters services for endpoint `/public/v1/helpdesk/parameter-groups/{group_id}/parameters` with factory method access via `.parameters(group_id)`
- Exposed new `helpdesk.parameter_groups` entrypoint on both sync and async Helpdesk client classes
- Added comprehensive unit tests covering service instantiation, endpoint path validation, mixin method availability, and nested factory method behavior
- Added end-to-end test suites for parameter groups and nested group parameters (both sync and async variants), marked as flaky and skipped pending issue MPT-18373 resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18372]: https://softwareone.atlassian.net/browse/MPT-18372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ