### PR TITLE
[MPT-20397] simplify AGENTS entrypoint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,20 @@
 # AGENTS.md
 
+Working protocol for any task in this repository:
+
+1. Identify the task type and select only the local repository files that are relevant to that task.
+2. Read only those relevant local files before making changes.
+3. If any selected local file references shared standards or shared operational guidance that are relevant to the same task, read those shared documents too before proceeding.
+4. Treat repository-local documents as repository-specific additions, restrictions, or overrides to shared guidance.
+5. If a repository-local rule conflicts with a shared rule, the local repository rule takes precedence.
+
 Python API client for the SoftwareONE Marketplace Platform (MPT) API. Provides synchronous
 (`MPTClient`) and asynchronous (`AsyncMPTClient`) clients built on httpx, with typed
 resource services, mixin-based HTTP operations, and an RQL query builder.
 
 ## Documentation Reading Order
+
+When applicable, read the repository documentation in this order:
 
 1. `README.md` — repository overview, quick start, and documentation map
 2. `docs/usage.md` — installation, configuration, Python usage examples, and supported Docker-based commands


### PR DESCRIPTION
## Summary
- adapt the AGENTS entrypoint guidance to a task-based working protocol
- make the repository documentation reading order conditional on task relevance
- keep the local repository guidance focused on selecting only relevant files before changes

## Testing
- not run (documentation-only change)

Closes [MPT-20397](https://softwareone.atlassian.net/browse/MPT-20397)

Source inspiration: https://github.com/softwareone-platform/swo-extension-playground/pull/47


[MPT-20397]: https://softwareone.atlassian.net/browse/MPT-20397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20397](https://softwareone.atlassian.net/browse/MPT-20397)

- Simplify AGENTS entrypoint guidance with a task-based working protocol
- Add "Working protocol for any task" section with ordered steps for selecting relevant local files, reading shared standards when applicable, and applying precedence rules
- Make documentation reading order conditional on task relevance
- Extend documentation sequence with additional guides (local-development.md, testing.md, contributing.md, documentation.md)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->