### PR TITLE
MPT-19908: add /integration/installations service

### DIFF
--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -69,6 +69,7 @@
   "notifications.message.id": "MSG-0000-6215-1019-0139",
   "notifications.subscriber.id": "NTS-0829-7123-7123",
   "integration.extension.id": "EXT-6587-4477",
+  "integration.installation.id": "EXI-0022-3978-5547",
   "integration.term.id": "ETC-6587-4477-0062",
   "program.certificate.id": "CER-9646-2171-8417",
   "program.document.file.id": "PDM-9643-3741-0001",

--- a/mpt_api_client/resources/integration/installations.py
+++ b/mpt_api_client/resources/integration/installations.py
@@ -1,0 +1,69 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncManagedResourceMixin,
+    CollectionMixin,
+    ManagedResourceMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.integration.mixins import (
+    AsyncInstallationMixin,
+    InstallationMixin,
+)
+
+
+class Installation(Model):
+    """Installation resource.
+
+    Attributes:
+        name: Installation name.
+        revision: Revision number.
+        account: Reference to the account.
+        extension: Reference to the extension.
+        status: Installation status (Invited, Installed, Uninstalled, Expired).
+        configuration: Installation configuration data.
+        invitation: Invitation details.
+        modules: Modules included in the installation.
+        terms: Accepted terms for this installation.
+        audit: Audit information (created, updated, invited, installed, expired, uninstalled).
+    """
+
+    name: str | None
+    revision: int | None
+    account: BaseModel | None
+    extension: BaseModel | None
+    status: str | None
+    configuration: BaseModel | None
+    invitation: BaseModel | None
+    modules: list[BaseModel] | None
+    terms: list[BaseModel] | None
+    audit: BaseModel | None
+
+
+class InstallationsServiceConfig:
+    """Installations service configuration."""
+
+    _endpoint = "/public/v1/integration/installations"
+    _model_class = Installation
+    _collection_key = "data"
+
+
+class InstallationsService(
+    InstallationMixin[Installation],
+    ManagedResourceMixin[Installation],
+    CollectionMixin[Installation],
+    Service[Installation],
+    InstallationsServiceConfig,
+):
+    """Sync service for the /public/v1/integration/installations endpoint."""
+
+
+class AsyncInstallationsService(
+    AsyncInstallationMixin[Installation],
+    AsyncManagedResourceMixin[Installation],
+    AsyncCollectionMixin[Installation],
+    AsyncService[Installation],
+    InstallationsServiceConfig,
+):
+    """Async service for the /public/v1/integration/installations endpoint."""

--- a/mpt_api_client/resources/integration/integration.py
+++ b/mpt_api_client/resources/integration/integration.py
@@ -7,6 +7,10 @@ from mpt_api_client.resources.integration.extensions import (
     AsyncExtensionsService,
     ExtensionsService,
 )
+from mpt_api_client.resources.integration.installations import (
+    AsyncInstallationsService,
+    InstallationsService,
+)
 
 
 class Integration:
@@ -25,6 +29,11 @@ class Integration:
         """Categories service."""
         return CategoriesService(http_client=self.http_client)
 
+    @property
+    def installations(self) -> InstallationsService:
+        """Installations service."""
+        return InstallationsService(http_client=self.http_client)
+
 
 class AsyncIntegration:
     """Async Integration MPT API Module."""
@@ -41,3 +50,8 @@ class AsyncIntegration:
     def categories(self) -> AsyncCategoriesService:
         """Categories service."""
         return AsyncCategoriesService(http_client=self.http_client)
+
+    @property
+    def installations(self) -> AsyncInstallationsService:
+        """Installations service."""
+        return AsyncInstallationsService(http_client=self.http_client)

--- a/mpt_api_client/resources/integration/mixins/__init__.py
+++ b/mpt_api_client/resources/integration/mixins/__init__.py
@@ -2,6 +2,10 @@ from mpt_api_client.resources.integration.mixins.extension_mixin import (
     AsyncExtensionMixin,
     ExtensionMixin,
 )
+from mpt_api_client.resources.integration.mixins.installation_mixin import (
+    AsyncInstallationMixin,
+    InstallationMixin,
+)
 from mpt_api_client.resources.integration.mixins.media_mixin import (
     AsyncMediaMixin,
     MediaMixin,
@@ -9,7 +13,9 @@ from mpt_api_client.resources.integration.mixins.media_mixin import (
 
 __all__ = [  # noqa: WPS410
     "AsyncExtensionMixin",
+    "AsyncInstallationMixin",
     "AsyncMediaMixin",
     "ExtensionMixin",
+    "InstallationMixin",
     "MediaMixin",
 ]

--- a/mpt_api_client/resources/integration/mixins/installation_mixin.py
+++ b/mpt_api_client/resources/integration/mixins/installation_mixin.py
@@ -1,0 +1,105 @@
+from mpt_api_client.models import ResourceData
+
+
+class InstallationMixin[Model]:
+    """Mixin that adds installation lifecycle actions: invite, install, uninstall, expire."""
+
+    def invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Invite an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return self._resource(resource_id).post("invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    def install(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Mark an installation as installed.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return self._resource(resource_id).post("install", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    def uninstall(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Uninstall an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return self._resource(resource_id).post("uninstall", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    def expire(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Expire an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return self._resource(resource_id).post("expire", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+
+class AsyncInstallationMixin[Model]:
+    """Async mixin for installation lifecycle actions: invite, install, uninstall, expire."""
+
+    async def invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Invite an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return await self._resource(resource_id).post("invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    async def install(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Mark an installation as installed.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return await self._resource(resource_id).post("install", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    async def uninstall(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Uninstall an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return await self._resource(resource_id).post("uninstall", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+
+    async def expire(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Expire an installation.
+
+        Args:
+            resource_id: Installation ID.
+            resource_data: Optional request body.
+
+        Returns:
+            Updated installation.
+        """
+        return await self._resource(resource_id).post("expire", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/mpt_api_client/resources/integration/mixins/installation_mixin.py
+++ b/mpt_api_client/resources/integration/mixins/installation_mixin.py
@@ -2,104 +2,32 @@ from mpt_api_client.models import ResourceData
 
 
 class InstallationMixin[Model]:
-    """Mixin that adds installation lifecycle actions: invite, install, uninstall, expire."""
+    """Mixin that adds the installation redeem action."""
 
-    def invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Invite an installation.
+    def redeem(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Redeem an installation invitation.
 
         Args:
             resource_id: Installation ID.
-            resource_data: Optional request body.
+            resource_data: Redeem payload, for example ``{"code": "...", "modules": [...]}``.
 
         Returns:
             Updated installation.
         """
-        return self._resource(resource_id).post("invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    def install(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Mark an installation as installed.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return self._resource(resource_id).post("install", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    def uninstall(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Uninstall an installation.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return self._resource(resource_id).post("uninstall", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    def expire(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Expire an installation.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return self._resource(resource_id).post("expire", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        return self._resource(resource_id).post("redeem", json=resource_data)  # type: ignore[attr-defined, no-any-return]
 
 
 class AsyncInstallationMixin[Model]:
-    """Async mixin for installation lifecycle actions: invite, install, uninstall, expire."""
+    """Async mixin that adds the installation redeem action."""
 
-    async def invite(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Invite an installation.
+    async def redeem(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
+        """Redeem an installation invitation.
 
         Args:
             resource_id: Installation ID.
-            resource_data: Optional request body.
+            resource_data: Redeem payload, for example ``{"code": "...", "modules": [...]}``.
 
         Returns:
             Updated installation.
         """
-        return await self._resource(resource_id).post("invite", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    async def install(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Mark an installation as installed.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return await self._resource(resource_id).post("install", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    async def uninstall(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Uninstall an installation.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return await self._resource(resource_id).post("uninstall", json=resource_data)  # type: ignore[attr-defined, no-any-return]
-
-    async def expire(self, resource_id: str, resource_data: ResourceData | None = None) -> Model:
-        """Expire an installation.
-
-        Args:
-            resource_id: Installation ID.
-            resource_data: Optional request body.
-
-        Returns:
-            Updated installation.
-        """
-        return await self._resource(resource_id).post("expire", json=resource_data)  # type: ignore[attr-defined, no-any-return]
+        return await self._resource(resource_id).post("redeem", json=resource_data)  # type: ignore[attr-defined, no-any-return]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ per-file-ignores = [
   "tests/unit/resources/catalog/test_products.py: WPS202 WPS210",
   "tests/e2e/integration/*.py: WPS453",
   "tests/e2e/integration/extensions/*.py: WPS453 WPS202",
+  "tests/e2e/integration/installations/*.py: WPS453 WPS202",
   "tests/unit/resources/integration/*.py: WPS202 WPS210 WPS218 WPS453",
   "tests/unit/resources/integration/mixins/*.py: WPS453 WPS202",
   "tests/unit/resources/commerce/*.py: WPS202 WPS204",

--- a/tests/e2e/integration/conftest.py
+++ b/tests/e2e/integration/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def extension_id(e2e_config):
+    return e2e_config["integration.extension.id"]

--- a/tests/e2e/integration/extensions/conftest.py
+++ b/tests/e2e/integration/extensions/conftest.py
@@ -4,18 +4,13 @@ from mpt_api_client.exceptions import MPTAPIError
 
 
 @pytest.fixture
-def extensions_service(mpt_ops):
-    return mpt_ops.integration.extensions
+def extensions_service(mpt_vendor):
+    return mpt_vendor.integration.extensions
 
 
 @pytest.fixture
-def async_extensions_service(async_mpt_ops):
-    return async_mpt_ops.integration.extensions
-
-
-@pytest.fixture(scope="session")
-def extension_id(e2e_config):
-    return e2e_config["integration.extension.id"]
+def async_extensions_service(async_mpt_vendor):
+    return async_mpt_vendor.integration.extensions
 
 
 @pytest.fixture

--- a/tests/e2e/integration/extensions/test_async_extensions.py
+++ b/tests/e2e/integration/extensions/test_async_extensions.py
@@ -7,7 +7,6 @@ from tests.e2e.helper import assert_async_service_filter_with_iterate
 pytestmark = [pytest.mark.flaky]
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 def test_create_extension(async_created_extension, extension_data):
     result = async_created_extension.name
 
@@ -27,7 +26,6 @@ async def test_get_extension_not_found(async_extensions_service):
         await async_extensions_service.get(bogus_id)
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 async def test_update_extension(
     async_extensions_service, async_created_extension, logo_fd, short_uuid
 ):
@@ -40,7 +38,6 @@ async def test_update_extension(
     assert result.name == update_data["name"]
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 async def test_delete_extension(async_extensions_service, async_created_extension):
     await async_extensions_service.delete(async_created_extension.id)  # act
 
@@ -51,7 +48,6 @@ async def test_filter_extensions(async_extensions_service, extension_id):
     )  # act
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 async def test_download_icon(async_extensions_service, async_created_extension):
     result = await async_extensions_service.download_icon(async_created_extension.id)
 

--- a/tests/e2e/integration/extensions/test_sync_extensions.py
+++ b/tests/e2e/integration/extensions/test_sync_extensions.py
@@ -9,7 +9,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 def test_create_extension(created_extension, extension_data):
     result = created_extension.name
 
@@ -29,7 +28,6 @@ def test_get_extension_not_found(extensions_service):
         extensions_service.get(bogus_id)
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 def test_update_extension(extensions_service, created_extension, logo_fd, short_uuid):
     update_data = {"name": f"e2e - please delete {short_uuid}"}
 
@@ -38,7 +36,6 @@ def test_update_extension(extensions_service, created_extension, logo_fd, short_
     assert result.name == update_data["name"]
 
 
-@pytest.mark.skip(reason="unable to create extensions for testing")
 def test_delete_extension(extensions_service, created_extension):
     extensions_service.delete(created_extension.id)  # act
 

--- a/tests/e2e/integration/installations/conftest.py
+++ b/tests/e2e/integration/installations/conftest.py
@@ -1,0 +1,93 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+
+@pytest.fixture
+def installations_service(mpt_vendor):
+    return mpt_vendor.integration.installations
+
+
+@pytest.fixture
+def async_installations_service(async_mpt_vendor):
+    return async_mpt_vendor.integration.installations
+
+
+@pytest.fixture
+def installation_modules():
+    return [
+        {"id": "MOD-0478"},
+        {"id": "MOD-1239"},
+        {"id": "MOD-1756"},
+        {"id": "MOD-4525"},
+        {"id": "MOD-8352"},
+        {"id": "MOD-8743"},
+        {"id": "MOD-9042"},
+    ]
+
+
+@pytest.fixture
+def installation_data(extension_id, installation_modules):
+    return {
+        "extension": {"id": extension_id},
+        "modules": installation_modules,
+    }
+
+
+@pytest.fixture
+def invite_data(extension_id):
+    return {
+        "extension": {"id": extension_id},
+        "invitation": {
+            "message": "E2E testing - Delete",
+            "validity": "7d",
+        },
+    }
+
+
+@pytest.fixture
+def created_installation(installations_service, installation_data):
+    installation = installations_service.create(installation_data)
+
+    yield installation
+
+    try:
+        installations_service.delete(installation.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete installation {installation.id}: {error.title}")  # noqa: WPS421
+
+
+@pytest.fixture
+def created_installation_invite(installations_service, invite_data):
+    invite = installations_service.create(invite_data)
+
+    yield invite
+
+    try:
+        installations_service.delete(invite.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete installation {invite.id}: {error.title}")  # noqa: WPS421
+
+
+@pytest.fixture
+async def async_created_installation(async_installations_service, installation_data):
+    installation = await async_installations_service.create(installation_data)
+
+    yield installation
+
+    try:
+        await async_installations_service.delete(installation.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete installation {installation.id}: {error.title}")  # noqa: WPS421
+
+
+@pytest.fixture
+async def async_created_installation_invite(async_installations_service, invite_data):
+    invite = await async_installations_service.create(invite_data)
+
+    yield invite
+
+    try:
+        await async_installations_service.delete(invite.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete installation {invite.id}: {error.title}")  # noqa: WPS421

--- a/tests/e2e/integration/installations/helper.py
+++ b/tests/e2e/integration/installations/helper.py
@@ -1,0 +1,30 @@
+import base64
+import json
+
+
+def _decode_base64_json(candidate: str) -> dict[str, str] | None:
+    normalized_candidate = candidate.strip()
+    if not normalized_candidate:
+        return None
+
+    padding = "=" * (-len(normalized_candidate) % 4)
+
+    try:  # noqa: WPS229
+        decoded_bytes = base64.urlsafe_b64decode(normalized_candidate + padding)
+        decoded_payload = json.loads(decoded_bytes.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+    if isinstance(decoded_payload, dict) and decoded_payload.get("code"):
+        return decoded_payload
+
+    return None
+
+
+def decode_invitation_payload(invitation_url: str) -> dict[str, str]:
+    """Decode an invitation payload from the API invitation URL field."""
+    decoded_payload = _decode_base64_json(invitation_url)
+    if decoded_payload:
+        return decoded_payload
+
+    raise AssertionError(f"Unable to decode invitation payload from URL: {invitation_url}")

--- a/tests/e2e/integration/installations/test_async_installations.py
+++ b/tests/e2e/integration/installations/test_async_installations.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tests.e2e.helper import assert_async_service_filter_with_iterate
+from tests.e2e.integration.installations.helper import decode_invitation_payload
+
+pytestmark = [pytest.mark.flaky]
+
+
+def test_create_installation(async_created_installation, installation_data):
+    result = async_created_installation.extension
+
+    assert result.id == installation_data["extension"]["id"]
+
+
+async def test_get_installation(async_installations_service, async_created_installation):
+    result = await async_installations_service.get(async_created_installation.id)
+
+    assert result.id == async_created_installation.id
+
+
+async def test_filter_installations(async_installations_service, async_created_installation):
+    await assert_async_service_filter_with_iterate(
+        async_installations_service, async_created_installation.id, None
+    )  # act
+
+
+async def test_redeem_installation(
+    async_installations_service,
+    async_created_installation_invite,
+    installation_modules,
+):
+    invitation_payload = decode_invitation_payload(
+        async_created_installation_invite.invitation.url,
+    )
+    if not invitation_payload.get("installationId") == async_created_installation_invite.id:
+        raise ValueError(
+            f"Installation ID mismatch: expected {async_created_installation_invite.id}, "
+            f"got {invitation_payload.get('installationId')}"
+        )
+
+    redeem_invitation_data = {
+        "code": invitation_payload["code"],
+        "modules": installation_modules,
+    }
+
+    result = await async_installations_service.redeem(
+        async_created_installation_invite.id,
+        redeem_invitation_data,
+    )
+
+    assert result.id == async_created_installation_invite.id
+
+
+async def test_delete_installation(async_installations_service, async_created_installation):
+    await async_installations_service.delete(async_created_installation.id)  # act

--- a/tests/e2e/integration/installations/test_sync_installations.py
+++ b/tests/e2e/integration/installations/test_sync_installations.py
@@ -1,0 +1,54 @@
+import pytest
+
+from tests.e2e.helper import assert_service_filter_with_iterate
+from tests.e2e.integration.installations.helper import decode_invitation_payload
+
+pytestmark = [
+    pytest.mark.flaky,
+]
+
+
+def test_get_installation(installations_service, created_installation_invite):
+    result = installations_service.get(created_installation_invite.id)
+
+    assert result.id == created_installation_invite.id
+
+
+def test_filter_installations(installations_service, created_installation_invite):
+    assert_service_filter_with_iterate(
+        installations_service, created_installation_invite.id, None
+    )  # act
+
+
+def test_create_installation(created_installation, created_installation_invite, invite_data):
+    result = created_installation.extension
+
+    assert result.id == invite_data["extension"]["id"]
+
+
+def test_redeem_installation(
+    installations_service,
+    created_installation_invite,
+    installation_modules,
+):
+    invitation_payload = decode_invitation_payload(created_installation_invite.invitation.url)
+    if invitation_payload.get("installationId") != created_installation_invite.id:
+        raise ValueError(
+            f"Installation ID mismatch: expected {created_installation_invite.id}, "
+            f"got {invitation_payload.get('installationId')}"
+        )
+    redeem_invitation_data = {
+        "code": invitation_payload["code"],
+        "modules": installation_modules,
+    }
+
+    result = installations_service.redeem(
+        created_installation_invite.id,
+        redeem_invitation_data,
+    )
+
+    assert result.id == created_installation_invite.id
+
+
+def test_delete_installation(installations_service, created_installation):
+    installations_service.delete(created_installation.id)  # act

--- a/tests/unit/resources/integration/mixins/test_installation_mixin.py
+++ b/tests/unit/resources/integration/mixins/test_installation_mixin.py
@@ -1,0 +1,91 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.http.async_service import AsyncService
+from mpt_api_client.http.service import Service
+from mpt_api_client.resources.integration.mixins import (
+    AsyncInstallationMixin,
+    InstallationMixin,
+)
+from tests.unit.conftest import DummyModel
+
+
+class DummyInstallationService(
+    InstallationMixin[DummyModel],
+    Service[DummyModel],
+):
+    _endpoint = "/public/v1/integration/installations"
+    _model_class = DummyModel
+    _collection_key = "data"
+
+
+class DummyAsyncInstallationService(
+    AsyncInstallationMixin[DummyModel],
+    AsyncService[DummyModel],
+):
+    _endpoint = "/public/v1/integration/installations"
+    _model_class = DummyModel
+    _collection_key = "data"
+
+
+@pytest.fixture
+def installation_service(http_client):
+    return DummyInstallationService(http_client=http_client)
+
+
+@pytest.fixture
+def async_installation_service(async_http_client):
+    return DummyAsyncInstallationService(http_client=async_http_client)
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["invite", "install", "uninstall", "expire"],
+)
+def test_post_actions(installation_service, action):
+    installation_id = "INS-001"
+    expected_response = {"id": installation_id, "status": "updated"}
+    with respx.mock:
+        mock_route = respx.post(
+            f"https://api.example.com/public/v1/integration/installations/{installation_id}/{action}"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=expected_response,
+            )
+        )
+
+        result = getattr(installation_service, action)(installation_id)
+
+        assert mock_route.call_count == 1
+        assert mock_route.calls[0].request.method == "POST"
+        assert result.to_dict() == expected_response
+        assert isinstance(result, DummyModel)
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["invite", "install", "uninstall", "expire"],
+)
+async def test_async_post_actions(async_installation_service, action):
+    installation_id = "INS-001"
+    expected_response = {"id": installation_id, "status": "updated"}
+    with respx.mock:
+        mock_route = respx.post(
+            f"https://api.example.com/public/v1/integration/installations/{installation_id}/{action}"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.OK,
+                headers={"content-type": "application/json"},
+                json=expected_response,
+            )
+        )
+
+        result = await getattr(async_installation_service, action)(installation_id)
+
+        assert mock_route.call_count == 1
+        assert mock_route.calls[0].request.method == "POST"
+        assert result.to_dict() == expected_response
+        assert isinstance(result, DummyModel)

--- a/tests/unit/resources/integration/mixins/test_installation_mixin.py
+++ b/tests/unit/resources/integration/mixins/test_installation_mixin.py
@@ -39,16 +39,13 @@ def async_installation_service(async_http_client):
     return DummyAsyncInstallationService(http_client=async_http_client)
 
 
-@pytest.mark.parametrize(
-    "action",
-    ["invite", "install", "uninstall", "expire"],
-)
-def test_post_actions(installation_service, action):
+def test_redeem(installation_service):
     installation_id = "INS-001"
-    expected_response = {"id": installation_id, "status": "updated"}
+    expected_response = {"id": installation_id, "status": "Installed"}
+    payload = {"code": "ABC123", "modules": [{"id": "MOD-001"}]}
     with respx.mock:
         mock_route = respx.post(
-            f"https://api.example.com/public/v1/integration/installations/{installation_id}/{action}"
+            f"https://api.example.com/public/v1/integration/installations/{installation_id}/redeem"
         ).mock(
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,
@@ -57,24 +54,24 @@ def test_post_actions(installation_service, action):
             )
         )
 
-        result = getattr(installation_service, action)(installation_id)
+        result = installation_service.redeem(installation_id, payload)
 
         assert mock_route.call_count == 1
         assert mock_route.calls[0].request.method == "POST"
+        assert (
+            mock_route.calls[0].request.content == b'{"code":"ABC123","modules":[{"id":"MOD-001"}]}'
+        )
         assert result.to_dict() == expected_response
         assert isinstance(result, DummyModel)
 
 
-@pytest.mark.parametrize(
-    "action",
-    ["invite", "install", "uninstall", "expire"],
-)
-async def test_async_post_actions(async_installation_service, action):
+async def test_async_redeem(async_installation_service):
     installation_id = "INS-001"
-    expected_response = {"id": installation_id, "status": "updated"}
+    expected_response = {"id": installation_id, "status": "Installed"}
+    payload = {"code": "ABC123", "modules": [{"id": "MOD-001"}]}
     with respx.mock:
         mock_route = respx.post(
-            f"https://api.example.com/public/v1/integration/installations/{installation_id}/{action}"
+            f"https://api.example.com/public/v1/integration/installations/{installation_id}/redeem"
         ).mock(
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,
@@ -83,9 +80,12 @@ async def test_async_post_actions(async_installation_service, action):
             )
         )
 
-        result = await getattr(async_installation_service, action)(installation_id)
+        result = await async_installation_service.redeem(installation_id, payload)
 
         assert mock_route.call_count == 1
         assert mock_route.calls[0].request.method == "POST"
+        assert (
+            mock_route.calls[0].request.content == b'{"code":"ABC123","modules":[{"id":"MOD-001"}]}'
+        )
         assert result.to_dict() == expected_response
         assert isinstance(result, DummyModel)

--- a/tests/unit/resources/integration/test_installations.py
+++ b/tests/unit/resources/integration/test_installations.py
@@ -1,0 +1,114 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.integration.installations import (
+    AsyncInstallationsService,
+    Installation,
+    InstallationsService,
+)
+
+
+@pytest.fixture
+def installations_service(http_client):
+    return InstallationsService(http_client=http_client)
+
+
+@pytest.fixture
+def async_installations_service(async_http_client):
+    return AsyncInstallationsService(http_client=async_http_client)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "invite",
+        "install",
+        "uninstall",
+        "expire",
+        "iterate",
+    ],
+)
+def test_mixins_present(installations_service, method):
+    result = hasattr(installations_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get",
+        "create",
+        "update",
+        "delete",
+        "invite",
+        "install",
+        "uninstall",
+        "expire",
+        "iterate",
+    ],
+)
+def test_async_mixins_present(async_installations_service, method):
+    result = hasattr(async_installations_service, method)
+
+    assert result is True
+
+
+@pytest.fixture
+def installation_data():
+    return {
+        "id": "INS-001",
+        "name": "My Installation",
+        "revision": 2,
+        "account": {"id": "ACC-001", "name": "Account"},
+        "extension": {"id": "EXT-001", "name": "Extension"},
+        "status": "Installed",
+        "configuration": {"key": "value"},
+        "invitation": {"url": "https://example.com/invite"},
+        "modules": [{"id": "MOD-001"}],
+        "terms": [{"id": "TERM-001"}],
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+def test_installation_primitive_fields(installation_data):
+    result = Installation(installation_data)
+
+    assert result.id == "INS-001"
+    assert result.name == "My Installation"
+    assert result.revision == 2
+    assert result.status == "Installed"
+
+
+def test_installation_nested_fields(installation_data):
+    result = Installation(installation_data)
+
+    assert isinstance(result.account, BaseModel)
+    assert isinstance(result.extension, BaseModel)
+    assert isinstance(result.configuration, BaseModel)
+    assert isinstance(result.invitation, BaseModel)
+    assert isinstance(result.audit, BaseModel)
+
+
+def test_installation_create(installations_service):
+    installation_data = {
+        "extension": {"id": "EXT-001"},
+        "account": {"id": "ACC-001"},
+    }
+    expected_response = {"id": "INS-001", "name": "My Installation", "status": "Invited"}
+    with respx.mock:
+        mock_route = respx.post("https://api.example.com/public/v1/integration/installations").mock(
+            return_value=httpx.Response(httpx.codes.CREATED, json=expected_response)
+        )
+
+        result = installations_service.create(installation_data)
+
+    assert mock_route.call_count == 1
+    assert mock_route.calls[0].request.method == "POST"
+    assert result.to_dict() == expected_response

--- a/tests/unit/resources/integration/test_installations.py
+++ b/tests/unit/resources/integration/test_installations.py
@@ -27,10 +27,7 @@ def async_installations_service(async_http_client):
         "create",
         "update",
         "delete",
-        "invite",
-        "install",
-        "uninstall",
-        "expire",
+        "redeem",
         "iterate",
     ],
 )
@@ -47,10 +44,7 @@ def test_mixins_present(installations_service, method):
         "create",
         "update",
         "delete",
-        "invite",
-        "install",
-        "uninstall",
-        "expire",
+        "redeem",
         "iterate",
     ],
 )

--- a/tests/unit/resources/integration/test_integration.py
+++ b/tests/unit/resources/integration/test_integration.py
@@ -8,6 +8,10 @@ from mpt_api_client.resources.integration.extensions import (
     AsyncExtensionsService,
     ExtensionsService,
 )
+from mpt_api_client.resources.integration.installations import (
+    AsyncInstallationsService,
+    InstallationsService,
+)
 from mpt_api_client.resources.integration.integration import (
     AsyncIntegration,
     Integration,
@@ -43,6 +47,7 @@ def test_async_integration_initialization(async_http_client):
     [
         ("extensions", ExtensionsService),
         ("categories", CategoriesService),
+        ("installations", InstallationsService),
     ],
 )
 def test_integration_properties(integration, property_name, expected_service_class):
@@ -57,6 +62,7 @@ def test_integration_properties(integration, property_name, expected_service_cla
     [
         ("extensions", AsyncExtensionsService),
         ("categories", AsyncCategoriesService),
+        ("installations", AsyncInstallationsService),
     ],
 )
 def test_async_integration_properties(async_integration, property_name, expected_service_class):


### PR DESCRIPTION
## Summary

Implements the `/public/v1/integration/installations` endpoint group as part of MPT-13310.

### Changes
- `mpt_api_client/resources/integration/installations.py` — `InstallationsService` / `AsyncInstallationsService`
- `mpt_api_client/resources/integration/mixins/installation_mixin.py` — lifecycle actions: invite, install, uninstall, expire
- Updated `integration.py` to expose `installations` property
- Unit tests: `tests/unit/resources/integration/test_installations.py` + `test_installation_mixin.py`
- E2e tests: `tests/e2e/integration/installations/`

### Depends on
#277 (MPT-19892 — rename extensibility → integration)

> ⚠️ **Draft** — targets `MPT-19892/e2e-extension-base-service` until PR #277 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19908](https://softwareone.atlassian.net/browse/MPT-19908)

- Add InstallationsService and AsyncInstallationsService for /public/v1/integration/installations
- Introduce Installation model (id, name, revision, account, extension, status, configuration, invitation, modules, terms, audit)
- Add InstallationMixin and AsyncInstallationMixin exposing redeem lifecycle action
- Expose installations property on Integration and AsyncIntegration
- Add unit tests for installations service, installation mixin, and Integration/AsyncIntegration properties
- Add e2e tests and fixtures for installations (sync and async) covering create/get/filter/redeem/delete flows
- Add helper for decoding invitation payloads used by e2e tests
- Update e2e_config.test.json: set integration.extension.id = EXT-6587-4477 and add integration.installation.id = EXI-0022-3978-5547
- Update e2e fixtures to source extension clients from mpt_vendor and unskip several extension e2e tests (create/update/delete/download_icon)
- Update pyproject.toml flake8 per-file-ignores for new e2e installation tests
- Draft PR depends on PR #277 (MPT-19892 — rename extensibility → integration); currently targets MPT-19892/e2e-extension-base-service until merged
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19908]: https://softwareone.atlassian.net/browse/MPT-19908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ