### PR TITLE
MPT-19124 remove module scope from fixtures

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,42 +20,42 @@ def api_timeout():
     return float(os.getenv("MPT_API_TIMEOUT", "60.0"))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def mpt_vendor(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_VENDOR"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def async_mpt_vendor(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_VENDOR"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def mpt_ops(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_OPERATIONS"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def async_mpt_ops(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_OPERATIONS"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def mpt_client(base_url, api_timeout):
     return MPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_CLIENT"), base_url=base_url, timeout=api_timeout
     )  # type: ignore
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def async_mpt_client(base_url, api_timeout):
     return AsyncMPTClient.from_config(
         api_token=os.getenv("MPT_API_TOKEN_CLIENT"), base_url=base_url, timeout=api_timeout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19124](https://softwareone.atlassian.net/browse/MPT-19124)

- Changed e2e pytest fixtures to use function scope instead of module scope
  - Affected fixtures: `mpt_vendor`, `async_mpt_vendor`, `mpt_ops`, `async_mpt_ops`, `mpt_client`, and `async_mpt_client`
  - Each test function now receives a fresh instance of these fixtures instead of sharing a single instance across the entire test module
  - Client configuration logic via `MPTClient.from_config` and `AsyncMPTClient.from_config` remains unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19124]: https://softwareone.atlassian.net/browse/MPT-19124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ