### PR TITLE
MPT-19124 remove session scope from pdf_fd and logo_fd fixtures

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -80,7 +80,7 @@ def project_root_path():
     return pathlib.Path(__file__).parent.parent.parent
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def pdf_fd():
     icon_path = pathlib.Path(__file__).parent / "empty.pdf"
     with pathlib.Path.open(icon_path, "rb") as fd:
@@ -119,10 +119,11 @@ def uuid_str():
     return str(uuid.uuid4())
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def logo_fd(project_root_path):
     file_path = project_root_path / "tests/data/logo.png"
-    return file_path.open("rb")
+    with file_path.open("rb") as fb:
+        yield fb
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19124](https://softwareone.atlassian.net/browse/MPT-19124)

- Removed session scope from pdf_fd and logo_fd fixtures so they are function-scoped (no longer shared across the test session)
- Ensured both fixtures use context-managed yield for file handles (fixture-managed cleanup of opened files)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19124]: https://softwareone.atlassian.net/browse/MPT-19124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ