### PR TITLE
MPT-21850 track shared CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Updated `.coderabbit.yaml` to use the shared CodeRabbit configuration directly from `softwareone-platform/mpt-extension-skills`.
- Removed the intermediate remote config reference through `swo-extension-playground`.
- Matched the current playground template update from MPT-21850.

## Testing
- Parsed `.coderabbit.yaml` successfully with Ruby YAML.
- Verified the shared raw GitHub URL returns CodeRabbit YAML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

## Changes

- Updated `.coderabbit.yaml` to reference shared CodeRabbit configuration directly from `softwareone-platform/mpt-extension-skills` repository instead of the intermediate `swo-extension-playground` reference
- Changed `remote_config.url` from `https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml` to `https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21850]: https://softwareone.atlassian.net/browse/MPT-21850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ