### PR TITLE
MPT-13785 remove obsolete skip markers from category tests

### DIFF
--- a/tests/e2e/notifications/categories/test_async_categories.py
+++ b/tests/e2e/notifications/categories/test_async_categories.py
@@ -52,7 +52,6 @@ async def test_filter_categories(async_mpt_vendor, category_id):
     assert result[0].id == category_id
 
 
-@pytest.mark.skip(reason="async_created_category kills performance due to MPT-13785")
 async def test_publish_category(async_mpt_ops, async_created_category):
     service = async_mpt_ops.notifications.categories
     unpublish_note_data = {"note": "Unpublishing category for async testing"}
@@ -64,7 +63,6 @@ async def test_publish_category(async_mpt_ops, async_created_category):
     assert result.id == async_created_category.id
 
 
-@pytest.mark.skip(reason="async_created_category kills performance due to MPT-13785")
 async def test_unpublish_category(async_mpt_ops, async_created_category):
     service = async_mpt_ops.notifications.categories
     unpublish_note_data = {"note": "Unpublishing category for async testing"}

--- a/tests/e2e/notifications/categories/test_sync_categories.py
+++ b/tests/e2e/notifications/categories/test_sync_categories.py
@@ -31,7 +31,6 @@ def test_get_category(mpt_client, category_id):
     assert result.id == category_id
 
 
-@pytest.mark.skip(reason="created_category kills performance due to MPT-13785")
 def test_update_category(mpt_ops, created_category):
     service = mpt_ops.notifications.categories
     update_data = {
@@ -54,7 +53,6 @@ def test_filter_categories(mpt_client, category_id):
     assert result[0].id == category_id
 
 
-@pytest.mark.skip(reason="created_category kills performance due to MPT-13785")
 def test_publish_category(mpt_ops, created_category):
     service = mpt_ops.notifications.categories
     unpublish_note_data = {"note": "Unpublishing category for testing"}
@@ -66,7 +64,6 @@ def test_publish_category(mpt_ops, created_category):
     assert result.id == created_category.id
 
 
-@pytest.mark.skip(reason="created_category kills performance due to MPT-13785")
 def test_unpublish_category(mpt_ops, created_category):
     service = mpt_ops.notifications.categories
     unpublish_note_data = {"note": "Unpublishing category for testing"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-13785](https://softwareone.atlassian.net/browse/MPT-13785)

- Re-enabled previously skipped category tests by removing obsolete @pytest.mark.skip decorators.
- Async tests re-enabled: test_publish_category, test_unpublish_category (tests/e2e/notifications/categories/test_async_categories.py).
- Sync tests re-enabled: test_update_category, test_publish_category, test_unpublish_category (tests/e2e/notifications/categories/test_sync_categories.py).
- No changes to test bodies, assertions, fixtures, or public API signatures; only skip markers were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-13785]: https://softwareone.atlassian.net/browse/MPT-13785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ