### PR TITLE
MPT-22046 reduce _process_value cognitive complexity below threshold

### DIFF
--- a/mpt_api_client/models/model.py
+++ b/mpt_api_client/models/model.py
@@ -113,6 +113,24 @@ class ModelList(UserList[Any]):
         return item
 
 
+def _build_model_from_dict(value: Resource, target_class: Any) -> "BaseModel":
+    """Builds a BaseModel (or target subclass) from a raw dict value."""
+    if target_class and isinstance(target_class, type) and issubclass(target_class, BaseModel):
+        model_class: type[BaseModel] = target_class
+        return model_class(**value)
+    return BaseModel(**value)
+
+
+def _resolve_list_model_class(target_class: Any) -> type["BaseModel"]:
+    """Resolves the element model class for a list-typed field from its type hint."""
+    if not target_class or get_origin(target_class) is not list:
+        return BaseModel
+    args = get_args(target_class)
+    if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):  # noqa: WPS221
+        return args[0]
+    return BaseModel
+
+
 class BaseModel:
     """Base dataclass for models providing object-only access and case conversion."""
 
@@ -183,34 +201,13 @@ class BaseModel:
             return [self._serialize_value(item) for item in value]
         return value
 
-    def _process_value(self, value: Any, target_class: Any = None) -> Any:  # noqa: WPS231 C901
+    def _process_value(self, value: Any, target_class: Any = None) -> Any:
         """Recursively processes values to ensure nested dicts are BaseModels."""
         if isinstance(value, dict) and not isinstance(value, BaseModel):
-            # If a target class is provided and it's a subclass of BaseModel, use it
-            if (
-                target_class
-                and isinstance(target_class, type)
-                and issubclass(target_class, BaseModel)
-            ):
-                return target_class(**value)
-            return BaseModel(**value)
-
+            return _build_model_from_dict(value, target_class)
         if isinstance(value, (list, UserList)) and not isinstance(value, ModelList):
-            # Try to determine the model class for the list elements from type hints
-            model_class = BaseModel
-            if target_class:
-                # Handle list[ModelClass]
-
-                origin = get_origin(target_class)
-                if origin is list:
-                    args = get_args(target_class)
-                    if args and isinstance(args[0], type) and issubclass(args[0], BaseModel):  # noqa: WPS221
-                        model_class = args[0]  # noqa: WPS220
-
-            return ModelList(value, model_class=model_class)
-        # Recursively handle BaseModel if it's already one
-        if isinstance(value, BaseModel):
-            return value
+            return ModelList(value, model_class=_resolve_list_model_class(target_class))
+        # Already a BaseModel or a scalar: nothing to convert.
         return value
 
 


### PR DESCRIPTION
## What

Refactors `BaseModel._process_value` in `mpt_api_client/models/model.py` to reduce its Cognitive Complexity from **18** to **~4**, under the allowed **15** (SonarQube finding).

The dict- and list-conversion branches are extracted into two flat module-level helpers:

- `_build_model_from_dict(value, target_class)` — builds a `BaseModel`/subclass from a raw dict.
- `_resolve_list_model_class(target_class)` — resolves the element model class for a `list[...]`-typed field via a guard clause instead of three levels of nesting.

`_process_value` is now three flat `if` statements.

## Why

The cost was concentrated in the list branch, where `if target_class → if origin is list → if args and …` reached nesting level 3 (each `if` costs `1 + nesting_depth`). Flattening into helpers removes the nesting penalty. Helpers are kept module-level (matching the existing `to_snake_case`/`to_camel_case` pattern) to avoid pushing `BaseModel` past WPS214's method-count limit.

## Notes for reviewers

- **Behaviour is unchanged.** The old trailing `if isinstance(value, BaseModel): return value` is folded into the final `return value` (both returned the value unchanged).
- The `# noqa: WPS231 C901` suppression on `_process_value` is removed (no longer needed).
- `_build_model_from_dict` narrows `target_class` through a typed local so mypy sees a `BaseModel` return rather than `Any`.

## Verification

`make check` passes clean (`ruff format`, `ruff check`, `flake8`/WPS, `mypy`, `uv lock --check`); 118 model unit tests pass.

## Context

Split out of MPT-21922 — this refactor was originally committed on that bug's branch but is unrelated to it. Tracked under MPT-22046.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22046](https://softwareone.atlassian.net/browse/MPT-22046)

- Refactored `BaseModel._process_value` to reduce Cognitive Complexity from 18 to approximately 4 (below the SonarQube threshold of 15)
- Extracted dict-to-model conversion logic into new private helper `_build_model_from_dict(value, target_class)`
- Extracted list element-type resolution logic into new private helper `_resolve_list_model_class(target_class)`
- Simplified `_process_value` to three flat if statements, improving code readability and maintainability
- Removed noqa suppression comment from `_process_value`
- Preserved existing behavior: all 118 model unit tests pass, and all linting checks (ruff, flake8, WPS, mypy) pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22046]: https://softwareone.atlassian.net/browse/MPT-22046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ