### PR TITLE
MPT-19124 remove fixture scope

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,49 +20,49 @@ def api_timeout():
     return float(os.getenv("MPT_API_TIMEOUT", "60.0"))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def mpt_vendor(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_VENDOR"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def async_mpt_vendor(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_VENDOR"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def mpt_ops(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_OPERATIONS"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def async_mpt_ops(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_OPERATIONS"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def mpt_client(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_CLIENT"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def async_mpt_client(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_CLIENT"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def rp_logger():
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19124](https://softwareone.atlassian.net/browse/MPT-19124)

- Changed pytest fixture scope from `session` to `module` for seven fixtures in `tests/e2e/conftest.py`:
  - `mpt_vendor`
  - `async_mpt_vendor`
  - `mpt_ops`
  - `async_mpt_ops`
  - `mpt_client`
  - `async_mpt_client`
  - `rp_logger`

- Fixtures now have a module-level lifetime, meaning they are created once per test module instead of once per entire test session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19124]: https://softwareone.atlassian.net/browse/MPT-19124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ