### PR TITLE
MPT-20587 update cron schedule for e2e tests

### DIFF
--- a/.github/workflows/cron-main-e2e.yml
+++ b/.github/workflows/cron-main-e2e.yml
@@ -1,7 +1,7 @@
 name: daily-e2e.yml
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 1,4'
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20587](https://softwareone.atlassian.net/browse/MPT-20587)

- Updated the E2E test workflow cron schedule to run on Mondays and Thursdays at 08:00 UTC instead of daily

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20587]: https://softwareone.atlassian.net/browse/MPT-20587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ