### PR TITLE
MPT-21557 handle orphaned parameter during parameter creation in sync and async tests

### DIFF
--- a/tests/e2e/program/program/parameter/conftest.py
+++ b/tests/e2e/program/program/parameter/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+EXTERNAL_ID = "e2eCreatedProgramParameter"
+
 
 @pytest.fixture
 def parameter_id(e2e_config):
@@ -14,7 +16,7 @@ def invalid_parameter_id():
 @pytest.fixture
 def parameter_data():
     return {
-        "externalId": "e2eCreatedProgramParameter",
+        "externalId": EXTERNAL_ID,
         "displayOrder": 100,
         "scope": "Enrollment",
         "phase": "Fulfillment",

--- a/tests/e2e/program/program/parameter/test_async_parameter.py
+++ b/tests/e2e/program/program/parameter/test_async_parameter.py
@@ -2,6 +2,7 @@ import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
 from mpt_api_client.rql.query_builder import RQLQuery
+from tests.e2e.program.program.parameter.conftest import EXTERNAL_ID
 
 pytestmark = [pytest.mark.flaky]
 
@@ -9,7 +10,19 @@ pytestmark = [pytest.mark.flaky]
 @pytest.fixture
 async def created_parameter(async_mpt_vendor, program_id, parameter_data):
     service = async_mpt_vendor.program.programs.parameters(program_id)
-    parameter = await service.create(parameter_data)
+    try:
+        parameter = await service.create(parameter_data)
+    except MPTAPIError as error:
+        if (
+            error.status_code == 400
+            and error.detail
+            and f"Parameter with given external identifier '{EXTERNAL_ID}' already "
+            "exists for given program."
+            in error.detail
+        ):
+            parameter = await service.filter(RQLQuery(externalId=EXTERNAL_ID)).fetch_one()
+        else:
+            raise
     yield parameter
     try:
         await service.delete(parameter.id)

--- a/tests/e2e/program/program/parameter/test_sync_parameter.py
+++ b/tests/e2e/program/program/parameter/test_sync_parameter.py
@@ -2,6 +2,7 @@ import pytest
 
 from mpt_api_client.exceptions import MPTAPIError
 from mpt_api_client.rql.query_builder import RQLQuery
+from tests.e2e.program.program.parameter.conftest import EXTERNAL_ID
 
 pytestmark = [pytest.mark.flaky]
 
@@ -9,7 +10,19 @@ pytestmark = [pytest.mark.flaky]
 @pytest.fixture
 def created_parameter(mpt_vendor, program_id, parameter_data):
     service = mpt_vendor.program.programs.parameters(program_id)
-    parameter = service.create(parameter_data)
+    try:
+        parameter = service.create(parameter_data)
+    except MPTAPIError as error:
+        if (
+            error.status_code == 400
+            and error.detail
+            and f"Parameter with given external identifier '{EXTERNAL_ID}' already "
+            "exists for given program."
+            in error.detail
+        ):
+            parameter = service.filter(RQLQuery(externalId=EXTERNAL_ID)).fetch_one()
+        else:
+            raise
     yield parameter
     try:
         service.delete(parameter.id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21557](https://softwareone.atlassian.net/browse/MPT-21557)

## Release Notes

- Add EXTERNAL_ID constant to tests/e2e/program/program/parameter/conftest.py and use it in the parameter_data fixture.
- Update created_parameter fixture in both sync and async tests to catch MPTAPIError during creation.
- On HTTP 400 errors indicating a parameter with the same external identifier already exists, fetch the existing parameter via service.filter(RQLQuery(externalId=EXTERNAL_ID)).fetch_one() instead of failing.
- Preserve teardown behavior: attempt to delete the created/found parameter and log if deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21557]: https://softwareone.atlassian.net/browse/MPT-21557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ