### PR TITLE
MPT-21857 pin SonarCloud scan action version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
       run: make check-all
 
     - name: "Run SonarCloud Scan"
-      uses: SonarSource/sonarqube-scan-action@master
+      uses: SonarSource/sonarqube-scan-action@v8.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-release-branch.yml
+++ b/.github/workflows/push-release-branch.yml
@@ -48,7 +48,7 @@ jobs:
         RP_LAUNCH_ATTR: ref:${{ github.ref }} event_name:${{ github.event_name }}
 
     - name: "Run SonarCloud Scan"
-      uses: SonarSource/sonarqube-scan-action@master
+      uses: SonarSource/sonarqube-scan-action@v8.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Pinned SonarSource/sonarqube-scan-action to v8.0.0 in PR validation workflow.
- Pinned SonarSource/sonarqube-scan-action to v8.0.0 in main/release push workflow.
- Verified every GitHub Actions uses reference under .github/workflows is versioned and no longer points to master/main.

## Testing
- make check-all