### PR TITLE
MPT-19489 unskip some chat participants e2e tests

### DIFF
--- a/tests/e2e/helpdesk/chats/participants/test_async_participants.py
+++ b/tests/e2e/helpdesk/chats/participants/test_async_participants.py
@@ -8,7 +8,6 @@ from mpt_api_client.resources.helpdesk.chat_participants import ChatParticipant
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_chat_participants(async_chat_participants_service):
     result = await async_chat_participants_service.fetch_page(limit=1)
 
@@ -42,7 +41,6 @@ async def test_delete_chat_participant(
     await async_chat_participants_service.delete(result.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_participant_not_found(
     async_chat_participants_service, invalid_chat_participant_id
 ):
@@ -54,10 +52,9 @@ async def test_update_chat_participant_not_found(
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_participant_not_found(
     async_chat_participants_service, invalid_chat_participant_id
 ):
     with pytest.raises(MPTAPIError) as error:
         await async_chat_participants_service.delete(invalid_chat_participant_id)
-    assert error.value.status_code == HTTPStatus.NOT_FOUND
+    assert error.value.status_code == HTTPStatus.BAD_REQUEST  # TODO: verify 400 is OK instead 404

--- a/tests/e2e/helpdesk/chats/participants/test_sync_participants.py
+++ b/tests/e2e/helpdesk/chats/participants/test_sync_participants.py
@@ -8,7 +8,6 @@ from mpt_api_client.resources.helpdesk.chat_participants import ChatParticipant
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_chat_participants(chat_participants_service):
     result = chat_participants_service.fetch_page(limit=1)
 
@@ -35,7 +34,6 @@ def test_delete_chat_participant(chat_participants_service, created_chat_partici
     chat_participants_service.delete(result.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_participant_not_found(chat_participants_service, invalid_chat_participant_id):
     with pytest.raises(MPTAPIError) as error:
         chat_participants_service.update(invalid_chat_participant_id, {"status": "Active"})
@@ -43,9 +41,8 @@ def test_update_chat_participant_not_found(chat_participants_service, invalid_ch
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_participant_not_found(chat_participants_service, invalid_chat_participant_id):
     with pytest.raises(MPTAPIError) as error:
         chat_participants_service.delete(invalid_chat_participant_id)
 
-    assert error.value.status_code == HTTPStatus.NOT_FOUND
+    assert error.value.status_code == HTTPStatus.BAD_REQUEST  # TODO: verify 400 is OK instead 404


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19489](https://softwareone.atlassian.net/browse/MPT-19489)

- Re-enabled three previously skipped chat participants e2e tests (removed pytest.mark.skip) in both async and sync suites:
  - test_list_chat_participants
  - test_update_chat_participant_not_found
  - test_delete_chat_participant_not_found
- Updated expected HTTP status in test_delete_chat_participant_not_found from HTTPStatus.NOT_FOUND to HTTPStatus.BAD_REQUEST (TODO: verify 400 is correct)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19489]: https://softwareone.atlassian.net/browse/MPT-19489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ