### PR TITLE
MPT-19482 unskip forms e2e tests and add fixtures for published forms

### DIFF
--- a/tests/e2e/helpdesk/forms/conftest.py
+++ b/tests/e2e/helpdesk/forms/conftest.py
@@ -26,8 +26,20 @@ def created_form(mpt_ops, form_data):
 
 
 @pytest.fixture
+def created_published_form(mpt_ops, created_form):
+    mpt_ops.helpdesk.forms.publish(created_form.id)
+    return created_form
+
+
+@pytest.fixture
 async def async_created_form(async_mpt_ops, form_data):
     async with async_create_fixture_resource_and_delete(
         async_mpt_ops.helpdesk.forms, form_data
     ) as form:
         yield form
+
+
+@pytest.fixture
+async def async_created_published_form(async_mpt_ops, async_created_form):
+    await async_mpt_ops.helpdesk.forms.publish(async_created_form.id)
+    return async_created_form

--- a/tests/e2e/helpdesk/forms/test_async_forms.py
+++ b/tests/e2e/helpdesk/forms/test_async_forms.py
@@ -8,14 +8,12 @@ from mpt_api_client.resources.helpdesk.forms import Form
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_form(async_mpt_ops, async_created_form):
     result = await async_mpt_ops.helpdesk.forms.get(async_created_form.id)
 
     assert result.id == async_created_form.id
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_list_forms(async_mpt_ops):
     result = await async_mpt_ops.helpdesk.forms.fetch_page(limit=1)
 
@@ -23,14 +21,12 @@ async def test_list_forms(async_mpt_ops):
     assert all(isinstance(form, Form) for form in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_form(async_created_form):
     result = async_created_form
 
     assert result is not None
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_update_form(async_mpt_ops, async_created_form, short_uuid):
     update_data = {"description": f"e2e update {short_uuid}"}
 
@@ -40,21 +36,18 @@ async def test_update_form(async_mpt_ops, async_created_form, short_uuid):
     assert result.to_dict().get("description") == update_data["description"]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_publish_form(async_mpt_ops, async_created_form):
     result = await async_mpt_ops.helpdesk.forms.publish(async_created_form.id)
 
     assert result is not None
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-async def test_unpublish_form(async_mpt_ops, async_created_form):
-    result = await async_mpt_ops.helpdesk.forms.unpublish(async_created_form.id)
+async def test_unpublish_form(async_mpt_ops, async_created_published_form):
+    result = await async_mpt_ops.helpdesk.forms.unpublish(async_created_published_form.id)
 
-    assert result is not None
+    assert result.status == "Unpublished"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_delete_form(async_mpt_ops, async_created_form):
     await async_mpt_ops.helpdesk.forms.delete(async_created_form.id)  # act
 

--- a/tests/e2e/helpdesk/forms/test_sync_forms.py
+++ b/tests/e2e/helpdesk/forms/test_sync_forms.py
@@ -8,14 +8,12 @@ from mpt_api_client.resources.helpdesk.forms import Form
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_form(mpt_ops, created_form):
     result = mpt_ops.helpdesk.forms.get(created_form.id)
 
     assert result.id == created_form.id
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_list_forms(mpt_ops):
     result = mpt_ops.helpdesk.forms.fetch_page(limit=1)
 
@@ -23,14 +21,12 @@ def test_list_forms(mpt_ops):
     assert all(isinstance(form, Form) for form in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_form(created_form):
     result = created_form
 
     assert result is not None
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_update_form(mpt_ops, created_form, short_uuid):
     update_data = {"description": f"e2e update {short_uuid}"}
 
@@ -40,21 +36,18 @@ def test_update_form(mpt_ops, created_form, short_uuid):
     assert result.to_dict().get("description") == update_data["description"]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_publish_form(mpt_ops, created_form):
     result = mpt_ops.helpdesk.forms.publish(created_form.id)
 
     assert result is not None
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-def test_unpublish_form(mpt_ops, created_form):
-    result = mpt_ops.helpdesk.forms.unpublish(created_form.id)
+def test_unpublish_form(mpt_ops, created_published_form):
+    result = mpt_ops.helpdesk.forms.unpublish(created_published_form.id)
 
-    assert result is not None
+    assert result.status == "Unpublished"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_delete_form(mpt_ops, created_form):
     mpt_ops.helpdesk.forms.delete(created_form.id)  # act
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19482](https://softwareone.atlassian.net/browse/MPT-19482)

## Release Notes

- Added `created_published_form` and `async_created_published_form` pytest fixtures to publish Helpdesk forms before running tests
- Unskipped 5 async e2e form tests (`test_get_form`, `test_list_forms`, `test_update_form`, `test_publish_form`, `test_delete_form`) to enable active execution
- Unskipped 6 sync e2e form tests (`test_get_form`, `test_list_forms`, `test_create_form`, `test_update_form`, `test_publish_form`, `test_delete_form`) to enable active execution
- Updated `test_unpublish_form` in both sync and async test files to use the new published form fixtures and validate unpublish operation with explicit status assertion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19482]: https://softwareone.atlassian.net/browse/MPT-19482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ