### PR TITLE
MPT-15431 Add MPTMaxRetryError in the MPT Errors and error handler

### DIFF
--- a/mpt_api_client/exceptions.py
+++ b/mpt_api_client/exceptions.py
@@ -17,6 +17,13 @@ class MPTHttpError(MPTError):
         super().__init__(f"HTTP {status_code}: {message}")
 
 
+class MPTMaxRetryError(MPTError):
+    """Represents an error when maximum retry attempts are exceeded."""
+
+    def __init__(self, message: str, attempts: int):
+        super().__init__(f"{message} error after {attempts} retry attempts.")
+
+
 class MPTAPIError(MPTHttpError):
     """Represents an API error."""
 

--- a/mpt_api_client/http/async_client.py
+++ b/mpt_api_client/http/async_client.py
@@ -1,14 +1,15 @@
 import os
 from typing import Any
 
-from httpx import AsyncClient, HTTPError, HTTPStatusError, RequestError
+from httpx import AsyncClient, HTTPError, RequestError
 from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
-from mpt_api_client.exceptions import MPTError, MPTMaxRetryError, transform_http_status_exception
+from mpt_api_client.exceptions import MPTError, MPTMaxRetryError
 from mpt_api_client.http.client import json_to_file_payload
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
+from mpt_api_client.http.request_response_utils import handle_response_http_error
 from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 
 
@@ -105,10 +106,8 @@ class AsyncHTTPClient:
         except HTTPError as err:
             raise MPTError(f"HTTP Error: {err}") from err
 
-        try:
-            response.raise_for_status()
-        except HTTPStatusError as http_status_exception:
-            raise transform_http_status_exception(http_status_exception) from http_status_exception
+        handle_response_http_error(response)
+
         return Response(
             headers=dict(response.headers),
             status_code=response.status_code,

--- a/mpt_api_client/http/async_client.py
+++ b/mpt_api_client/http/async_client.py
@@ -1,24 +1,15 @@
 import os
 from typing import Any
 
-from httpx import (
-    AsyncClient,
-    AsyncHTTPTransport,
-    HTTPError,
-    HTTPStatusError,
-)
+from httpx import AsyncClient, HTTPError, HTTPStatusError
+from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
 from mpt_api_client.exceptions import MPTError, transform_http_status_exception
 from mpt_api_client.http.client import json_to_file_payload
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
-from mpt_api_client.http.types import (
-    HeaderTypes,
-    QueryParam,
-    RequestFiles,
-    Response,
-)
+from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 
 
 class AsyncHTTPClient:
@@ -32,6 +23,9 @@ class AsyncHTTPClient:
         timeout: float = 20.0,
         retries: int = 5,
     ):
+        retry = Retry(total=retries)
+        transport = RetryTransport(retry=retry)
+
         api_token = api_token or os.getenv("MPT_API_TOKEN")
         if not api_token:
             raise ValueError(
@@ -49,7 +43,7 @@ class AsyncHTTPClient:
             base_url=base_url,
             headers=base_headers,
             timeout=timeout,
-            transport=AsyncHTTPTransport(retries=retries),
+            transport=transport,
             follow_redirects=True,
         )
 

--- a/mpt_api_client/http/async_client.py
+++ b/mpt_api_client/http/async_client.py
@@ -1,11 +1,11 @@
 import os
 from typing import Any
 
-from httpx import AsyncClient, HTTPError, HTTPStatusError
+from httpx import AsyncClient, HTTPError, HTTPStatusError, RequestError
 from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
-from mpt_api_client.exceptions import MPTError, transform_http_status_exception
+from mpt_api_client.exceptions import MPTError, MPTMaxRetryError, transform_http_status_exception
 from mpt_api_client.http.client import json_to_file_payload
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
@@ -23,7 +23,11 @@ class AsyncHTTPClient:
         timeout: float = 20.0,
         retries: int = 5,
     ):
-        retry = Retry(total=retries)
+        self._retries = retries
+        retry = Retry(
+            total=retries,
+            allowed_methods={"DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"},
+        )
         transport = RetryTransport(retry=retry)
 
         api_token = api_token or os.getenv("MPT_API_TOKEN")
@@ -80,6 +84,7 @@ class AsyncHTTPClient:
             MPTError: If the request fails.
             MPTApiError: If the response contains an error.
             MPTHttpError: If the response contains an HTTP error.
+            MPTMaxRetryError: If the request fails after maximum retry attempts.
         """
         files = dict(files or {})
         if force_multipart or (files and json):
@@ -95,6 +100,8 @@ class AsyncHTTPClient:
                 params=params_str or None,
                 headers=headers,
             )
+        except RequestError as err:
+            raise MPTMaxRetryError(str(err), self._retries + 1) from err
         except HTTPError as err:
             raise MPTError(f"HTTP Error: {err}") from err
 

--- a/mpt_api_client/http/client.py
+++ b/mpt_api_client/http/client.py
@@ -2,13 +2,14 @@ import json as json_package
 import os
 from typing import Any
 
-from httpx import Client, HTTPError, HTTPStatusError, RequestError
+from httpx import Client, HTTPError, RequestError
 from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
-from mpt_api_client.exceptions import MPTError, MPTMaxRetryError, transform_http_status_exception
+from mpt_api_client.exceptions import MPTError, MPTMaxRetryError
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
+from mpt_api_client.http.request_response_utils import handle_response_http_error
 from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 from mpt_api_client.models import ResourceData
 
@@ -114,10 +115,8 @@ class HTTPClient:
         except HTTPError as err:
             raise MPTError(f"HTTP Error: {err}") from err
 
-        try:
-            response.raise_for_status()
-        except HTTPStatusError as http_status_exception:
-            raise transform_http_status_exception(http_status_exception) from http_status_exception
+        handle_response_http_error(response)
+
         return Response(
             headers=dict(response.headers),
             status_code=response.status_code,

--- a/mpt_api_client/http/client.py
+++ b/mpt_api_client/http/client.py
@@ -2,11 +2,11 @@ import json as json_package
 import os
 from typing import Any
 
-from httpx import Client, HTTPError, HTTPStatusError
+from httpx import Client, HTTPError, HTTPStatusError, RequestError
 from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
-from mpt_api_client.exceptions import MPTError, transform_http_status_exception
+from mpt_api_client.exceptions import MPTError, MPTMaxRetryError, transform_http_status_exception
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
 from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
@@ -33,7 +33,11 @@ class HTTPClient:
         timeout: float = 20.0,
         retries: int = 5,
     ):
-        retry = Retry(total=retries)
+        self._retries = retries
+        retry = Retry(
+            total=self._retries,
+            allowed_methods={"DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"},
+        )
         transport = RetryTransport(retry=retry)
 
         api_token = api_token or os.getenv("MPT_API_TOKEN")
@@ -105,6 +109,8 @@ class HTTPClient:
                 params=params_str or None,
                 headers=headers,
             )
+        except RequestError as err:
+            raise MPTMaxRetryError(str(err), self._retries + 1) from err
         except HTTPError as err:
             raise MPTError(f"HTTP Error: {err}") from err
 

--- a/mpt_api_client/http/client.py
+++ b/mpt_api_client/http/client.py
@@ -2,26 +2,14 @@ import json as json_package
 import os
 from typing import Any
 
-from httpx import (
-    Client,
-    HTTPError,
-    HTTPStatusError,
-    HTTPTransport,
-)
+from httpx import Client, HTTPError, HTTPStatusError
+from httpx_retries import Retry, RetryTransport
 
 from mpt_api_client.constants import APPLICATION_JSON
-from mpt_api_client.exceptions import (
-    MPTError,
-    transform_http_status_exception,
-)
+from mpt_api_client.exceptions import MPTError, transform_http_status_exception
 from mpt_api_client.http.client_utils import get_query_params, validate_base_url
 from mpt_api_client.http.query_options import QueryOptions
-from mpt_api_client.http.types import (
-    HeaderTypes,
-    QueryParam,
-    RequestFiles,
-    Response,
-)
+from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 from mpt_api_client.models import ResourceData
 
 
@@ -45,6 +33,9 @@ class HTTPClient:
         timeout: float = 20.0,
         retries: int = 5,
     ):
+        retry = Retry(total=retries)
+        transport = RetryTransport(retry=retry)
+
         api_token = api_token or os.getenv("MPT_API_TOKEN")
         if not api_token:
             raise ValueError(
@@ -62,7 +53,7 @@ class HTTPClient:
             base_url=base_url,
             headers=base_headers,
             timeout=timeout,
-            transport=HTTPTransport(retries=retries),
+            transport=transport,
             follow_redirects=True,
         )
 

--- a/mpt_api_client/http/request_response_utils.py
+++ b/mpt_api_client/http/request_response_utils.py
@@ -1,0 +1,12 @@
+from httpx import HTTPStatusError
+from httpx import Response as HTTPXResponse
+
+from mpt_api_client.exceptions import transform_http_status_exception
+
+
+def handle_response_http_error(response: HTTPXResponse) -> None:
+    """Handles HTTP response error by raising a transformed HTTPStatusError exception."""
+    try:
+        response.raise_for_status()
+    except HTTPStatusError as http_status_exception:
+        raise transform_http_status_exception(http_status_exception) from http_status_exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx==0.28.*",
+  "httpx-retries==0.5.*",
 ]
 
 [dependency-groups]

--- a/tests/unit/http/test_async_client.py
+++ b/tests/unit/http/test_async_client.py
@@ -79,10 +79,10 @@ async def test_async_http_call_success(async_http_client, mock_response):
 async def test_async_http_call_failure(async_http_client):
     timeout_route = respx.get(f"{API_URL}/timeout").mock(side_effect=ConnectTimeout("Mock Timeout"))
 
-    with pytest.raises(MPTError, match="HTTP Error: Mock Timeout"):
+    with pytest.raises(MPTError, match=r"Mock Timeout error after 6 retry attempts."):
         await async_http_client.request("GET", "/timeout")
 
-    assert timeout_route.called
+    assert timeout_route.call_count == 6
 
 
 async def test_http_call_with_json_and_files(mocker, async_http_client, mock_httpx_response):  # noqa: WPS210

--- a/tests/unit/http/test_client.py
+++ b/tests/unit/http/test_client.py
@@ -5,7 +5,7 @@ import pytest
 import respx
 from httpx import ConnectTimeout, Response, codes
 
-from mpt_api_client.exceptions import MPTError
+from mpt_api_client.exceptions import MPTMaxRetryError
 from mpt_api_client.http.client import HTTPClient
 from mpt_api_client.http.query_options import QueryOptions
 from tests.unit.conftest import API_TOKEN, API_URL
@@ -71,10 +71,10 @@ def test_http_call_success(http_client):
 def test_http_call_failure(http_client):
     timeout_route = respx.get(f"{API_URL}/timeout").mock(side_effect=ConnectTimeout("Mock Timeout"))
 
-    with pytest.raises(MPTError, match="HTTP Error: Mock Timeout"):
+    with pytest.raises(MPTMaxRetryError, match=r"Mock Timeout error after 6 retry attempts."):
         http_client.request("GET", "/timeout")
 
-    assert timeout_route.called
+    assert timeout_route.call_count == 6
 
 
 def test_http_call_with_json_and_files(mocker, http_client, mock_httpx_response):

--- a/uv.lock
+++ b/uv.lock
@@ -564,6 +564,18 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-retries"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/f5/046cac13877ce9b55aebdbb3999e0e45b19b989a95c5fd1040fa04bd1f92/httpx_retries-0.5.0.tar.gz", hash = "sha256:d8c8e1e0852d84be3837aba0bcf78aeb89a4b77db95e8cc988c8c058830b3044", size = 15647, upload-time = "2026-04-20T01:21:47.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/a8/aadeaa9a28510727d538636ee8688f0782a98523147852b29404ce696f1b/httpx_retries-0.5.0-py3-none-any.whl", hash = "sha256:d3124592979a9dc6197e666d1f02e9ab996a0c58fce59fad8db6201a6a87304e", size = 8908, upload-time = "2026-04-20T01:21:46.157Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -735,6 +747,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx-retries" },
 ]
 
 [package.dev-dependencies]
@@ -767,7 +780,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", specifier = "==0.28.*" }]
+requires-dist = [
+    { name = "httpx", specifier = "==0.28.*" },
+    { name = "httpx-retries", specifier = "==0.5.*" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-15431](https://softwareone.atlassian.net/browse/MPT-15431)

- Add MPTMaxRetryError (subclass of MPTError) with constructor (message: str, attempts: int) to signal retry exhaustion
- Switch HTTP clients to httpx-retries (Retry / RetryTransport) and store configured retry count on clients
- HTTPClient and AsyncHTTPClient now catch httpx.RequestError and raise MPTMaxRetryError including attempt count
- Replace direct response.raise_for_status() handling with new handle_response_http_error(response) helper that transforms HTTPStatusError into domain exceptions
- Add httpx-retries==0.5.* to pyproject.toml
- Update unit tests to expect MPTMaxRetryError and assert retry attempt counts for timeout scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-15431]: https://softwareone.atlassian.net/browse/MPT-15431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ