### PR TITLE
MPT-19904: add /integration/extensions/{id}/documents service

### DIFF
--- a/mpt_api_client/resources/integration/extension_documents.py
+++ b/mpt_api_client/resources/integration/extension_documents.py
@@ -1,0 +1,79 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncCreateFileMixin,
+    AsyncModifiableResourceMixin,
+    CollectionMixin,
+    CreateFileMixin,
+    ModifiableResourceMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.integration.mixins import (
+    AsyncPublishableMixin,
+    PublishableMixin,
+)
+
+
+class ExtensionDocument(Model):
+    """Extension Document resource.
+
+    Attributes:
+        name: Document name.
+        revision: Revision number.
+        type: Document type (Online or File).
+        description: Document description.
+        status: Document status (Draft, Published, Unpublished, Deleted).
+        filename: Original file name.
+        size: File size in bytes.
+        content_type: MIME content type.
+        url: URL to access the document.
+        language: Language code.
+        extension: Reference to the extension.
+        audit: Audit information (created, updated, published, unpublished).
+    """
+
+    name: str | None
+    revision: int | None
+    type: str | None
+    description: str | None
+    status: str | None
+    filename: str | None
+    size: int | None
+    content_type: str | None
+    url: str | None
+    language: str | None
+    extension: BaseModel | None
+    audit: BaseModel | None
+
+
+class ExtensionDocumentsServiceConfig:
+    """Extension Documents service configuration."""
+
+    _endpoint = "/public/v1/integration/extensions/{extension_id}/documents"
+    _model_class = ExtensionDocument
+    _collection_key = "data"
+    _upload_file_key = "file"
+    _upload_data_key = "document"
+
+
+class ExtensionDocumentsService(
+    PublishableMixin[ExtensionDocument],
+    CreateFileMixin[ExtensionDocument],
+    ModifiableResourceMixin[ExtensionDocument],
+    CollectionMixin[ExtensionDocument],
+    Service[ExtensionDocument],
+    ExtensionDocumentsServiceConfig,
+):
+    """Sync service for /public/v1/integration/extensions/{extensionId}/documents endpoint."""
+
+
+class AsyncExtensionDocumentsService(
+    AsyncPublishableMixin[ExtensionDocument],
+    AsyncCreateFileMixin[ExtensionDocument],
+    AsyncModifiableResourceMixin[ExtensionDocument],
+    AsyncCollectionMixin[ExtensionDocument],
+    AsyncService[ExtensionDocument],
+    ExtensionDocumentsServiceConfig,
+):
+    """Async service for /public/v1/integration/extensions/{extensionId}/documents endpoint."""

--- a/mpt_api_client/resources/integration/extension_documents.py
+++ b/mpt_api_client/resources/integration/extension_documents.py
@@ -2,9 +2,11 @@ from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import (
     AsyncCollectionMixin,
     AsyncCreateFileMixin,
+    AsyncDownloadFileMixin,
     AsyncModifiableResourceMixin,
     CollectionMixin,
     CreateFileMixin,
+    DownloadFileMixin,
     ModifiableResourceMixin,
 )
 from mpt_api_client.models import Model
@@ -59,6 +61,7 @@ class ExtensionDocumentsServiceConfig:
 
 class ExtensionDocumentsService(
     PublishableMixin[ExtensionDocument],
+    DownloadFileMixin[ExtensionDocument],
     CreateFileMixin[ExtensionDocument],
     ModifiableResourceMixin[ExtensionDocument],
     CollectionMixin[ExtensionDocument],
@@ -70,6 +73,7 @@ class ExtensionDocumentsService(
 
 class AsyncExtensionDocumentsService(
     AsyncPublishableMixin[ExtensionDocument],
+    AsyncDownloadFileMixin[ExtensionDocument],
     AsyncCreateFileMixin[ExtensionDocument],
     AsyncModifiableResourceMixin[ExtensionDocument],
     AsyncCollectionMixin[ExtensionDocument],

--- a/mpt_api_client/resources/integration/extensions.py
+++ b/mpt_api_client/resources/integration/extensions.py
@@ -13,6 +13,10 @@ from mpt_api_client.http.mixins import (
 )
 from mpt_api_client.models import Model
 from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.integration.extension_documents import (
+    AsyncExtensionDocumentsService,
+    ExtensionDocumentsService,
+)
 from mpt_api_client.resources.integration.extension_media import (
     AsyncExtensionMediaService,
     ExtensionMediaService,
@@ -106,6 +110,19 @@ class ExtensionsService(
             http_client=self.http_client, endpoint_params={"extension_id": extension_id}
         )
 
+    def documents(self, extension_id: str) -> ExtensionDocumentsService:
+        """Return extension documents service.
+
+        Args:
+            extension_id: Extension ID.
+
+        Returns:
+            ExtensionDocumentsService instance.
+        """
+        return ExtensionDocumentsService(
+            http_client=self.http_client, endpoint_params={"extension_id": extension_id}
+        )
+
 
 class AsyncExtensionsService(
     AsyncExtensionMixin[Extension],
@@ -135,5 +152,18 @@ class AsyncExtensionsService(
             AsyncExtensionMediaService instance.
         """
         return AsyncExtensionMediaService(
+            http_client=self.http_client, endpoint_params={"extension_id": extension_id}
+        )
+
+    def documents(self, extension_id: str) -> AsyncExtensionDocumentsService:
+        """Return async extension documents service.
+
+        Args:
+            extension_id: Extension ID.
+
+        Returns:
+            AsyncExtensionDocumentsService instance.
+        """
+        return AsyncExtensionDocumentsService(
             http_client=self.http_client, endpoint_params={"extension_id": extension_id}
         )

--- a/tests/e2e/integration/extension_documents/conftest.py
+++ b/tests/e2e/integration/extension_documents/conftest.py
@@ -24,14 +24,13 @@ def document_data(short_uuid):
         "name": f"e2e - please delete {short_uuid}",
         "description": "Created by automated E2E tests. Safe to delete.",
         "language": "en-US",
-        "documentType": "Online",
-        "url": "https://example.com/terms",
+        "documentType": "File",
     }
 
 
 @pytest.fixture
-def created_document(extension_documents_service, document_data):
-    document = extension_documents_service.create(document_data)
+def created_document(extension_documents_service, document_data, pdf_fd):
+    document = extension_documents_service.create(document_data, file=pdf_fd)
 
     yield document
 
@@ -42,8 +41,8 @@ def created_document(extension_documents_service, document_data):
 
 
 @pytest.fixture
-async def async_created_document(async_extension_documents_service, document_data):
-    document = await async_extension_documents_service.create(document_data)
+async def async_created_document(async_extension_documents_service, document_data, pdf_fd):
+    document = await async_extension_documents_service.create(document_data, file=pdf_fd)
 
     yield document
 

--- a/tests/e2e/integration/extension_documents/conftest.py
+++ b/tests/e2e/integration/extension_documents/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+
+from mpt_api_client.exceptions import MPTAPIError
+
+
+@pytest.fixture(scope="session")
+def extension_id(e2e_config):
+    return e2e_config["integration.extension.id"]
+
+
+@pytest.fixture
+def extension_documents_service(mpt_vendor, extension_id):
+    return mpt_vendor.integration.extensions.documents(extension_id)
+
+
+@pytest.fixture
+def async_extension_documents_service(async_mpt_vendor, extension_id):
+    return async_mpt_vendor.integration.extensions.documents(extension_id)
+
+
+@pytest.fixture
+def document_data(short_uuid):
+    return {
+        "name": f"e2e - please delete {short_uuid}",
+        "description": "Created by automated E2E tests. Safe to delete.",
+        "language": "en-US",
+        "documentType": "Online",
+        "url": "https://example.com/terms",
+    }
+
+
+@pytest.fixture
+def created_document(extension_documents_service, document_data):
+    document = extension_documents_service.create(document_data)
+
+    yield document
+
+    try:
+        extension_documents_service.delete(document.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete document {document.id}: {error.title}")  # noqa: WPS421
+
+
+@pytest.fixture
+async def async_created_document(async_extension_documents_service, document_data):
+    document = await async_extension_documents_service.create(document_data)
+
+    yield document
+
+    try:
+        await async_extension_documents_service.delete(document.id)
+    except MPTAPIError as error:
+        print(f"TEARDOWN - Unable to delete document {document.id}: {error.title}")  # noqa: WPS421

--- a/tests/e2e/integration/extension_documents/test_async_extension_documents.py
+++ b/tests/e2e/integration/extension_documents/test_async_extension_documents.py
@@ -1,0 +1,53 @@
+import pytest
+
+from tests.e2e.helper import assert_async_service_filter_with_iterate
+
+pytestmark = [
+    pytest.mark.flaky,
+]
+
+
+def test_create_extension_document(async_created_document, document_data):
+    result = async_created_document.name
+
+    assert result == document_data["name"]
+
+
+async def test_filter_extension_documents(
+    async_extension_documents_service, async_created_document
+):
+    await assert_async_service_filter_with_iterate(
+        async_extension_documents_service, async_created_document.id, None
+    )  # act
+
+
+async def test_update_extension_document(
+    async_extension_documents_service, async_created_document, short_uuid
+):
+    update_data = {"name": f"e2e updated {short_uuid}"}
+
+    result = await async_extension_documents_service.update(async_created_document.id, update_data)
+
+    assert result.name == update_data["name"]
+
+
+async def test_publish_extension_document(
+    async_extension_documents_service, async_created_document
+):
+    result = await async_extension_documents_service.publish(async_created_document.id)
+
+    assert result.status == "Published"
+
+
+async def test_unpublish_extension_document(
+    async_extension_documents_service, async_created_document
+):
+    await async_extension_documents_service.publish(async_created_document.id)
+
+    result = await async_extension_documents_service.unpublish(async_created_document.id)
+
+    assert result.status == "Unpublished"
+
+
+async def test_delete_extension_document(async_extension_documents_service, async_created_document):
+    await async_extension_documents_service.delete(async_created_document.id)  # act

--- a/tests/e2e/integration/extension_documents/test_async_extension_documents.py
+++ b/tests/e2e/integration/extension_documents/test_async_extension_documents.py
@@ -39,6 +39,14 @@ async def test_publish_extension_document(
     assert result.status == "Published"
 
 
+async def test_download_extension_document(
+    async_extension_documents_service, async_created_document
+):
+    result = await async_extension_documents_service.download(async_created_document.id)
+
+    assert result.file_contents is not None
+
+
 async def test_unpublish_extension_document(
     async_extension_documents_service, async_created_document
 ):

--- a/tests/e2e/integration/extension_documents/test_sync_extension_documents.py
+++ b/tests/e2e/integration/extension_documents/test_sync_extension_documents.py
@@ -33,6 +33,12 @@ def test_publish_extension_document(extension_documents_service, created_documen
     assert result.status == "Published"
 
 
+def test_download_extension_document(extension_documents_service, created_document):
+    result = extension_documents_service.download(created_document.id)
+
+    assert result.file_contents is not None
+
+
 def test_unpublish_extension_document(extension_documents_service, created_document):
     extension_documents_service.publish(created_document.id)
 

--- a/tests/e2e/integration/extension_documents/test_sync_extension_documents.py
+++ b/tests/e2e/integration/extension_documents/test_sync_extension_documents.py
@@ -1,0 +1,45 @@
+import pytest
+
+from tests.e2e.helper import assert_service_filter_with_iterate
+
+pytestmark = [
+    pytest.mark.flaky,
+]
+
+
+def test_create_extension_document(created_document, document_data):
+    result = created_document.name
+
+    assert result == document_data["name"]
+
+
+def test_filter_extension_documents(extension_documents_service, created_document):
+    assert_service_filter_with_iterate(
+        extension_documents_service, created_document.id, None
+    )  # act
+
+
+def test_update_extension_document(extension_documents_service, created_document, short_uuid):
+    update_data = {"name": f"e2e updated {short_uuid}"}
+
+    result = extension_documents_service.update(created_document.id, update_data)
+
+    assert result.name == update_data["name"]
+
+
+def test_publish_extension_document(extension_documents_service, created_document):
+    result = extension_documents_service.publish(created_document.id)
+
+    assert result.status == "Published"
+
+
+def test_unpublish_extension_document(extension_documents_service, created_document):
+    extension_documents_service.publish(created_document.id)
+
+    result = extension_documents_service.unpublish(created_document.id)
+
+    assert result.status == "Unpublished"
+
+
+def test_delete_extension_document(extension_documents_service, created_document):
+    extension_documents_service.delete(created_document.id)  # act

--- a/tests/unit/resources/integration/test_extension_documents.py
+++ b/tests/unit/resources/integration/test_extension_documents.py
@@ -76,7 +76,7 @@ def test_async_endpoint(async_extension_documents_service) -> None:
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "publish", "unpublish", "iterate"],
+    ["get", "create", "update", "delete", "download", "publish", "unpublish", "iterate"],
 )
 def test_mixins_present(extension_documents_service, method: str) -> None:
     result = hasattr(extension_documents_service, method)
@@ -86,7 +86,7 @@ def test_mixins_present(extension_documents_service, method: str) -> None:
 
 @pytest.mark.parametrize(
     "method",
-    ["get", "create", "update", "delete", "publish", "unpublish", "iterate"],
+    ["get", "create", "update", "delete", "download", "publish", "unpublish", "iterate"],
 )
 def test_async_mixins_present(async_extension_documents_service, method: str) -> None:
     result = hasattr(async_extension_documents_service, method)

--- a/tests/unit/resources/integration/test_extension_documents.py
+++ b/tests/unit/resources/integration/test_extension_documents.py
@@ -1,0 +1,147 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.integration.extension_documents import (
+    AsyncExtensionDocumentsService,
+    ExtensionDocument,
+    ExtensionDocumentsService,
+)
+from mpt_api_client.resources.integration.extensions import (
+    AsyncExtensionsService,
+    ExtensionsService,
+)
+
+
+@pytest.fixture
+def extension_documents_service(http_client) -> ExtensionDocumentsService:
+    return ExtensionDocumentsService(
+        http_client=http_client, endpoint_params={"extension_id": "EXT-001"}
+    )
+
+
+@pytest.fixture
+def async_extension_documents_service(async_http_client) -> AsyncExtensionDocumentsService:
+    return AsyncExtensionDocumentsService(
+        http_client=async_http_client, endpoint_params={"extension_id": "EXT-001"}
+    )
+
+
+@pytest.fixture
+def extensions_service(http_client) -> ExtensionsService:
+    return ExtensionsService(http_client=http_client)
+
+
+@pytest.fixture
+def async_extensions_service(async_http_client) -> AsyncExtensionsService:
+    return AsyncExtensionsService(http_client=async_http_client)
+
+
+@pytest.fixture
+def document_data():
+    return {
+        "id": "DOC-001",
+        "name": "User Guide",
+        "revision": 1,
+        "type": "File",
+        "description": "Extension user guide",
+        "status": "Draft",
+        "filename": "guide.pdf",
+        "size": 4096,
+        "contentType": "application/pdf",
+        "url": "https://example.com/guide.pdf",
+        "language": "en",
+        "extension": {"id": "EXT-001", "name": "My Extension"},
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+def test_endpoint(extension_documents_service) -> None:
+    result = (
+        extension_documents_service.path == "/public/v1/integration/extensions/EXT-001/documents"
+    )
+
+    assert result is True
+
+
+def test_async_endpoint(async_extension_documents_service) -> None:
+    result = (
+        async_extension_documents_service.path
+        == "/public/v1/integration/extensions/EXT-001/documents"
+    )
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "publish", "unpublish", "iterate"],
+)
+def test_mixins_present(extension_documents_service, method: str) -> None:
+    result = hasattr(extension_documents_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "publish", "unpublish", "iterate"],
+)
+def test_async_mixins_present(async_extension_documents_service, method: str) -> None:
+    result = hasattr(async_extension_documents_service, method)
+
+    assert result is True
+
+
+def test_extension_document_primitive_fields(document_data):
+    result = ExtensionDocument(document_data)
+
+    assert result.to_dict() == document_data
+
+
+def test_extension_document_nested_fields(document_data):
+    result = ExtensionDocument(document_data)
+
+    assert isinstance(result.extension, BaseModel)
+    assert isinstance(result.audit, BaseModel)
+
+
+def test_extension_document_optional_absent():
+    result = ExtensionDocument({"id": "DOC-001"})
+
+    assert result.id == "DOC-001"
+    assert not hasattr(result, "name")
+    assert not hasattr(result, "status")
+    assert not hasattr(result, "audit")
+
+
+def test_extension_document_create(extension_documents_service, tmp_path):
+    document_data = {"Name": "User Guide", "Description": "Guide", "Language": "en"}
+    expected_response = {"id": "DOC-001", "name": "User Guide"}
+    file_path = tmp_path / "guide.pdf"
+    file_path.write_bytes(b"fake pdf data")
+    with file_path.open("rb") as doc_file, respx.mock:
+        mock_route = respx.post(
+            "https://api.example.com/public/v1/integration/extensions/EXT-001/documents"
+        ).mock(return_value=httpx.Response(httpx.codes.CREATED, json=expected_response))
+
+        result = extension_documents_service.create(document_data, file=doc_file)
+
+    assert mock_route.call_count == 1
+    assert mock_route.calls[0].request.method == "POST"
+    assert result.to_dict() == expected_response
+
+
+def test_extensions_documents_accessor(extensions_service):
+    result = extensions_service.documents("EXT-001")
+
+    assert isinstance(result, ExtensionDocumentsService)
+    assert result.path == "/public/v1/integration/extensions/EXT-001/documents"
+
+
+def test_async_extensions_documents_accessor(async_extensions_service):
+    result = async_extensions_service.documents("EXT-001")
+
+    assert isinstance(result, AsyncExtensionDocumentsService)
+    assert result.path == "/public/v1/integration/extensions/EXT-001/documents"


### PR DESCRIPTION
## Summary

Implements the `/public/v1/integration/extensions/{extensionId}/documents` endpoint group.

### Changes
- `mpt_api_client/resources/integration/extension_documents.py` — `PublishableMixin` + `CreateFileMixin` + `ModifiableResourceMixin` + `CollectionMixin`
- `mpt_api_client/resources/integration/mixins/publishable_mixin.py` — `publish`/`unpublish` mixin (no `review`; differs from catalog variant)
- `mpt_api_client/resources/integration/extensions.py` — added `documents(extension_id)` accessor to both sync and async services; rebased on `main` (includes MPT-19906 `terms` accessor)
- Unit tests: 100% coverage on all new code
  - `tests/unit/resources/integration/test_extension_documents.py`
  - `tests/unit/resources/integration/mixins/test_publishable_mixin.py`
- E2E tests: `tests/e2e/integration/extension_documents/`

### QA
- `make check-all`: all linting (ruff, flake8, mypy) + 1889 tests pass ✅
- `publishable_mixin.py`: 100% coverage ✅
- `extension_documents.py`: 100% coverage ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19904](https://softwareone.atlassian.net/browse/MPT-19904)

- Implement /public/v1/integration/extensions/{extensionId}/documents with sync and async services
- Add ExtensionDocument model (metadata + file attributes) and ExtensionDocumentsService / AsyncExtensionDocumentsService
- Add PublishableMixin for publish/unpublish (integration variant, no review flow)
- Implement create-file (upload), ModifiableResourceMixin and CollectionMixin behavior for document operations
- Add download support for extension documents
- Expose documents(extension_id) accessor on ExtensionsService and AsyncExtensionsService
- Tests: unit tests (100% coverage for new files) and E2E tests covering create, filter, update, publish, unpublish, download, and delete
- QA: ruff, flake8, mypy checks and test suite run (1889 tests) passed
- Commit: "MPT-19904: add download support and tests for extension documents" (includes Co-authored-by: Copilot)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19904]: https://softwareone.atlassian.net/browse/MPT-19904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ