### PR TITLE
MPT-19486 unskip attachment e2e tests

### DIFF
--- a/tests/e2e/helpdesk/chats/attachment/test_async_attachment.py
+++ b/tests/e2e/helpdesk/chats/attachment/test_async_attachment.py
@@ -63,7 +63,6 @@ async def test_delete_chat_attachment(async_chat_attachments_service, chat_attac
     await async_chat_attachments_service.delete(created.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):
@@ -72,7 +71,6 @@ async def test_get_chat_attachment_not_found(
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):
@@ -84,7 +82,6 @@ async def test_update_chat_attachment_not_found(
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_attachment_not_found(
     async_chat_attachments_service, invalid_chat_attachment_id
 ):

--- a/tests/e2e/helpdesk/chats/attachment/test_sync_attachment.py
+++ b/tests/e2e/helpdesk/chats/attachment/test_sync_attachment.py
@@ -56,7 +56,6 @@ def test_delete_chat_attachment(chat_attachments_service, chat_attachment_data, 
     chat_attachments_service.delete(created.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError) as error:
         chat_attachments_service.get(invalid_chat_attachment_id)
@@ -64,7 +63,6 @@ def test_get_chat_attachment_not_found(chat_attachments_service, invalid_chat_at
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError) as error:
         chat_attachments_service.update(
@@ -75,7 +73,6 @@ def test_update_chat_attachment_not_found(chat_attachments_service, invalid_chat
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_attachment_not_found(chat_attachments_service, invalid_chat_attachment_id):
     with pytest.raises(MPTAPIError) as error:
         chat_attachments_service.delete(invalid_chat_attachment_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19486](https://softwareone.atlassian.net/browse/MPT-19486)

- Unskip three async attachment e2e tests in `test_async_attachment.py`: `test_get_chat_attachment_not_found`, `test_update_chat_attachment_not_found`, and `test_delete_chat_attachment_not_found`
- Unskip three sync attachment e2e tests in `test_sync_attachment.py`: `test_get_chat_attachment_not_found`, `test_update_chat_attachment_not_found`, and `test_delete_chat_attachment_not_found`
- These tests now execute and validate that the corresponding `ChatAttachmentsService` methods raise `MPTAPIError` with `HTTPStatus.NOT_FOUND` status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19486]: https://softwareone.atlassian.net/browse/MPT-19486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ