### PR TITLE
MPT-21922 finalize helpdesk queues/cases on E2E teardown (+ _process_value refactor)

### DIFF
--- a/mpt_api_client/models/model.py
+++ b/mpt_api_client/models/model.py
@@ -113,6 +113,24 @@ class ModelList(UserList[Any]):
         return item
 
 
+def _build_model_from_dict(value: Resource, target_class: Any) -> "BaseModel":
+    """Builds a BaseModel (or target subclass) from a raw dict value."""
+    if target_class and isinstance(target_class, type) and issubclass(target_class, BaseModel):
+        model_class: type[BaseModel] = target_class
+        return model_class(**value)
+    return BaseModel(**value)
+
+
+def _resolve_list_model_class(target_class: Any) -> type["BaseModel"]:
+    """Resolves the element model class for a list-typed field from its type hint."""
+    if not target_class or get_origin(target_class) is not list:
+        return BaseModel
+    args = get_args(target_class)
+    if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):  # noqa: WPS221
+        return args[0]
+    return BaseModel
+
+
 class BaseModel:
     """Base dataclass for models providing object-only access and case conversion."""
 
@@ -183,34 +201,13 @@ class BaseModel:
             return [self._serialize_value(item) for item in value]
         return value
 
-    def _process_value(self, value: Any, target_class: Any = None) -> Any:  # noqa: WPS231 C901
+    def _process_value(self, value: Any, target_class: Any = None) -> Any:
         """Recursively processes values to ensure nested dicts are BaseModels."""
         if isinstance(value, dict) and not isinstance(value, BaseModel):
-            # If a target class is provided and it's a subclass of BaseModel, use it
-            if (
-                target_class
-                and isinstance(target_class, type)
-                and issubclass(target_class, BaseModel)
-            ):
-                return target_class(**value)
-            return BaseModel(**value)
-
+            return _build_model_from_dict(value, target_class)
         if isinstance(value, (list, UserList)) and not isinstance(value, ModelList):
-            # Try to determine the model class for the list elements from type hints
-            model_class = BaseModel
-            if target_class:
-                # Handle list[ModelClass]
-
-                origin = get_origin(target_class)
-                if origin is list:
-                    args = get_args(target_class)
-                    if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):  # noqa: WPS221
-                        model_class = args[0]  # noqa: WPS220
-
-            return ModelList(value, model_class=model_class)
-        # Recursively handle BaseModel if it's already one
-        if isinstance(value, BaseModel):
-            return value
+            return ModelList(value, model_class=_resolve_list_model_class(target_class))
+        # Already a BaseModel or a scalar: nothing to convert.
         return value
 
 


### PR DESCRIPTION
This branch carries two changes under MPT-21922.

---

## 1. MPT-21922 — E2E helpdesk teardown cleanup (the ticket)

**Bug:** *"[E2E] Queue and Case Status update upon test completions — when test completed, update queue status to disabled and case status to completed."* (reported by John McDonnell)

E2E helpdesk fixtures left resources in non-terminal states after a test:

- `created_case` / `async_created_case` had **no teardown at all**, and `CasesService` has no delete — so every run left cases lingering open.
- `created_queue` tore down via **delete**, but `case_data` attaches a case to that queue; deleting a queue with an active case fails (the "TEARDOWN - Unable to delete" path), leaving the queue active too.

**Fix** (`tests/e2e/helper.py`, `tests/e2e/helpdesk/conftest.py`):

- Add `create_fixture_resource_and_finalize` + `async_create_fixture_resource_and_finalize`, mirroring the existing delete-teardown context managers but invoking a terminal-state transition best-effort (errors logged, never raised — same convention as the delete helpers).
- Wire helpdesk fixtures: **queues are disabled** and **cases are completed** on teardown. Fixture ordering means the case is completed before its queue is disabled. Forms and parameters keep their existing delete teardown.

> Note: these are E2E tests against the live MPT API, so they require credentials to execute and were not run as part of this change. Verified via `make check` and `pytest --collect-only` (32 tests collect cleanly). Teardown is best-effort, so a case that can't reach `Completed` from its current state logs and moves on rather than failing the test.

---

## 2. `_process_value` cognitive-complexity refactor

Refactors `BaseModel._process_value` in `mpt_api_client/models/model.py` to reduce its Cognitive Complexity from **18** to **~4** (allowed: 15), flagged by SonarQube.

The dict- and list-conversion branches are extracted into two flat module-level helpers (`_build_model_from_dict`, `_resolve_list_model_class`), removing the nesting that drove the score. Behaviour is unchanged; the redundant trailing `isinstance(value, BaseModel)` check folds into the final return. Helpers are kept module-level (matching `to_snake_case`/`to_camel_case`) to avoid tripping WPS214's method-count limit.

---

## Verification

`make check` passes clean for both changes (`ruff format`, `ruff check`, `flake8`/WPS, `mypy`, `uv lock --check`); 118 model unit tests pass; helpdesk E2E suite collects cleanly.