### PR TITLE
MPT-19484 unskip tests and refactor fixtures for async and sync cases

### DIFF
--- a/tests/e2e/helpdesk/cases/conftest.py
+++ b/tests/e2e/helpdesk/cases/conftest.py
@@ -26,5 +26,27 @@ def created_case(mpt_ops, case_factory):
 
 
 @pytest.fixture
+def queried_case(mpt_ops, created_case):
+    return mpt_ops.helpdesk.cases.query(created_case.id, {"queryPrompt": "More details needed"})
+
+
+@pytest.fixture
+def processed_case(mpt_ops, queried_case):
+    return mpt_ops.helpdesk.cases.process(queried_case.id)
+
+
+@pytest.fixture
 async def async_created_case(async_mpt_ops, case_factory):
     return await async_mpt_ops.helpdesk.cases.create(case_factory())
+
+
+@pytest.fixture
+async def async_queried_case(async_mpt_ops, async_created_case):
+    return await async_mpt_ops.helpdesk.cases.query(
+        async_created_case.id, {"queryPrompt": "More details needed"}
+    )
+
+
+@pytest.fixture
+async def async_processed_case(async_mpt_ops, async_queried_case):
+    return await async_mpt_ops.helpdesk.cases.process(async_queried_case.id)

--- a/tests/e2e/helpdesk/cases/test_async_cases.py
+++ b/tests/e2e/helpdesk/cases/test_async_cases.py
@@ -8,7 +8,6 @@ from mpt_api_client.resources.helpdesk.cases import Case
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 async def test_get_case(async_mpt_ops, async_created_case):
     result = await async_mpt_ops.helpdesk.cases.get(async_created_case.id)
 
@@ -24,7 +23,6 @@ async def test_list_cases(async_mpt_ops):
     assert all(isinstance(case, Case) for case in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_case(async_created_case):
     result = async_created_case
 
@@ -41,28 +39,22 @@ async def test_update_case(async_mpt_ops, async_created_case, short_uuid):
     assert result.to_dict().get("awaiting") is True
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-async def test_process_case(async_mpt_ops, async_created_case):
-    result = await async_mpt_ops.helpdesk.cases.process(async_created_case.id)
+def test_process_case(async_mpt_ops, async_processed_case):
+    result = async_processed_case.to_dict().get("status")
 
-    assert result is not None
-
-
-async def test_query_case(async_mpt_ops, async_created_case, short_uuid):
-    result = await async_mpt_ops.helpdesk.cases.query(
-        async_created_case.id, {"queryPrompt": f"e2e update {short_uuid}"}
-    )
-
-    assert result.to_dict().get("queryPrompt") == f"e2e update {short_uuid}"
+    assert result == "Processing"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-async def test_complete_case(async_mpt_ops, async_created_case):
-    processed_case = await async_mpt_ops.helpdesk.cases.process(async_created_case.id)
+def test_query_case(async_mpt_ops, async_queried_case):
+    result = async_queried_case.to_dict().get("status")
 
-    result = await async_mpt_ops.helpdesk.cases.complete(processed_case.id)
+    assert result == "Querying"
 
-    assert result is not None
+
+async def test_complete_case(async_mpt_ops, async_processed_case):
+    result = await async_mpt_ops.helpdesk.cases.complete(async_processed_case.id)
+
+    assert result.to_dict().get("status") == "Completed"
 
 
 async def test_not_found(async_mpt_ops, invalid_case_id):

--- a/tests/e2e/helpdesk/cases/test_sync_cases.py
+++ b/tests/e2e/helpdesk/cases/test_sync_cases.py
@@ -8,7 +8,6 @@ from mpt_api_client.resources.helpdesk.cases import Case
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_get_case(mpt_ops, created_case):
     result = mpt_ops.helpdesk.cases.get(created_case.id)
 
@@ -24,7 +23,6 @@ def test_list_cases(mpt_ops):
     assert all(isinstance(case, Case) for case in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
 def test_create_case(created_case):
     result = created_case
 
@@ -41,28 +39,22 @@ def test_update_case(mpt_ops, created_case, short_uuid):
     assert result.to_dict().get("awaiting") is True
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-def test_process_case(mpt_ops, created_case):
-    result = mpt_ops.helpdesk.cases.process(created_case.id)
+def test_process_case(mpt_ops, processed_case):
+    result = processed_case.to_dict().get("status")
 
-    assert result is not None
-
-
-def test_query_case(mpt_ops, created_case, short_uuid):
-    result = mpt_ops.helpdesk.cases.query(
-        created_case.id, {"queryPrompt": f"e2e update {short_uuid}"}
-    )
-
-    assert result.to_dict().get("queryPrompt") == f"e2e update {short_uuid}"
+    assert result == "Processing"
 
 
-@pytest.mark.skip(reason="Unskip after MPT-19124 completed")
-def test_complete_case(mpt_ops, created_case):
-    processed_case = mpt_ops.helpdesk.cases.process(created_case.id)
+def test_query_case(mpt_ops, queried_case):
+    result = queried_case.to_dict().get("status")
 
+    assert result == "Querying"
+
+
+def test_complete_case(mpt_ops, processed_case):
     result = mpt_ops.helpdesk.cases.complete(processed_case.id)
 
-    assert result is not None
+    assert result.to_dict().get("status") == "Completed"
 
 
 def test_not_found(mpt_ops, invalid_case_id):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19484](https://softwareone.atlassian.net/browse/MPT-19484)

- Add pytest fixtures for helpdesk case e2e lifecycle:
  - Sync: queried_case, processed_case
  - Async: async_queried_case, async_processed_case
- Unskip and refactor async tests to use async fixtures and assert case status values (Querying, Processing, Completed)
- Unskip and refactor sync tests to use sync fixtures and assert case status values instead of performing inline operations
- Consolidate case state transitions into reusable fixtures to simplify and DRY test implementations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19484]: https://softwareone.atlassian.net/browse/MPT-19484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ