### PR TITLE
MPT-19488 unskip async and sync chat link not found tests

### DIFF
--- a/tests/e2e/helpdesk/chats/links/test_async_links.py
+++ b/tests/e2e/helpdesk/chats/links/test_async_links.py
@@ -42,7 +42,6 @@ async def test_delete_chat_link(async_chat_links_service, async_created_chat_lin
     await async_chat_links_service.delete(result.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_chat_link_not_found(async_chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError) as error:
         await async_chat_links_service.update(
@@ -52,7 +51,6 @@ async def test_update_chat_link_not_found(async_chat_links_service, invalid_chat
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_chat_link_not_found(async_chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError) as error:
         await async_chat_links_service.delete(invalid_chat_link_id)

--- a/tests/e2e/helpdesk/chats/links/test_sync_links.py
+++ b/tests/e2e/helpdesk/chats/links/test_sync_links.py
@@ -39,7 +39,6 @@ def test_delete_chat_link(chat_links_service, created_chat_link):
     chat_links_service.delete(result.id)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_chat_link_not_found(chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError) as error:
         chat_links_service.update(invalid_chat_link_id, {"name": "updated name"})
@@ -47,7 +46,6 @@ def test_update_chat_link_not_found(chat_links_service, invalid_chat_link_id):
     assert error.value.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_chat_link_not_found(chat_links_service, invalid_chat_link_id):
     with pytest.raises(MPTAPIError) as error:
         chat_links_service.delete(invalid_chat_link_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19488](https://softwareone.atlassian.net/browse/MPT-19488)

## Changes

- Unskipped `test_update_chat_link_not_found` and `test_delete_chat_link_not_found` tests in the async chat links E2E test suite
- Unskipped `test_update_chat_link_not_found` and `test_delete_chat_link_not_found` tests in the sync chat links E2E test suite
- These tests now execute and validate that updating or deleting a chat link with an invalid ID raises `MPTAPIError` with `HTTPStatus.NOT_FOUND`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19488]: https://softwareone.atlassian.net/browse/MPT-19488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ