### PR TITLE
MPT-20694: include certificate in order factory payload

### DIFF
--- a/tests/e2e/commerce/order/conftest.py
+++ b/tests/e2e/commerce/order/conftest.py
@@ -9,7 +9,9 @@ def invalid_order_id():
 
 @pytest.fixture
 @freeze_time("2025-12-01T10:00:00.000Z")
-def order_factory(licensee_id, commerce_product_id, commerce_item_id, authorization_id):
+def order_factory(
+    licensee_id, commerce_product_id, commerce_item_id, authorization_id, certificate_id
+):
     def factory(
         notes: str = "E2E Created Order",
         line_item_period: str = "1y",
@@ -49,6 +51,7 @@ def order_factory(licensee_id, commerce_product_id, commerce_item_id, authorizat
                     "quantity": line_quantity,
                 }
             ],
+            "certificates": [{"id": certificate_id}],
         }
 
     return factory

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -179,3 +179,8 @@ def user_group_id(e2e_config):
 @pytest.fixture(scope="session")
 def commerce_product_id(e2e_config):
     return e2e_config["commerce.product.id"]
+
+
+@pytest.fixture
+def certificate_id(e2e_config):
+    return e2e_config["program.certificate.id"]

--- a/tests/e2e/program/certificate/conftest.py
+++ b/tests/e2e/program/certificate/conftest.py
@@ -2,11 +2,6 @@ import pytest
 
 
 @pytest.fixture
-def certificate_id(e2e_config):
-    return e2e_config["program.certificate.id"]
-
-
-@pytest.fixture
 def invalid_certificate_id():
     return "CER-0000-0000-0000"
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary
Fixes the flaky commerce order e2e tests that were failing during setup with `400 Cannot update agreement on setup`. The upstream API now requires a `certificates` reference on the agreement when an order is created, so the order factory was producing an invalid payload.

## Changes
- `tests/e2e/commerce/order/conftest.py` — add `certificate_id` to the `order_factory` signature and include `"certificates": [{"id": certificate_id}]` in the order payload.
- `tests/e2e/conftest.py` — promote the `certificate_id` fixture to the shared e2e conftest so it is available to fixtures outside the `program.certificate` scope.
- `tests/e2e/program/certificate/conftest.py` — remove the now-redundant local `certificate_id` fixture.

## Testing
- e2e commerce order suite (sync + async) to confirm the 400 on setup is gone.
- Existing program certificate e2e tests still pass (fixture moved, not removed).

## Jira
MPT-20694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20694](https://softwareone.atlassian.net/browse/MPT-20694)

## Changes

- Updated `order_factory` fixture to accept a `certificate_id` parameter and include a `certificates` field in the constructed order payload
- Promoted `certificate_id` fixture from `tests/e2e/program/certificate/conftest.py` to `tests/e2e/conftest.py` to make it available across all e2e test scopes
- Removed the local `certificate_id` fixture from `tests/e2e/program/certificate/conftest.py` after moving it to the shared e2e configuration

## Impact

Resolves flaky commerce order e2e test setup failures by ensuring orders include the required certificate reference in the payload as mandated by the upstream API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20694]: https://softwareone.atlassian.net/browse/MPT-20694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ