### PR TITLE
MPT-19657 fix unauthorized response in E2E tests

### DIFF
--- a/tests/e2e/test_access.py
+++ b/tests/e2e/test_access.py
@@ -8,7 +8,7 @@ from mpt_api_client.exceptions import MPTHttpError
 def test_unauthorised(base_url):
     client = MPTClient.from_config(api_token="TKN-invalid", base_url=base_url)  # noqa: S106
 
-    with pytest.raises(MPTHttpError, match=r"401 Unauthorized"):
+    with pytest.raises(MPTHttpError, match=r"401 Authentication Failed"):
         client.catalog.products.fetch_page()
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19657](https://softwareone.atlassian.net/browse/MPT-19657)

- Updated E2E authorization test to expect "401 Authentication Failed" error message instead of "401 Unauthorized" when validating responses with invalid API tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19657]: https://softwareone.atlassian.net/browse/MPT-19657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ