### PR TITLE
MPT-19660 Improve resource action implementation

### DIFF
--- a/mpt_api_client/http/async_service.py
+++ b/mpt_api_client/http/async_service.py
@@ -1,12 +1,8 @@
-from urllib.parse import urljoin
-
-from mpt_api_client.constants import APPLICATION_JSON
 from mpt_api_client.http.async_client import AsyncHTTPClient
 from mpt_api_client.http.base_service import ServiceBase
-from mpt_api_client.http.types import QueryParam, Response
+from mpt_api_client.http.resource_accessor import AsyncResourceAccessor
+from mpt_api_client.http.url_utils import join_url_path
 from mpt_api_client.models import Model as BaseModel
-from mpt_api_client.models import ResourceData
-from mpt_api_client.models.collection import ResourceList
 
 
 class AsyncService[Model: BaseModel](ServiceBase[AsyncHTTPClient, Model]):  # noqa: WPS214
@@ -21,60 +17,15 @@ class AsyncService[Model: BaseModel](ServiceBase[AsyncHTTPClient, Model]):  # no
 
     """
 
-    async def _resource_do_request(  # noqa: WPS211
-        self,
-        resource_id: str,
-        method: str = "GET",
-        action: str | None = None,
-        json: ResourceData | ResourceList | None = None,
-        query_params: QueryParam | None = None,
-        headers: dict[str, str] | None = None,
-    ) -> Response:
-        """Perform an action on a specific resource using.
+    def _resource(self, resource_id: str) -> AsyncResourceAccessor[Model]:
+        """Return an :class:`AsyncResourceAccessor` bound to *resource_id*.
 
-        Request with action: `HTTP_METHOD /endpoint/{resource_id}/{action}`.
-        Request without action: `HTTP_METHOD /endpoint/{resource_id}`.
+        Usage::
 
-        Args:
-            resource_id: The resource ID to operate on.
-            method: The HTTP method to use.
-            action: The action name to use.
-            json: The updated resource data.
-            query_params: Additional query parameters.
-            headers: Additional headers.
-
-        Raises:
-            HTTPError: If the action fails.
+            await self._resource("RES-123").post("complete", json=data)
+            await self._resource("RES-123").get()
+            await self._resource("RES-123").put(json=data)
+            await self._resource("RES-123").delete()
         """
-        resource_url = urljoin(f"{self.path}/", resource_id)
-        url = urljoin(f"{resource_url}/", action) if action else resource_url
-        return await self.http_client.request(
-            method, url, json=json, query_params=query_params, headers=headers
-        )
-
-    async def _resource_action(
-        self,
-        resource_id: str,
-        method: str = "GET",
-        action: str | None = None,
-        json: ResourceData | ResourceList | None = None,
-        query_params: QueryParam | None = None,
-    ) -> Model:
-        """Perform an action on a specific resource using `HTTP_METHOD /endpoint/{resource_id}`.
-
-        Args:
-            resource_id: The resource ID to operate on.
-            method: The HTTP method to use.
-            action: The action name to use.
-            json: The updated resource data.
-            query_params: Additional query parameters.
-        """
-        response = await self._resource_do_request(
-            resource_id,
-            method,
-            action,
-            json=json,
-            query_params=query_params,
-            headers={"Accept": APPLICATION_JSON},
-        )
-        return self._model_class.from_response(response)
+        resource_url = join_url_path(self.path, resource_id)
+        return AsyncResourceAccessor(self.http_client, resource_url, self._model_class)

--- a/mpt_api_client/http/mixins/delete_mixin.py
+++ b/mpt_api_client/http/mixins/delete_mixin.py
@@ -1,6 +1,3 @@
-from urllib.parse import urljoin
-
-
 class DeleteMixin:
     """Delete resource mixin."""
 
@@ -10,7 +7,7 @@ class DeleteMixin:
         Args:
             resource_id: Resource ID.
         """
-        self._resource_do_request(resource_id, "DELETE")  # type: ignore[attr-defined]
+        self._resource(resource_id).delete()  # type: ignore[attr-defined]
 
 
 class AsyncDeleteMixin:
@@ -22,5 +19,4 @@ class AsyncDeleteMixin:
         Args:
             resource_id: Resource ID.
         """
-        url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
-        await self.http_client.request("delete", url)  # type: ignore[attr-defined]
+        await self._resource(resource_id).delete()  # type: ignore[attr-defined]

--- a/mpt_api_client/http/mixins/disable_mixin.py
+++ b/mpt_api_client/http/mixins/disable_mixin.py
@@ -7,9 +7,7 @@ class AsyncDisableMixin[Model: BaseModel]:
 
     async def disable(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Disable a specific resource."""
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id=resource_id, method="POST", action="disable", json=resource_data
-        )
+        return await self._resource(resource_id).post("disable", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class DisableMixin[Model: BaseModel]:
@@ -17,6 +15,4 @@ class DisableMixin[Model: BaseModel]:
 
     def disable(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Disable a specific resource."""
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id=resource_id, method="POST", action="disable", json=resource_data
-        )
+        return self._resource(resource_id).post("disable", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/http/mixins/download_file_mixin.py
+++ b/mpt_api_client/http/mixins/download_file_mixin.py
@@ -17,14 +17,13 @@ class DownloadFileMixin[Model]:
         Returns:
             File model containing the downloaded file.
         """
+        accessor = self._resource(resource_id)  # type: ignore[attr-defined]
         if not accept:
-            resource: Model = self._resource_action(resource_id, method="GET")  # type: ignore[attr-defined]
+            resource: Model = accessor.get()
             accept = resource.content_type  # type: ignore[attr-defined]
             if not accept:
                 raise MPTError("Unable to download file. Content type not found in resource")
-        response: Response = self._resource_do_request(  # type: ignore[attr-defined]
-            resource_id, method="GET", headers={"Accept": accept}
-        )
+        response: Response = accessor.do_request("GET", headers={"Accept": accept})
         return FileModel(response)
 
 
@@ -42,12 +41,11 @@ class AsyncDownloadFileMixin[Model]:
         Returns:
             File model containing the downloaded file.
         """
+        accessor = self._resource(resource_id)  # type: ignore[attr-defined]
         if not accept:
-            resource: Model = await self._resource_action(resource_id, method="GET")  # type: ignore[attr-defined]
+            resource: Model = await accessor.get()
             accept = resource.content_type  # type: ignore[attr-defined]
             if not accept:
                 raise MPTError("Unable to download file. Content type not found in resource")
-        response = await self._resource_do_request(  # type: ignore[attr-defined]
-            resource_id, method="GET", headers={"Accept": accept}
-        )
+        response = await accessor.do_request("GET", headers={"Accept": accept})
         return FileModel(response)

--- a/mpt_api_client/http/mixins/enable_mixin.py
+++ b/mpt_api_client/http/mixins/enable_mixin.py
@@ -7,9 +7,7 @@ class AsyncEnableMixin[Model: BaseModel]:
 
     async def enable(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Enable a specific resource."""
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id=resource_id, method="POST", action="enable", json=resource_data
-        )
+        return await self._resource(resource_id).post("enable", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class EnableMixin[Model: BaseModel]:
@@ -17,6 +15,4 @@ class EnableMixin[Model: BaseModel]:
 
     def enable(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Enable a specific resource."""
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id=resource_id, method="POST", action="enable", json=resource_data
-        )
+        return self._resource(resource_id).post("enable", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/http/mixins/get_mixin.py
+++ b/mpt_api_client/http/mixins/get_mixin.py
@@ -14,7 +14,7 @@ class GetMixin[Model]:
         if isinstance(select, list):
             select = ",".join(select) if select else None
 
-        return self._resource_action(resource_id=resource_id, query_params={"select": select})  # type: ignore[attr-defined, no-any-return]
+        return self._resource(resource_id).get(query_params={"select": select})  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncGetMixin[Model]:
@@ -32,4 +32,4 @@ class AsyncGetMixin[Model]:
         """
         if isinstance(select, list):
             select = ",".join(select) if select else None
-        return await self._resource_action(resource_id=resource_id, query_params={"select": select})  # type: ignore[attr-defined, no-any-return]
+        return await self._resource(resource_id).get(query_params={"select": select})  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/http/mixins/update_file_mixin.py
+++ b/mpt_api_client/http/mixins/update_file_mixin.py
@@ -1,6 +1,5 @@
-from urllib.parse import urljoin
-
 from mpt_api_client.http.types import FileTypes
+from mpt_api_client.http.url_utils import join_url_path
 from mpt_api_client.models import ResourceData
 
 
@@ -27,7 +26,7 @@ class UpdateFileMixin[Model]:
         """
         files = {}
 
-        url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
+        url = join_url_path(self.path, resource_id)  # type: ignore[attr-defined]
 
         if file:
             files[self._upload_file_key] = file  # type: ignore[attr-defined]
@@ -67,7 +66,7 @@ class AsyncUpdateFileMixin[Model]:
         """
         files = {}
 
-        url = urljoin(f"{self.path}/", resource_id)  # type: ignore[attr-defined]
+        url = join_url_path(self.path, resource_id)  # type: ignore[attr-defined]
 
         if file:
             files[self._upload_file_key] = file  # type: ignore[attr-defined]

--- a/mpt_api_client/http/mixins/update_mixin.py
+++ b/mpt_api_client/http/mixins/update_mixin.py
@@ -5,31 +5,13 @@ class UpdateMixin[Model]:
     """Update resource mixin."""
 
     def update(self, resource_id: str, resource_data: ResourceData) -> Model:
-        """Update a resource using `PUT /endpoint/{resource_id}`.
-
-        Args:
-            resource_id: Resource ID.
-            resource_data: Resource data.
-
-        Returns:
-            Resource object.
-
-        """
-        return self._resource_action(resource_id, "PUT", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        """Update a resource using `PUT /endpoint/{resource_id}`."""
+        return self._resource(resource_id).put(json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncUpdateMixin[Model]:
     """Update resource mixin."""
 
     async def update(self, resource_id: str, resource_data: ResourceData) -> Model:
-        """Update a resource using `PUT /endpoint/{resource_id}`.
-
-        Args:
-            resource_id: Resource ID.
-            resource_data: Resource data.
-
-        Returns:
-            Resource object.
-
-        """
-        return await self._resource_action(resource_id, "PUT", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        """Update a resource using `PUT /endpoint/{resource_id}`."""
+        return await self._resource(resource_id).put(json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/http/resource_accessor.py
+++ b/mpt_api_client/http/resource_accessor.py
@@ -1,0 +1,199 @@
+from mpt_api_client.constants import APPLICATION_JSON
+from mpt_api_client.http.async_client import AsyncHTTPClient
+from mpt_api_client.http.client import HTTPClient
+from mpt_api_client.http.types import QueryParam, Response
+from mpt_api_client.http.url_utils import join_url_path
+from mpt_api_client.models.collection import ResourceList
+from mpt_api_client.models.model import Model, ResourceData  # NOSONAR
+
+_JsonPayload = ResourceData | ResourceList | None
+
+
+class ResourceAccessor[ResourceModel: Model]:  # NOSONAR
+    """Synchronous accessor bound to a single resource URL.
+
+    Provides ``.get()``, ``.post()``, ``.put()``, ``.delete()`` helpers that
+    deserialize the response into a ``Model``, and a ``.do_request()`` escape
+    hatch that returns the raw ``Response``.
+    """
+
+    def __init__(
+        self,
+        http_client: HTTPClient,
+        resource_url: str,
+        model_class: type[ResourceModel],
+    ) -> None:
+        self._http_client = http_client
+        self._resource_url = resource_url
+        self._model_class = model_class
+
+    # -- raw request ---------------------------------------------------------
+
+    def do_request(  # noqa: WPS211
+        self,
+        method: str,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Response:
+        """Perform an HTTP request and return the raw ``Response``.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE …).
+            action: Optional sub-path appended after the resource id.
+            json: JSON body payload.
+            query_params: Query-string parameters.
+            headers: Extra HTTP headers.
+        """
+        url = join_url_path(self._resource_url, action) if action else self._resource_url
+        return self._http_client.request(
+            method, url, json=json, query_params=query_params, headers=headers
+        )
+
+    # -- model-returning helpers ---------------------------------------------
+
+    def get(
+        self,
+        action: str | None = None,
+        *,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``GET`` the resource (optionally with a sub-action)."""
+        return self._action("GET", action, query_params=query_params)
+
+    def post(
+        self,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``POST`` to the resource (optionally with a sub-action)."""
+        return self._action("POST", action, json=json, query_params=query_params)
+
+    def put(
+        self,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``PUT`` to the resource (optionally with a sub-action)."""
+        return self._action("PUT", action, json=json, query_params=query_params)
+
+    def delete(self) -> None:
+        """``DELETE`` the resource."""
+        self.do_request("DELETE")
+
+    def _action(
+        self,
+        method: str,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        response = self.do_request(
+            method,
+            action,
+            json=json,
+            query_params=query_params,
+            headers={"Accept": APPLICATION_JSON},
+        )
+        return self._model_class.from_response(response)
+
+
+class AsyncResourceAccessor[ResourceModel: Model]:  # NOSONAR
+    """Asynchronous accessor bound to a single resource URL.
+
+    Async counterpart of :class:`ResourceAccessor`.
+    """
+
+    def __init__(
+        self,
+        http_client: AsyncHTTPClient,
+        resource_url: str,
+        model_class: type[ResourceModel],
+    ) -> None:
+        self._http_client = http_client
+        self._resource_url = resource_url
+        self._model_class = model_class
+
+    # -- raw request ---------------------------------------------------------
+
+    async def do_request(  # noqa: WPS211
+        self,
+        method: str,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Response:
+        """Perform an HTTP request and return the raw ``Response``.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE …).
+            action: Optional sub-path appended after the resource id.
+            json: JSON body payload.
+            query_params: Query-string parameters.
+            headers: Extra HTTP headers.
+        """
+        url = join_url_path(self._resource_url, action) if action else self._resource_url
+        return await self._http_client.request(
+            method, url, json=json, query_params=query_params, headers=headers
+        )
+
+    # -- model-returning helpers ---------------------------------------------
+
+    async def get(
+        self,
+        action: str | None = None,
+        *,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``GET`` the resource (optionally with a sub-action)."""
+        return await self._action("GET", action, query_params=query_params)
+
+    async def post(
+        self,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``POST`` to the resource (optionally with a sub-action)."""
+        return await self._action("POST", action, json=json, query_params=query_params)
+
+    async def put(
+        self,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        """``PUT`` to the resource (optionally with a sub-action)."""
+        return await self._action("PUT", action, json=json, query_params=query_params)
+
+    async def delete(self) -> None:
+        """``DELETE`` the resource."""
+        await self.do_request("DELETE")
+
+    async def _action(
+        self,
+        method: str,
+        action: str | None = None,
+        *,
+        json: _JsonPayload = None,
+        query_params: QueryParam | None = None,
+    ) -> ResourceModel:
+        response = await self.do_request(
+            method,
+            action,
+            json=json,
+            query_params=query_params,
+            headers={"Accept": APPLICATION_JSON},
+        )
+        return self._model_class.from_response(response)

--- a/mpt_api_client/http/service.py
+++ b/mpt_api_client/http/service.py
@@ -1,12 +1,8 @@
-from urllib.parse import urljoin
-
-from mpt_api_client.constants import APPLICATION_JSON
 from mpt_api_client.http.base_service import ServiceBase
 from mpt_api_client.http.client import HTTPClient
-from mpt_api_client.http.types import QueryParam, Response
+from mpt_api_client.http.resource_accessor import ResourceAccessor
+from mpt_api_client.http.url_utils import join_url_path
 from mpt_api_client.models import Model as BaseModel
-from mpt_api_client.models import ResourceData
-from mpt_api_client.models.collection import ResourceList
 
 
 class Service[Model: BaseModel](ServiceBase[HTTPClient, Model]):  # noqa: WPS214
@@ -21,60 +17,15 @@ class Service[Model: BaseModel](ServiceBase[HTTPClient, Model]):  # noqa: WPS214
 
     """
 
-    def _resource_do_request(  # noqa: WPS211
-        self,
-        resource_id: str,
-        method: str = "GET",
-        action: str | None = None,
-        json: ResourceData | ResourceList | None = None,
-        query_params: QueryParam | None = None,
-        headers: dict[str, str] | None = None,
-    ) -> Response:
-        """Perform an action on a specific resource using `HTTP_METHOD /endpoint/{resource_id}`.
+    def _resource(self, resource_id: str) -> ResourceAccessor[Model]:
+        """Return a :class:`ResourceAccessor` bound to *resource_id*.
 
-        Args:
-            resource_id: The resource ID to operate on.
-            method: The HTTP method to use.
-            action: The action name to use.
-            json: The updated resource data.
-            query_params: Additional query parameters.
-            headers: Additional headers.
+        Usage::
 
-        Returns:
-            HTTP response object.
-
-        Raises:
-            HTTPError: If the action fails.
+            self._resource("RES-123").post("complete", json=data)
+            self._resource("RES-123").get()
+            self._resource("RES-123").put(json=data)
+            self._resource("RES-123").delete()
         """
-        resource_url = urljoin(f"{self.path}/", resource_id)
-        url = urljoin(f"{resource_url}/", action) if action else resource_url
-        return self.http_client.request(
-            method, url, json=json, query_params=query_params, headers=headers
-        )
-
-    def _resource_action(
-        self,
-        resource_id: str,
-        method: str = "GET",
-        action: str | None = None,
-        json: ResourceData | ResourceList | None = None,
-        query_params: QueryParam | None = None,
-    ) -> Model:
-        """Perform an action on a specific resource using `HTTP_METHOD /endpoint/{resource_id}`.
-
-        Args:
-            resource_id: The resource ID to operate on.
-            method: The HTTP method to use.
-            action: The action name to use.
-            json: The updated resource data.
-            query_params: Additional query parameters.
-        """
-        response = self._resource_do_request(
-            resource_id,
-            method,
-            action,
-            json=json,
-            query_params=query_params,
-            headers={"Accept": APPLICATION_JSON},
-        )
-        return self._model_class.from_response(response)
+        resource_url = join_url_path(self.path, resource_id)
+        return ResourceAccessor(self.http_client, resource_url, self._model_class)

--- a/mpt_api_client/http/url_utils.py
+++ b/mpt_api_client/http/url_utils.py
@@ -1,0 +1,26 @@
+def join_url_path(base: str, *segments: str) -> str:
+    """Join *segments* onto *base* as literal path components.
+
+    Unlike :func:`urllib.parse.urljoin`, this function **never** interprets a
+    segment as an absolute path or URL it always appends.
+
+    Args:
+        base: The base URL path (e.g. ``/public/v1/billing/journals``).
+        *segments: One or more path segments to append
+            (e.g. ``"JRN-123"``, ``"upload"``).
+
+    Returns:
+        The joined path with exactly one ``/`` between each part and no
+        trailing slash.
+
+    Examples:
+        >>> join_url_path("/api/v1/orders", "ORD-001")
+        '/api/v1/orders/ORD-001'
+        >>> join_url_path("/api/v1/orders", "ORD-001", "complete")
+        '/api/v1/orders/ORD-001/complete'
+        >>> join_url_path("/api/v1/orders/", "/ORD-001/")
+        '/api/v1/orders/ORD-001'
+    """
+    parts = [base.rstrip("/")]
+    parts.extend(seg.strip("/") for seg in segments if seg)
+    return "/".join(parts)

--- a/mpt_api_client/resources/accounts/buyers.py
+++ b/mpt_api_client/resources/accounts/buyers.py
@@ -61,7 +61,7 @@ class BuyersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "synchronize", json=resource_data)
+        return self._resource(resource_id).post("synchronize", json=resource_data)
 
     def transfer(self, resource_id: str, resource_data: ResourceData | None = None) -> Buyer:
         """Transfer a buyer.
@@ -70,7 +70,7 @@ class BuyersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "transfer", json=resource_data)
+        return self._resource(resource_id).post("transfer", json=resource_data)
 
 
 class AsyncBuyersService(
@@ -97,7 +97,7 @@ class AsyncBuyersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "synchronize", json=resource_data)
+        return await self._resource(resource_id).post("synchronize", json=resource_data)
 
     async def transfer(self, resource_id: str, resource_data: ResourceData | None = None) -> Buyer:
         """Transfer a buyer.
@@ -106,4 +106,4 @@ class AsyncBuyersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "transfer", json=resource_data)
+        return await self._resource(resource_id).post("transfer", json=resource_data)

--- a/mpt_api_client/resources/accounts/mixins/activatable_mixin.py
+++ b/mpt_api_client/resources/accounts/mixins/activatable_mixin.py
@@ -2,54 +2,28 @@ from mpt_api_client.models import ResourceData
 
 
 class ActivatableMixin[Model]:
-    """Activatable mixin for activating, enabling, disabling and deactivating resources."""
+    """Activatable mixin for activating and deactivating resources."""
 
     def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Activate a resource.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "activate", json=resource_data
-        )
+        """Activate a resource."""
+        return self._resource(resource_id).post("activate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def deactivate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Deactivate a resource.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "deactivate", json=resource_data
-        )
+        """Deactivate a resource."""
+        return self._resource(resource_id).post("deactivate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncActivatableMixin[Model]:
-    """Async activatable mixin for activating, enabling, disabling and deactivating resources."""
+    """Async activatable mixin for activating and deactivating resources."""
 
     async def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Activate a resource.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "activate", json=resource_data
-        )
+        """Activate a resource."""
+        return await self._resource(resource_id).post("activate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def deactivate(
-        self, resource_id: str, resource_data: ResourceData | None = None
+        self,
+        resource_id: str,
+        resource_data: ResourceData | None = None,
     ) -> Model:
-        """Deactivate a resource.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "deactivate", json=resource_data
-        )
+        """Deactivate a resource."""
+        return await self._resource(resource_id).post("deactivate", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/accounts/mixins/blockable_mixin.py
+++ b/mpt_api_client/resources/accounts/mixins/blockable_mixin.py
@@ -11,9 +11,7 @@ class BlockableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "block", json=resource_data
-        )
+        return self._resource(resource_id).post("block", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def unblock(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Unblock a resource.
@@ -22,9 +20,7 @@ class BlockableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "unblock", json=resource_data
-        )
+        return self._resource(resource_id).post("unblock", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncBlockableMixin[Model]:
@@ -37,9 +33,7 @@ class AsyncBlockableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "block", json=resource_data
-        )
+        return await self._resource(resource_id).post("block", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def unblock(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Unblock a resource.
@@ -48,6 +42,4 @@ class AsyncBlockableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "unblock", json=resource_data
-        )
+        return await self._resource(resource_id).post("unblock", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/accounts/mixins/invitable_mixin.py
+++ b/mpt_api_client/resources/accounts/mixins/invitable_mixin.py
@@ -11,9 +11,7 @@ class InvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept-invite", json=resource_data
-        )
+        return self._resource(resource_id).post("accept-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def resend_invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Resend an invite to a resource.
@@ -22,9 +20,7 @@ class InvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "resend-invite", json=resource_data
-        )
+        return self._resource(resource_id).post("resend-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def send_new_invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Send a new invite to a resource.
@@ -33,9 +29,7 @@ class InvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "send-new-invite", json=resource_data
-        )
+        return self._resource(resource_id).post("send-new-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncInvitableMixin[Model]:
@@ -50,9 +44,7 @@ class AsyncInvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept-invite", json=resource_data
-        )
+        return await self._resource(resource_id).post("accept-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def resend_invite(
         self, resource_id: str, resource_data: ResourceData | None = None
@@ -63,9 +55,7 @@ class AsyncInvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "resend-invite", json=resource_data
-        )
+        return await self._resource(resource_id).post("resend-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def send_new_invite(
         self, resource_id: str, resource_data: ResourceData | None = None
@@ -76,6 +66,4 @@ class AsyncInvitableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "send-new-invite", json=resource_data
-        )
+        return await self._resource(resource_id).post("send-new-invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/accounts/mixins/validate_mixin.py
+++ b/mpt_api_client/resources/accounts/mixins/validate_mixin.py
@@ -11,9 +11,7 @@ class ValidateMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be validated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "validate", json=resource_data
-        )
+        return self._resource(resource_id).post("validate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncValidateMixin[Model]:
@@ -26,6 +24,4 @@ class AsyncValidateMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be validated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "validate", json=resource_data
-        )
+        return await self._resource(resource_id).post("validate", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/accounts/sellers.py
+++ b/mpt_api_client/resources/accounts/sellers.py
@@ -41,7 +41,7 @@ class SellersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return self._resource(resource_id).post("disable", json=resource_data)
 
 
 class AsyncSellersService(
@@ -60,4 +60,4 @@ class AsyncSellersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return await self._resource(resource_id).post("disable", json=resource_data)

--- a/mpt_api_client/resources/accounts/users.py
+++ b/mpt_api_client/resources/accounts/users.py
@@ -49,7 +49,7 @@ class UsersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "sso", json=resource_data)
+        return self._resource(resource_id).post("sso", json=resource_data)
 
     def sso_check(self, resource_id: str, resource_data: ResourceData | None = None) -> User:
         """Perform SSO check action for a user.
@@ -58,7 +58,7 @@ class UsersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "sso-check", json=resource_data)
+        return self._resource(resource_id).post("sso-check", json=resource_data)
 
     def set_password(self, resource_id: str, password: str) -> User:
         """Set password for a user.
@@ -69,7 +69,7 @@ class UsersService(
         """
         resource_data = {"password": password}
 
-        return self._resource_action(resource_id, "POST", "set-password", json=resource_data)
+        return self._resource(resource_id).post("set-password", json=resource_data)
 
 
 class AsyncUsersService(
@@ -90,7 +90,7 @@ class AsyncUsersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "sso", json=resource_data)
+        return await self._resource(resource_id).post("sso", json=resource_data)
 
     async def sso_check(self, resource_id: str, resource_data: ResourceData | None = None) -> User:
         """Perform SSO check action for a user.
@@ -99,7 +99,7 @@ class AsyncUsersService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "sso-check", json=resource_data)
+        return await self._resource(resource_id).post("sso-check", json=resource_data)
 
     async def set_password(self, resource_id: str, password: str) -> User:
         """Set password for a user.
@@ -110,4 +110,4 @@ class AsyncUsersService(
         """
         resource_data = {"password": password}
 
-        return await self._resource_action(resource_id, "POST", "set-password", json=resource_data)
+        return await self._resource(resource_id).post("set-password", json=resource_data)

--- a/mpt_api_client/resources/billing/custom_ledgers.py
+++ b/mpt_api_client/resources/billing/custom_ledgers.py
@@ -1,6 +1,5 @@
 import pathlib
 from typing import cast
-from urllib.parse import urljoin
 
 from mpt_api_client.constants import MIMETYPE_EXCEL_XLSX
 from mpt_api_client.http import AsyncService, Service
@@ -11,6 +10,7 @@ from mpt_api_client.http.mixins import (
     ManagedResourceMixin,
 )
 from mpt_api_client.http.types import FileContent, FileTypes
+from mpt_api_client.http.url_utils import join_url_path
 from mpt_api_client.models import Model
 from mpt_api_client.resources.billing.custom_ledger_attachments import (
     AsyncCustomLedgerAttachmentsService,
@@ -68,7 +68,7 @@ class CustomLedgersService(
         )  # UNUSED type: ignore[attr-defined]
         files[self._upload_data_key] = custom_ledger_id  # UNUSED type: ignore
 
-        path = urljoin(f"{self.path}/", f"{custom_ledger_id}/upload")
+        path = join_url_path(self.path, custom_ledger_id, "upload")
 
         response = self.http_client.request(  # UNUSED type: ignore[attr-defined]
             "post",
@@ -127,7 +127,7 @@ class AsyncCustomLedgersService(
         )  # UNUSED type: ignore[attr-defined]
         files[self._upload_data_key] = custom_ledger_id  # UNUSED type: ignore
 
-        path = urljoin(f"{self.path}/", f"{custom_ledger_id}/upload")
+        path = join_url_path(self.path, custom_ledger_id, "upload")
 
         response = await self.http_client.request(  # UNUSED type: ignore[attr-defined]
             "post",

--- a/mpt_api_client/resources/billing/journals.py
+++ b/mpt_api_client/resources/billing/journals.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin
-
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
@@ -8,6 +6,7 @@ from mpt_api_client.http.mixins import (
     ManagedResourceMixin,
 )
 from mpt_api_client.http.types import FileTypes
+from mpt_api_client.http.url_utils import join_url_path
 from mpt_api_client.models import Model
 from mpt_api_client.resources.billing.journal_attachments import (
     AsyncJournalAttachmentsService,
@@ -63,7 +62,7 @@ class JournalsService(
             files[self._upload_file_key] = file  # UNUSED type: ignore[attr-defined]
             files[self._upload_data_key] = journal_id  # UNUSED type: ignore
 
-        path = urljoin(f"{self.path}/", f"{journal_id}/upload")
+        path = join_url_path(self.path, journal_id, "upload")
 
         response = self.http_client.request(  # UNUSED type: ignore[attr-defined]
             "post",
@@ -121,7 +120,7 @@ class AsyncJournalsService(
             files[self._upload_file_key] = file  # UNUSED type: ignore[attr-defined]
             files[self._upload_data_key] = journal_id  # UNUSED type: ignore
 
-        path = urljoin(f"{self.path}/", f"{journal_id}/upload")
+        path = join_url_path(self.path, journal_id, "upload")
 
         response = await self.http_client.request(  # UNUSED type: ignore[attr-defined]
             "post",

--- a/mpt_api_client/resources/billing/mixins/acceptable_mixin.py
+++ b/mpt_api_client/resources/billing/mixins/acceptable_mixin.py
@@ -11,9 +11,7 @@ class AcceptableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -22,9 +20,7 @@ class AcceptableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncAcceptableMixin[Model]:
@@ -37,9 +33,7 @@ class AsyncAcceptableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return await self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -48,6 +42,4 @@ class AsyncAcceptableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return await self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/billing/mixins/issuable_mixin.py
+++ b/mpt_api_client/resources/billing/mixins/issuable_mixin.py
@@ -11,9 +11,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "issue", json=resource_data
-        )
+        return self._resource(resource_id).post("issue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def cancel(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Cancel resource.
@@ -22,9 +20,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "cancel", json=resource_data
-        )
+        return self._resource(resource_id).post("cancel", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def error(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Error resource.
@@ -33,9 +29,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "error", json=resource_data
-        )
+        return self._resource(resource_id).post("error", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def pending(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Pending resource.
@@ -44,9 +38,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "pending", json=resource_data
-        )
+        return self._resource(resource_id).post("pending", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -55,9 +47,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def retry(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Retry resource.
@@ -66,9 +56,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "retry", json=resource_data
-        )
+        return self._resource(resource_id).post("retry", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def recalculate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Recalculate resource.
@@ -77,9 +65,7 @@ class IssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "recalculate", json=resource_data
-        )
+        return self._resource(resource_id).post("recalculate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncIssuableMixin[Model]:
@@ -92,9 +78,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "issue", json=resource_data
-        )
+        return await self._resource(resource_id).post("issue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def cancel(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Cancel resource.
@@ -103,9 +87,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "cancel", json=resource_data
-        )
+        return await self._resource(resource_id).post("cancel", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def error(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Error resource.
@@ -114,9 +96,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "error", json=resource_data
-        )
+        return await self._resource(resource_id).post("error", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def pending(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Pending resource.
@@ -125,9 +105,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "pending", json=resource_data
-        )
+        return await self._resource(resource_id).post("pending", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -136,9 +114,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return await self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def retry(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Retry resource.
@@ -147,9 +123,7 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "retry", json=resource_data
-        )
+        return await self._resource(resource_id).post("retry", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def recalculate(
         self, resource_id: str, resource_data: ResourceData | None = None
@@ -160,6 +134,4 @@ class AsyncIssuableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "recalculate", json=resource_data
-        )
+        return await self._resource(resource_id).post("recalculate", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/billing/mixins/recalculatable_mixin.py
+++ b/mpt_api_client/resources/billing/mixins/recalculatable_mixin.py
@@ -11,9 +11,7 @@ class RecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "recalculate", json=resource_data
-        )
+        return self._resource(resource_id).post("recalculate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def accept(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Accept resource.
@@ -22,9 +20,7 @@ class RecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -33,9 +29,7 @@ class RecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncRecalculatableMixin[Model]:
@@ -50,9 +44,7 @@ class AsyncRecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "recalculate", json=resource_data
-        )
+        return await self._resource(resource_id).post("recalculate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def accept(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Accept resource.
@@ -61,9 +53,7 @@ class AsyncRecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return await self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def queue(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Queue resource.
@@ -72,6 +62,4 @@ class AsyncRecalculatableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "queue", json=resource_data
-        )
+        return await self._resource(resource_id).post("queue", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/billing/mixins/regeneratable_mixin.py
+++ b/mpt_api_client/resources/billing/mixins/regeneratable_mixin.py
@@ -11,9 +11,7 @@ class RegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "regenerate", json=resource_data
-        )
+        return self._resource(resource_id).post("regenerate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def submit(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Submit resource.
@@ -22,9 +20,7 @@ class RegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "submit", json=resource_data
-        )
+        return self._resource(resource_id).post("submit", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def enquiry(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Enquiry resource.
@@ -33,9 +29,7 @@ class RegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "enquiry", json=resource_data
-        )
+        return self._resource(resource_id).post("enquiry", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def accept(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Accept resource.
@@ -44,9 +38,7 @@ class RegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncRegeneratableMixin[Model]:
@@ -61,9 +53,7 @@ class AsyncRegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "regenerate", json=resource_data
-        )
+        return await self._resource(resource_id).post("regenerate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def submit(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Submit resource.
@@ -72,9 +62,7 @@ class AsyncRegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "submit", json=resource_data
-        )
+        return await self._resource(resource_id).post("submit", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def enquiry(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Enquiry resource.
@@ -83,9 +71,7 @@ class AsyncRegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "enquiry", json=resource_data
-        )
+        return await self._resource(resource_id).post("enquiry", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def accept(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Accept resource.
@@ -94,6 +80,4 @@ class AsyncRegeneratableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "accept", json=resource_data
-        )
+        return await self._resource(resource_id).post("accept", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/catalog/mixins/activatable_mixin.py
+++ b/mpt_api_client/resources/catalog/mixins/activatable_mixin.py
@@ -5,51 +5,25 @@ class ActivatableMixin[Model]:
     """Activatable mixin adds the ability to activate and deactivate."""
 
     def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Update state to Active.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "activate", json=resource_data
-        )
+        """Update state to Active."""
+        return self._resource(resource_id).post("activate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def deactivate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Update state to Inactive.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "deactivate", json=resource_data
-        )
+        """Update state to Inactive."""
+        return self._resource(resource_id).post("deactivate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncActivatableMixin[Model]:
     """Activatable mixin adds the ability to activate and deactivate."""
 
     async def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Update state to Active.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "activate", json=resource_data
-        )
+        """Update state to Active."""
+        return await self._resource(resource_id).post("activate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def deactivate(
-        self, resource_id: str, resource_data: ResourceData | None = None
+        self,
+        resource_id: str,
+        resource_data: ResourceData | None = None,
     ) -> Model:
-        """Update state to Inactive.
-
-        Args:
-            resource_id: Resource ID
-            resource_data: Resource data will be updated
-        """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "deactivate", json=resource_data
-        )
+        """Update state to Inactive."""
+        return await self._resource(resource_id).post("deactivate", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/catalog/mixins/publishable_mixin.py
+++ b/mpt_api_client/resources/catalog/mixins/publishable_mixin.py
@@ -11,9 +11,7 @@ class PublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "review", json=resource_data
-        )
+        return self._resource(resource_id).post("review", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def publish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Published.
@@ -22,9 +20,7 @@ class PublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "publish", json=resource_data
-        )
+        return self._resource(resource_id).post("publish", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Unpublished.
@@ -33,9 +29,7 @@ class PublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "unpublish", json=resource_data
-        )
+        return self._resource(resource_id).post("unpublish", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncPublishableMixin[Model]:
@@ -48,9 +42,7 @@ class AsyncPublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "review", json=resource_data
-        )
+        return await self._resource(resource_id).post("review", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def publish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Published.
@@ -59,9 +51,7 @@ class AsyncPublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "publish", json=resource_data
-        )
+        return await self._resource(resource_id).post("publish", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
     async def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Unpublished.
@@ -70,6 +60,4 @@ class AsyncPublishableMixin[Model]:
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(  # type: ignore[attr-defined, no-any-return]
-            resource_id, "POST", "unpublish", json=resource_data
-        )
+        return await self._resource(resource_id).post("unpublish", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/catalog/pricing_policies.py
+++ b/mpt_api_client/resources/catalog/pricing_policies.py
@@ -81,7 +81,7 @@ class PricingPoliciesService(  # noqa: WPS215
         Returns:
             Activated pricing policy.
         """
-        return self._resource_action(resource_id, "POST", "activate", json=resource_data)
+        return self._resource(resource_id).post("activate", json=resource_data)
 
     def disable(self, resource_id: str, resource_data: ResourceData | None = None) -> PricingPolicy:
         """Disable pricing policy.
@@ -93,7 +93,7 @@ class PricingPoliciesService(  # noqa: WPS215
         Returns:
             Disabled pricing policy.
         """
-        return self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return self._resource(resource_id).post("disable", json=resource_data)
 
 
 class AsyncPricingPoliciesService(
@@ -123,7 +123,7 @@ class AsyncPricingPoliciesService(
         Returns:
             Activated pricing policy.
         """
-        return await self._resource_action(resource_id, "POST", "activate", json=resource_data)
+        return await self._resource(resource_id).post("activate", json=resource_data)
 
     async def disable(
         self, resource_id: str, resource_data: ResourceData | None = None
@@ -137,4 +137,4 @@ class AsyncPricingPoliciesService(
         Returns:
             Disabled pricing policy.
         """
-        return await self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return await self._resource(resource_id).post("disable", json=resource_data)

--- a/mpt_api_client/resources/catalog/products.py
+++ b/mpt_api_client/resources/catalog/products.py
@@ -151,7 +151,7 @@ class ProductsService(
 
     def update_settings(self, product_id: str, settings: ResourceData) -> Product:
         """Update product settings."""
-        return self._resource_action(product_id, "PUT", "settings", settings)
+        return self._resource(product_id).put("settings", json=settings)
 
 
 class AsyncProductsService(
@@ -216,4 +216,4 @@ class AsyncProductsService(
 
     async def update_settings(self, product_id: str, settings: ResourceData) -> Product:
         """Update product settings."""
-        return await self._resource_action(product_id, "PUT", "settings", settings)
+        return await self._resource(product_id).put("settings", json=settings)

--- a/mpt_api_client/resources/commerce/mixins/render_mixin.py
+++ b/mpt_api_client/resources/commerce/mixins/render_mixin.py
@@ -10,7 +10,7 @@ class RenderMixin[Model]:
         Returns:
             Rendered resource.
         """
-        response = self._resource_do_request(resource_id, action="render")  # type: ignore[attr-defined]
+        response = self._resource(resource_id).do_request("GET", "render")  # type: ignore[attr-defined]
         return response.text  # type: ignore[no-any-return]
 
 
@@ -26,5 +26,5 @@ class AsyncRenderMixin[Model]:
         Returns:
             Rendered resource.
         """
-        response = await self._resource_do_request(resource_id, action="render")  # type: ignore[attr-defined]
+        response = await self._resource(resource_id).do_request("GET", "render")  # type: ignore[attr-defined]
         return response.text  # type: ignore[no-any-return]

--- a/mpt_api_client/resources/commerce/mixins/template_mixin.py
+++ b/mpt_api_client/resources/commerce/mixins/template_mixin.py
@@ -10,7 +10,7 @@ class TemplateMixin[Model]:
         Returns:
             Resource template.
         """
-        response = self._resource_do_request(resource_id, action="template")  # type: ignore[attr-defined]
+        response = self._resource(resource_id).do_request("GET", "template")  # type: ignore[attr-defined]
         return response.text  # type: ignore[no-any-return]
 
 
@@ -26,6 +26,5 @@ class AsyncTemplateMixin[Model]:
         Returns:
             Resource template.
         """
-        # pylint: disable=duplicate-code
-        response = await self._resource_do_request(resource_id, action="template")  # type: ignore[attr-defined]
+        response = await self._resource(resource_id).do_request("GET", "template")  # type: ignore[attr-defined]
         return response.text  # type: ignore[no-any-return]

--- a/mpt_api_client/resources/commerce/mixins/terminate_mixin.py
+++ b/mpt_api_client/resources/commerce/mixins/terminate_mixin.py
@@ -14,7 +14,7 @@ class TerminateMixin[Model]:
         Returns:
             Terminated resource.
         """
-        return self._resource_action(resource_id, "POST", "terminate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        return self._resource(resource_id).post("terminate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncTerminateMixin[Model]:
@@ -30,4 +30,4 @@ class AsyncTerminateMixin[Model]:
         Returns:
             Terminated resource.
         """
-        return await self._resource_action(resource_id, "POST", "terminate", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        return await self._resource(resource_id).post("terminate", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/commerce/orders.py
+++ b/mpt_api_client/resources/commerce/orders.py
@@ -117,7 +117,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: Order data will be updated
         """
-        return self._resource_action(resource_id, "POST", "validate", json=resource_data)
+        return self._resource(resource_id).post("validate", json=resource_data)
 
     def process(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to process state.
@@ -126,7 +126,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: Order data will be updated
         """
-        return self._resource_action(resource_id, "POST", "process", json=resource_data)
+        return self._resource(resource_id).post("process", json=resource_data)
 
     def query(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to query state.
@@ -135,7 +135,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: Order data will be updated
         """
-        return self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return self._resource(resource_id).post("query", json=resource_data)
 
     def complete(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to complete state.
@@ -144,7 +144,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: Order data will be updated
         """
-        return self._resource_action(resource_id, "POST", "complete", json=resource_data)
+        return self._resource(resource_id).post("complete", json=resource_data)
 
     def fail(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to fail state.
@@ -153,7 +153,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: Order data will be updated
         """
-        return self._resource_action(resource_id, "POST", "fail", json=resource_data)
+        return self._resource(resource_id).post("fail", json=resource_data)
 
     def notify(self, resource_id: str, user: ResourceData) -> None:
         """Notify user about order status.
@@ -162,7 +162,7 @@ class OrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             user: User data
         """
-        self._resource_do_request(resource_id, "POST", "notify", json=user)
+        self._resource(resource_id).do_request("POST", "notify", json=user)
 
     def quote(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Quote the order.
@@ -174,7 +174,7 @@ class OrdersService(  # noqa: WPS215 WPS214
         Returns:
             Quoted order resource.
         """
-        return self._resource_action(resource_id, "POST", "quote", json=resource_data)
+        return self._resource(resource_id).post("quote", json=resource_data)
 
     def subscriptions(self, order_id: str) -> OrderSubscriptionsService:
         """Get the subscription service for the given Order id.
@@ -225,7 +225,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Updated order resource
         """
-        return await self._resource_action(resource_id, "POST", "validate", json=resource_data)
+        return await self._resource(resource_id).post("validate", json=resource_data)
 
     async def process(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to process state.
@@ -237,7 +237,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Updated order resource
         """
-        return await self._resource_action(resource_id, "POST", "process", json=resource_data)
+        return await self._resource(resource_id).post("process", json=resource_data)
 
     async def query(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to query state.
@@ -249,7 +249,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Updated order resource
         """
-        return await self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return await self._resource(resource_id).post("query", json=resource_data)
 
     async def complete(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to complete state.
@@ -261,7 +261,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Updated order resource
         """
-        return await self._resource_action(resource_id, "POST", "complete", json=resource_data)
+        return await self._resource(resource_id).post("complete", json=resource_data)
 
     async def fail(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Switch order to fail state.
@@ -273,7 +273,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Updated order resource
         """
-        return await self._resource_action(resource_id, "POST", "fail", json=resource_data)
+        return await self._resource(resource_id).post("fail", json=resource_data)
 
     async def notify(self, resource_id: str, resource_data: ResourceData) -> None:
         """Notify user about order status.
@@ -282,7 +282,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
             resource_id: Order resource ID
             resource_data: User data to notify
         """
-        await self._resource_do_request(resource_id, "POST", "notify", json=resource_data)
+        await self._resource(resource_id).do_request("POST", "notify", json=resource_data)
 
     async def quote(self, resource_id: str, resource_data: ResourceData | None = None) -> Order:
         """Quote the order.
@@ -294,7 +294,7 @@ class AsyncOrdersService(  # noqa: WPS215 WPS214
         Returns:
             Quoted order resource.
         """
-        return await self._resource_action(resource_id, "POST", "quote", json=resource_data)
+        return await self._resource(resource_id).post("quote", json=resource_data)
 
     def subscriptions(self, order_id: str) -> AsyncOrderSubscriptionsService:
         """Get the subscription service for the given Order id.

--- a/mpt_api_client/resources/helpdesk/cases.py
+++ b/mpt_api_client/resources/helpdesk/cases.py
@@ -36,15 +36,15 @@ class CasesService(
 
     def query(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to query state."""
-        return self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return self._resource(resource_id).post("query", json=resource_data)
 
     def process(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to process state."""
-        return self._resource_action(resource_id, "POST", "process", json=resource_data)
+        return self._resource(resource_id).post("process", json=resource_data)
 
     def complete(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to complete state."""
-        return self._resource_action(resource_id, "POST", "complete", json=resource_data)
+        return self._resource(resource_id).post("complete", json=resource_data)
 
 
 class AsyncCasesService(
@@ -59,12 +59,12 @@ class AsyncCasesService(
 
     async def query(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to query state."""
-        return await self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return await self._resource(resource_id).post("query", json=resource_data)
 
     async def process(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to process state."""
-        return await self._resource_action(resource_id, "POST", "process", json=resource_data)
+        return await self._resource(resource_id).post("process", json=resource_data)
 
     async def complete(self, resource_id: str, resource_data: ResourceData | None = None) -> Case:
         """Switch case to complete state."""
-        return await self._resource_action(resource_id, "POST", "complete", json=resource_data)
+        return await self._resource(resource_id).post("complete", json=resource_data)

--- a/mpt_api_client/resources/helpdesk/chat_answers.py
+++ b/mpt_api_client/resources/helpdesk/chat_answers.py
@@ -31,19 +31,19 @@ class ChatAnswersService(
 
     def submit(self, resource_id: str, resource_data: ResourceData | None = None) -> ChatAnswer:
         """Switch answer to submitted state."""
-        return self._resource_action(resource_id, "POST", "submit", json=resource_data)
+        return self._resource(resource_id).post("submit", json=resource_data)
 
     def accept(self, resource_id: str, resource_data: ResourceData | None = None) -> ChatAnswer:
         """Switch answer to accepted state."""
-        return self._resource_action(resource_id, "POST", "accept", json=resource_data)
+        return self._resource(resource_id).post("accept", json=resource_data)
 
     def query(self, resource_id: str, resource_data: ResourceData | None = None) -> ChatAnswer:
         """Switch answer to query state."""
-        return self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return self._resource(resource_id).post("query", json=resource_data)
 
     def validate(self, resource_id: str, resource_data: ResourceData | None = None) -> ChatAnswer:
         """Validate answer."""
-        return self._resource_action(resource_id, "POST", "validate", json=resource_data)
+        return self._resource(resource_id).post("validate", json=resource_data)
 
     def parameters(self, answer_id: str) -> ChatAnswerParametersService:  # noqa: WPS110
         """Return chat answer parameters service."""
@@ -73,7 +73,7 @@ class AsyncChatAnswersService(
         resource_data: ResourceData | None = None,
     ) -> ChatAnswer:
         """Switch answer to submitted state."""
-        return await self._resource_action(resource_id, "POST", "submit", json=resource_data)
+        return await self._resource(resource_id).post("submit", json=resource_data)
 
     async def accept(
         self,
@@ -81,7 +81,7 @@ class AsyncChatAnswersService(
         resource_data: ResourceData | None = None,
     ) -> ChatAnswer:
         """Switch answer to accepted state."""
-        return await self._resource_action(resource_id, "POST", "accept", json=resource_data)
+        return await self._resource(resource_id).post("accept", json=resource_data)
 
     async def query(
         self,
@@ -89,7 +89,7 @@ class AsyncChatAnswersService(
         resource_data: ResourceData | None = None,
     ) -> ChatAnswer:
         """Switch answer to query state."""
-        return await self._resource_action(resource_id, "POST", "query", json=resource_data)
+        return await self._resource(resource_id).post("query", json=resource_data)
 
     async def validate(
         self,
@@ -97,7 +97,7 @@ class AsyncChatAnswersService(
         resource_data: ResourceData | None = None,
     ) -> ChatAnswer:
         """Validate answer."""
-        return await self._resource_action(resource_id, "POST", "validate", json=resource_data)
+        return await self._resource(resource_id).post("validate", json=resource_data)
 
     def parameters(self, answer_id: str) -> AsyncChatAnswerParametersService:  # noqa: WPS110
         """Return async chat answer parameters service."""

--- a/mpt_api_client/resources/helpdesk/forms.py
+++ b/mpt_api_client/resources/helpdesk/forms.py
@@ -30,11 +30,11 @@ class FormsService(
 
     def publish(self, resource_id: str, resource_data: ResourceData | None = None) -> Form:
         """Switch form to published state."""
-        return self._resource_action(resource_id, "POST", "publish", json=resource_data)
+        return self._resource(resource_id).post("publish", json=resource_data)
 
     def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Form:
         """Switch form to unpublished state."""
-        return self._resource_action(resource_id, "POST", "unpublish", json=resource_data)
+        return self._resource(resource_id).post("unpublish", json=resource_data)
 
 
 class AsyncFormsService(
@@ -47,8 +47,8 @@ class AsyncFormsService(
 
     async def publish(self, resource_id: str, resource_data: ResourceData | None = None) -> Form:
         """Switch form to published state."""
-        return await self._resource_action(resource_id, "POST", "publish", json=resource_data)
+        return await self._resource(resource_id).post("publish", json=resource_data)
 
     async def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Form:
         """Switch form to unpublished state."""
-        return await self._resource_action(resource_id, "POST", "unpublish", json=resource_data)
+        return await self._resource(resource_id).post("unpublish", json=resource_data)

--- a/mpt_api_client/resources/helpdesk/queues.py
+++ b/mpt_api_client/resources/helpdesk/queues.py
@@ -30,11 +30,11 @@ class QueuesService(
 
     def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Queue:
         """Switch queue to active state."""
-        return self._resource_action(resource_id, "POST", "activate", json=resource_data)
+        return self._resource(resource_id).post("activate", json=resource_data)
 
     def disable(self, resource_id: str, resource_data: ResourceData | None = None) -> Queue:
         """Switch queue to disabled state."""
-        return self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return self._resource(resource_id).post("disable", json=resource_data)
 
 
 class AsyncQueuesService(
@@ -47,8 +47,8 @@ class AsyncQueuesService(
 
     async def activate(self, resource_id: str, resource_data: ResourceData | None = None) -> Queue:
         """Switch queue to active state."""
-        return await self._resource_action(resource_id, "POST", "activate", json=resource_data)
+        return await self._resource(resource_id).post("activate", json=resource_data)
 
     async def disable(self, resource_id: str, resource_data: ResourceData | None = None) -> Queue:
         """Switch queue to disabled state."""
-        return await self._resource_action(resource_id, "POST", "disable", json=resource_data)
+        return await self._resource(resource_id).post("disable", json=resource_data)

--- a/mpt_api_client/resources/notifications/categories.py
+++ b/mpt_api_client/resources/notifications/categories.py
@@ -35,7 +35,7 @@ class CategoriesService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "publish", json=resource_data)
+        return self._resource(resource_id).post("publish", json=resource_data)
 
     def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Unpublished.
@@ -44,7 +44,7 @@ class CategoriesService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return self._resource_action(resource_id, "POST", "unpublish", json=resource_data)
+        return self._resource(resource_id).post("unpublish", json=resource_data)
 
 
 class AsyncCategoriesService(
@@ -62,7 +62,7 @@ class AsyncCategoriesService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "publish", json=resource_data)
+        return await self._resource(resource_id).post("publish", json=resource_data)
 
     async def unpublish(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Update state to Unpublished.
@@ -71,4 +71,4 @@ class AsyncCategoriesService(
             resource_id: Resource ID
             resource_data: Resource data will be updated
         """
-        return await self._resource_action(resource_id, "POST", "unpublish", json=resource_data)
+        return await self._resource(resource_id).post("unpublish", json=resource_data)

--- a/mpt_api_client/resources/notifications/contacts.py
+++ b/mpt_api_client/resources/notifications/contacts.py
@@ -30,11 +30,11 @@ class ContactsService(
 
     def block(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Block a contact."""
-        return self._resource_action(resource_id, "POST", "block", json=resource_data)
+        return self._resource(resource_id).post("block", json=resource_data)
 
     def unblock(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Unblock a contact."""
-        return self._resource_action(resource_id, "POST", "unblock", json=resource_data)
+        return self._resource(resource_id).post("unblock", json=resource_data)
 
 
 class AsyncContactsService(
@@ -47,8 +47,8 @@ class AsyncContactsService(
 
     async def block(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Block a contact."""
-        return await self._resource_action(resource_id, "POST", "block", json=resource_data)
+        return await self._resource(resource_id).post("block", json=resource_data)
 
     async def unblock(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
         """Unblock a contact."""
-        return await self._resource_action(resource_id, "POST", "unblock", json=resource_data)
+        return await self._resource(resource_id).post("unblock", json=resource_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ per-file-ignores = [
   "tests/e2e/commerce/order/asset/*.py: WPS211 WPS202",
   "tests/e2e/commerce/subscription/*.py: WPS202",
   "tests/unit/http/test_async_service.py: WPS204 WPS202",
+  "tests/unit/http/test_resource_accessor.py: WPS204 WPS202 WPS210 WPS219",
   "tests/unit/http/test_service.py: WPS204 WPS202",
   "tests/unit/http/mixins/*: WPS204 WPS202 WPS210",
   "tests/unit/resources/accounts/*.py: WPS204 WPS202 WPS210",

--- a/tests/unit/http/test_resource_accessor.py
+++ b/tests/unit/http/test_resource_accessor.py
@@ -1,0 +1,242 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.http.resource_accessor import AsyncResourceAccessor, ResourceAccessor
+from tests.unit.conftest import API_URL, DummyModel
+
+RESOURCE_URL = "/api/v1/test/RES-123"
+FULL_URL = f"{API_URL}{RESOURCE_URL}"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("complete", f"{FULL_URL}/complete"),
+    ],
+    ids=["without-action", "with-action"],
+)
+def test_do_request(http_client, action, expected_url):
+    response_data = {"id": "RES-123"}
+    with respx.mock:
+        mock_route = respx.post(expected_url).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.do_request("POST", action)
+
+    assert result.json() == response_data
+    assert mock_route.call_count == 1
+
+
+def test_do_request_forwards_json(http_client):
+    payload = {"name": "Updated"}
+    response_data = {"id": "RES-123", "name": "Updated"}
+    with respx.mock:
+        mock_route = respx.put(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.do_request("PUT", json=payload)
+
+    assert result.json() == response_data
+    assert json.loads(mock_route.calls[0].request.content.decode()) == payload
+
+
+def test_do_request_forwards_query_params(http_client):
+    response_data = {"id": "RES-123"}
+    with respx.mock:
+        mock_route = respx.get(FULL_URL, params={"select": "id"}).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.do_request("GET", query_params={"select": "id"})
+
+    assert result.json() == response_data
+    assert mock_route.call_count == 1
+
+
+def test_do_request_forwards_headers(http_client):
+    response_data = {"id": "RES-123"}
+    with respx.mock:
+        mock_route = respx.get(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.do_request("GET", headers={"X-Custom": "value"})
+
+    assert result.json() == response_data
+    assert mock_route.calls[0].request.headers["X-Custom"] == "value"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("status", f"{FULL_URL}/status"),
+    ],
+    ids=["without-action", "with-action"],
+)
+def test_get(http_client, action, expected_url):
+    response_data = {"id": "RES-123", "name": "Test Resource"}
+    ok_response = httpx.Response(httpx.codes.OK, json=response_data)
+    with respx.mock:
+        mock_route = respx.get(expected_url).mock(return_value=ok_response)
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.get(action)
+
+    assert result.to_dict() == response_data
+    assert mock_route.calls[0].request.headers["Accept"] == "application/json"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("complete", f"{FULL_URL}/complete"),
+    ],
+    ids=["without-action", "with-action"],
+)
+def test_post(http_client, action, expected_url):
+    payload = {"name": "New"}
+    response_data = {"id": "RES-123", "name": "New"}
+    with respx.mock:
+        mock_route = respx.post(expected_url).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.post(action, json=payload)
+
+    assert result.to_dict() == response_data
+    assert json.loads(mock_route.calls[0].request.content.decode()) == payload
+
+
+def test_put(http_client):
+    payload = {"name": "Updated"}
+    response_data = {"id": "RES-123", "name": "Updated"}
+    with respx.mock:
+        mock_route = respx.put(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        result = accessor.put(json=payload)
+
+    assert result.to_dict() == response_data
+    assert json.loads(mock_route.calls[0].request.content.decode()) == payload
+
+
+def test_delete(http_client):  # noqa: AAA01
+    with respx.mock:
+        mock_route = respx.delete(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.NO_CONTENT)
+        )
+        accessor = ResourceAccessor(http_client, RESOURCE_URL, DummyModel)
+
+        accessor.delete()
+
+    assert mock_route.call_count == 1
+    assert mock_route.calls[0].request.method == "DELETE"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("complete", f"{FULL_URL}/complete"),
+    ],
+    ids=["without-action", "with-action"],
+)
+async def test_async_do_request(async_http_client, action, expected_url):
+    response_data = {"id": "RES-123"}
+    with respx.mock:
+        mock_route = respx.post(expected_url).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = AsyncResourceAccessor(async_http_client, RESOURCE_URL, DummyModel)
+
+        result = await accessor.do_request("POST", action)
+
+    assert result.json() == response_data
+    assert mock_route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("status", f"{FULL_URL}/status"),
+    ],
+    ids=["without-action", "with-action"],
+)
+async def test_async_get(async_http_client, action, expected_url):
+    response_data = {"id": "RES-123", "name": "Test Resource"}
+    ok_response = httpx.Response(httpx.codes.OK, json=response_data)
+    with respx.mock:
+        mock_route = respx.get(expected_url).mock(return_value=ok_response)
+        accessor = AsyncResourceAccessor(async_http_client, RESOURCE_URL, DummyModel)
+
+        result = await accessor.get(action)
+
+    assert result.to_dict() == response_data
+    assert mock_route.calls[0].request.headers["Accept"] == "application/json"
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_url"),
+    [
+        (None, FULL_URL),
+        ("complete", f"{FULL_URL}/complete"),
+    ],
+    ids=["without-action", "with-action"],
+)
+async def test_async_post(async_http_client, action, expected_url):
+    payload = {"name": "New"}
+    response_data = {"id": "RES-123", "name": "New"}
+    with respx.mock:
+        mock_route = respx.post(expected_url).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = AsyncResourceAccessor(async_http_client, RESOURCE_URL, DummyModel)
+
+        result = await accessor.post(action, json=payload)
+
+    assert result.to_dict() == response_data
+    assert json.loads(mock_route.calls[0].request.content.decode()) == payload
+
+
+async def test_async_put(async_http_client):
+    payload = {"name": "Updated"}
+    response_data = {"id": "RES-123", "name": "Updated"}
+    with respx.mock:
+        mock_route = respx.put(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.OK, json=response_data)
+        )
+        accessor = AsyncResourceAccessor(async_http_client, RESOURCE_URL, DummyModel)
+
+        result = await accessor.put(json=payload)
+
+    assert result.to_dict() == response_data
+    assert json.loads(mock_route.calls[0].request.content.decode()) == payload
+
+
+async def test_async_delete(async_http_client):  # noqa: AAA01
+    with respx.mock:
+        mock_route = respx.delete(FULL_URL).mock(
+            return_value=httpx.Response(httpx.codes.NO_CONTENT)
+        )
+        accessor = AsyncResourceAccessor(async_http_client, RESOURCE_URL, DummyModel)
+
+        await accessor.delete()
+
+    assert mock_route.call_count == 1
+    assert mock_route.calls[0].request.method == "DELETE"

--- a/tests/unit/http/test_url_utils.py
+++ b/tests/unit/http/test_url_utils.py
@@ -1,0 +1,86 @@
+import pytest
+
+from mpt_api_client.http.url_utils import join_url_path
+
+
+def test_simple_segment():
+    result = join_url_path("/api/v1/orders", "ORD-001")
+
+    assert result == "/api/v1/orders/ORD-001"
+
+
+def test_multiple_segments():
+    result = join_url_path("/api/v1/orders", "ORD-001", "complete")
+
+    assert result == "/api/v1/orders/ORD-001/complete"
+
+
+def test_base_with_trailing_slash():
+    result = join_url_path("/api/v1/orders/", "ORD-001")
+
+    assert result == "/api/v1/orders/ORD-001"
+
+
+def test_segment_with_leading_slash():
+    result = join_url_path("/api/v1/orders", "/ORD-001")
+
+    assert result == "/api/v1/orders/ORD-001"
+
+
+def test_segment_with_surrounding_slashes():
+    result = join_url_path("/api/v1/orders/", "/ORD-001/")
+
+    assert result == "/api/v1/orders/ORD-001"
+
+
+def test_absolute_segment():
+    result = join_url_path("/api/v1/orders", "https://evil.com")
+
+    assert result == "/api/v1/orders/https://evil.com"
+
+
+def test_dotdot_segment_is_literal():
+    result = join_url_path("/api/v1/orders", "../other")
+
+    assert result == "/api/v1/orders/../other"
+
+
+def test_no_segments():
+    result = join_url_path("/api/v1/orders")
+
+    assert result == "/api/v1/orders"
+
+
+def test_empty_segment_is_skipped():
+    result = join_url_path("/api/v1/orders", "", "upload")
+
+    assert result == "/api/v1/orders/upload"
+
+
+def test_none_segment_is_skipped():
+    result = join_url_path("/api/v1/orders", None, "upload")  # type: ignore[arg-type]
+
+    assert result == "/api/v1/orders/upload"
+
+
+@pytest.mark.parametrize(
+    ("base", "segments", "expected"),
+    [
+        ("/public/v1/billing/journals", ("JRN-123",), "/public/v1/billing/journals/JRN-123"),
+        (
+            "/public/v1/billing/journals",
+            ("JRN-123", "upload"),
+            "/public/v1/billing/journals/JRN-123/upload",
+        ),
+        (
+            "/public/v1/billing/custom-ledgers",
+            ("CL-456", "upload"),
+            "/public/v1/billing/custom-ledgers/CL-456/upload",
+        ),
+    ],
+    ids=["resource-id", "resource-id-and-action", "custom-ledger-upload"],
+)
+def test_real_world_paths(base, segments, expected):
+    result = join_url_path(base, *segments)
+
+    assert result == expected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19660](https://softwareone.atlassian.net/browse/MPT-19660)

- Add ResourceAccessor and AsyncResourceAccessor (mpt_api_client/http/resource_accessor.py) to provide resource-scoped do_request/get/post/put/delete with Accept header handling and model deserialization
- Remove Service._resource_do_request and Service._resource_action; add Service._resource / AsyncService._resource to return resource accessors and delegate request handling
- Replace _resource_action/_resource_do_request usage across many mixins and services to call the new resource-scoped API (.post(action, json=...), .put(...), .get(...), .do_request(...), .delete())
- Add join_url_path utility (mpt_api_client/http/url_utils.py) and replace urljoin usages with join_url_path for consistent path joining
- Add unit tests for ResourceAccessor and join_url_path and update pyproject flake8 per-file ignores for the new tests
- Shorten docstrings in several mixins; preserve public signatures and behavior while centralizing HTTP method selection, action path construction, payload/query handling, and response-to-model conversion in the new accessors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19660]: https://softwareone.atlassian.net/browse/MPT-19660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ