### PR TITLE
MPT-19654 Sellers now supports multiple currencies

### DIFF
--- a/tests/e2e/accounts/sellers/conftest.py
+++ b/tests/e2e/accounts/sellers/conftest.py
@@ -22,7 +22,7 @@ def seller_factory(currencies):
                 "postCode": "12345",
                 "country": "US",
             },
-            "currency": currencies,
+            "currencies": currencies,
             "externalId": external_id,
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19654](https://softwareone.atlassian.net/browse/MPT-19654)

- Updated the seller factory fixture to use `currencies` (plural) instead of `currency` (singular) when constructing the seller payload, enabling support for multiple currencies in the sellers endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19654]: https://softwareone.atlassian.net/browse/MPT-19654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ