### PR TITLE
MPT-20245 update fixtures and tests for chat participants, unskip tests

### DIFF
--- a/e2e_config.test.json
+++ b/e2e_config.test.json
@@ -69,5 +69,6 @@
   "notifications.subscriber.id": "NTS-0829-7123-7123",
   "integration.extension.id": "EXT-6587-4477",
   "integration.term.id": "ETC-6587-4477-0062",
-  "program.program.id": "PRG-9643-3741"
+  "program.program.id": "PRG-9643-3741",
+  "notifications.contact.id": "CTT-0001-9158"
 }

--- a/mpt_api_client/models/model.py
+++ b/mpt_api_client/models/model.py
@@ -8,7 +8,8 @@ from mpt_api_client.http.types import Response
 from mpt_api_client.models.meta import Meta
 from mpt_api_client.models.model_collection import ModelCollection
 
-ResourceData = dict[str, Any]
+Resource = dict[str, Any]
+ResourceData = Resource | list[Resource]
 
 
 _SNAKE_CASE_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
@@ -158,7 +159,7 @@ class BaseModel:
         processed_value = self._process_value(value, target_class=target_class)
         object.__setattr__(self, snake_name, processed_value)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Resource:
         """Returns the resource as a dictionary with original API keys."""
         out_dict = {}
 
@@ -219,7 +220,7 @@ class Model(BaseModel):
     id: str
 
     def __init__(
-        self, resource_data: ResourceData | None = None, meta: Meta | None = None, **kwargs: Any
+        self, resource_data: Resource | None = None, meta: Meta | None = None, **kwargs: Any
     ) -> None:
         object.__setattr__(self, "meta", meta)
         data = dict(resource_data or {})

--- a/tests/e2e/helpdesk/chats/participants/conftest.py
+++ b/tests/e2e/helpdesk/chats/participants/conftest.py
@@ -1,10 +1,5 @@
 import pytest
 
-from tests.e2e.helper import (
-    async_create_fixture_resource_and_delete,
-    create_fixture_resource_and_delete,
-)
-
 
 @pytest.fixture
 def chat_participants_service(mpt_ops, created_chat):
@@ -17,27 +12,23 @@ def async_chat_participants_service(async_mpt_ops, created_chat):
 
 
 @pytest.fixture
-def chat_participant_data(account_id, user_id):
-    return {
-        "identity": {"id": user_id},
-        "account": {"id": account_id},
-    }
+def contact_id(e2e_config):
+    return e2e_config["notifications.contact.id"]
+
+
+@pytest.fixture
+def chat_participant_data(contact_id):
+    return {"contact": {"id": contact_id}}
 
 
 @pytest.fixture
 def created_chat_participant(chat_participants_service, chat_participant_data):
-    with create_fixture_resource_and_delete(
-        chat_participants_service, chat_participant_data
-    ) as chat_participant:
-        yield chat_participant
+    return chat_participants_service.create([chat_participant_data])
 
 
 @pytest.fixture
 async def async_created_chat_participant(async_chat_participants_service, chat_participant_data):
-    async with async_create_fixture_resource_and_delete(
-        async_chat_participants_service, chat_participant_data
-    ) as chat_participant:
-        yield chat_participant
+    return await async_chat_participants_service.create([chat_participant_data])
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/helpdesk/chats/participants/test_async_participants.py
+++ b/tests/e2e/helpdesk/chats/participants/test_async_participants.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.models import ModelCollection
 from mpt_api_client.resources.helpdesk.chat_participants import ChatParticipant
 
 pytestmark = [pytest.mark.flaky]
@@ -15,30 +16,35 @@ async def test_list_chat_participants(async_chat_participants_service):
     assert all(isinstance(participant, ChatParticipant) for participant in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")  # noqa: AAA01
-def test_create_chat_participant(async_created_chat_participant):
-    assert isinstance(async_created_chat_participant, ChatParticipant)
+def test_create_chat_participant(async_created_chat_participant, contact_id):  # noqa: AAA01
+    assert isinstance(async_created_chat_participant, ModelCollection)
+    assert all(isinstance(cp, ChatParticipant) for cp in async_created_chat_participant)
+    chat_participants_list = async_created_chat_participant.to_list()
+    assert any(cp["contact"]["id"] == contact_id for cp in chat_participants_list)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")
 async def test_update_chat_participant(
     async_chat_participants_service, async_created_chat_participant
 ):
-    result = await async_chat_participants_service.update(
-        async_created_chat_participant.id,
-        {"status": "Active"},
+    chat_participant = async_created_chat_participant[0].to_dict()
+    new_muted_status = not chat_participant["muted"]
+    chat_participant["muted"] = new_muted_status
+
+    result = await async_chat_participants_service.update(chat_participant["id"], chat_participant)
+
+    assert result.to_dict().get("muted") == new_muted_status
+
+
+async def test_delete_chat_participant(
+    async_chat_participants_service, async_created_chat_participant, contact_id
+):
+    result = next(
+        chat_participant
+        for chat_participant in async_created_chat_participant.to_list()
+        if chat_participant["contact"]["id"] == contact_id
     )
 
-    assert isinstance(result, ChatParticipant)
-
-
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")
-async def test_delete_chat_participant(
-    async_chat_participants_service, async_created_chat_participant
-):
-    result = async_created_chat_participant
-
-    await async_chat_participants_service.delete(result.id)
+    await async_chat_participants_service.delete(result["id"])
 
 
 async def test_update_chat_participant_not_found(

--- a/tests/e2e/helpdesk/chats/participants/test_sync_participants.py
+++ b/tests/e2e/helpdesk/chats/participants/test_sync_participants.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
+from mpt_api_client.models import ModelCollection
 from mpt_api_client.resources.helpdesk.chat_participants import ChatParticipant
 
 pytestmark = [pytest.mark.flaky]
@@ -15,23 +16,31 @@ def test_list_chat_participants(chat_participants_service):
     assert all(isinstance(participant, ChatParticipant) for participant in result)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")  # noqa: AAA01
-def test_create_chat_participant(created_chat_participant):
-    assert isinstance(created_chat_participant, ChatParticipant)
+def test_create_chat_participant(created_chat_participant, contact_id):  # noqa: AAA01
+    assert isinstance(created_chat_participant, ModelCollection)
+    assert all(isinstance(cp, ChatParticipant) for cp in created_chat_participant)
+    chat_participants_list = created_chat_participant.to_list()
+    assert any(cp["contact"]["id"] == contact_id for cp in chat_participants_list)
 
 
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")
 def test_update_chat_participant(chat_participants_service, created_chat_participant):
-    result = chat_participants_service.update(created_chat_participant.id, {"status": "Active"})
+    chat_participant = created_chat_participant[0].to_dict()
+    new_muted_status = not chat_participant["muted"]
+    chat_participant["muted"] = new_muted_status
 
-    assert isinstance(result, ChatParticipant)
+    result = chat_participants_service.update(chat_participant["id"], chat_participant)
+
+    assert result.to_dict().get("muted") == new_muted_status
 
 
-@pytest.mark.skip(reason="Unskip after MPT-20015 completed")
-def test_delete_chat_participant(chat_participants_service, created_chat_participant):
-    result = created_chat_participant
+def test_delete_chat_participant(chat_participants_service, created_chat_participant, contact_id):
+    result = next(
+        chat_participant
+        for chat_participant in created_chat_participant.to_list()
+        if chat_participant["contact"]["id"] == contact_id
+    )
 
-    chat_participants_service.delete(result.id)
+    chat_participants_service.delete(result["id"])
 
 
 def test_update_chat_participant_not_found(chat_participants_service, invalid_chat_participant_id):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20245](https://softwareone.atlassian.net/browse/MPT-20245)

- Add e2e config key notifications.contact.id = "CTT-0001-9158" to e2e_config.test.json
- Replace chat participant fixture inputs (account_id, user_id) with contact_id sourced from e2e_config
- Change chat_participant_data payload to {"contact": {"id": contact_id}}
- Refactor created_chat_participant and async_created_chat_participant fixtures to return create([...]) results (ModelCollection) instead of using create/delete context managers
- Unskip sync and async create/update/delete participant tests
- Update create tests to expect a ModelCollection of ChatParticipant and assert presence by contact.id
- Update update tests to select a participant, convert to dict, toggle "muted", call update with the full payload, and assert muted was updated
- Update delete tests to locate the participant by contact.id in the returned collection and call delete with the returned id
- Introduce Resource = dict[str, Any]; set ResourceData = Resource | list[Resource]; update BaseModel.to_dict() return type and Model.__init__ signature accordingly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20245]: https://softwareone.atlassian.net/browse/MPT-20245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ