### PR TITLE
MPT-19478 fix e2e queue tests and add fixtures for disabled queues

### DIFF
--- a/tests/e2e/helpdesk/queues/conftest.py
+++ b/tests/e2e/helpdesk/queues/conftest.py
@@ -11,6 +11,7 @@ def queue_data(short_uuid):
     return {
         "name": f"E2E Queue {short_uuid}",
         "description": "E2E Created Helpdesk Queue",
+        "internal": False,
     }
 
 
@@ -26,8 +27,24 @@ def created_queue(mpt_ops, queue_data):
 
 
 @pytest.fixture
+def created_disabled_queue(mpt_ops, created_queue):
+    result = mpt_ops.helpdesk.queues.disable(created_queue.id)
+    assert result.status == "Disabled"
+
+    return result
+
+
+@pytest.fixture
 async def async_created_queue(async_mpt_ops, queue_data):
     async with async_create_fixture_resource_and_delete(
         async_mpt_ops.helpdesk.queues, queue_data
     ) as queue:
         yield queue
+
+
+@pytest.fixture
+async def async_created_disabled_queue(async_mpt_ops, async_created_queue):
+    result = await async_mpt_ops.helpdesk.queues.disable(async_created_queue.id)
+    assert result.status == "Disabled"
+
+    return result

--- a/tests/e2e/helpdesk/queues/test_async_queues.py
+++ b/tests/e2e/helpdesk/queues/test_async_queues.py
@@ -8,14 +8,12 @@ from mpt_api_client.resources.helpdesk.queues import Queue
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_queue(async_mpt_ops, async_created_queue):
     result = await async_mpt_ops.helpdesk.queues.get(async_created_queue.id)
 
     assert result.id == async_created_queue.id
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_queues(async_mpt_ops):
     result = await async_mpt_ops.helpdesk.queues.fetch_page(limit=1)
 
@@ -23,14 +21,12 @@ async def test_list_queues(async_mpt_ops):
     assert all(isinstance(queue, Queue) for queue in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_queue(async_created_queue):
     result = async_created_queue
 
-    assert result is not None
+    assert isinstance(result, Queue)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_queue(async_mpt_ops, async_created_queue, short_uuid):
     update_data = {"description": f"e2e update {short_uuid}"}
 
@@ -40,21 +36,18 @@ async def test_update_queue(async_mpt_ops, async_created_queue, short_uuid):
     assert result.to_dict().get("description") == update_data["description"]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-async def test_activate_queue(async_mpt_ops, async_created_queue):
-    result = await async_mpt_ops.helpdesk.queues.activate(async_created_queue.id)
+async def test_activate_queue(async_mpt_ops, async_created_disabled_queue):
+    result = await async_mpt_ops.helpdesk.queues.activate(async_created_disabled_queue.id)
 
-    assert result is not None
+    assert result.status == "Active"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_disable_queue(async_mpt_ops, async_created_queue):
     result = await async_mpt_ops.helpdesk.queues.disable(async_created_queue.id)
 
-    assert result is not None
+    assert result.status == "Disabled"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_queue(async_mpt_ops, async_created_queue):
     await async_mpt_ops.helpdesk.queues.delete(async_created_queue.id)  # act
 

--- a/tests/e2e/helpdesk/queues/test_sync_queues.py
+++ b/tests/e2e/helpdesk/queues/test_sync_queues.py
@@ -8,14 +8,12 @@ from mpt_api_client.resources.helpdesk.queues import Queue
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_queue(mpt_ops, created_queue):
     result = mpt_ops.helpdesk.queues.get(created_queue.id)
 
     assert result.id == created_queue.id
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_queues(mpt_ops):
     result = mpt_ops.helpdesk.queues.fetch_page(limit=1)
 
@@ -23,14 +21,12 @@ def test_list_queues(mpt_ops):
     assert all(isinstance(queue, Queue) for queue in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_queue(created_queue):
     result = created_queue
 
-    assert result is not None
+    assert isinstance(result, Queue)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_queue(mpt_ops, created_queue, short_uuid):
     update_data = {"description": f"e2e update {short_uuid}"}
 
@@ -40,21 +36,18 @@ def test_update_queue(mpt_ops, created_queue, short_uuid):
     assert result.to_dict().get("description") == update_data["description"]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-def test_activate_queue(mpt_ops, created_queue):
-    result = mpt_ops.helpdesk.queues.activate(created_queue.id)
+def test_activate_queue(mpt_ops, created_disabled_queue):
+    result = mpt_ops.helpdesk.queues.activate(created_disabled_queue.id)
 
-    assert result is not None
+    assert result.status == "Active"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_disable_queue(mpt_ops, created_queue):
     result = mpt_ops.helpdesk.queues.disable(created_queue.id)
 
-    assert result is not None
+    assert result.status == "Disabled"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_queue(mpt_ops, created_queue):
     mpt_ops.helpdesk.queues.delete(created_queue.id)  # act
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19478](https://softwareone.atlassian.net/browse/MPT-19478)

## Changes

- Added `internal: False` to the `queue_data` fixture payload
- Created new pytest fixtures for disabled queues: `created_disabled_queue` (sync) and `async_created_disabled_queue` (async)
- Enabled e2e queue tests by removing `@pytest.mark.skip` decorators from test functions
- Enhanced test assertions to verify queue state transitions (checking `status == "Active"` and `status == "Disabled"`)
- Updated `test_activate_queue` to use the new `created_disabled_queue` fixture
- Improved `test_create_queue` assertion to verify `Queue` instance type instead of generic non-None checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19478]: https://softwareone.atlassian.net/browse/MPT-19478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ