### PR TITLE
MPT-21555: Add shortDescription to queue_data function

### DIFF
--- a/tests/e2e/helpdesk/conftest.py
+++ b/tests/e2e/helpdesk/conftest.py
@@ -11,6 +11,7 @@ def queue_data(short_uuid):
     return {
         "name": f"E2E Queue {short_uuid}",
         "description": "E2E Created Helpdesk Queue",
+        "shortDescription": "E2E Created Queue",
         "internal": False,
     }
 


### PR DESCRIPTION
JIRA Ticket: https://softwareone.atlassian.net/browse/MPT-21555

Add "short description" as it is mandatory field when creating queues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21555](https://softwareone.atlassian.net/browse/MPT-21555)

- Added `shortDescription` field to the `queue_data` fixture in `tests/e2e/helpdesk/conftest.py` to include the mandatory field required when creating queues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-api-python-client/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21555]: https://softwareone.atlassian.net/browse/MPT-21555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ