### PR TITLE
MPT-22084 use shortDescription in helpdesk queue fixture

### DIFF
--- a/tests/e2e/helpdesk/conftest.py
+++ b/tests/e2e/helpdesk/conftest.py
@@ -12,7 +12,7 @@ from tests.e2e.helper import (
 def queue_data(short_uuid):
     return {
         "name": f"E2E Queue {short_uuid}",
-        "description": "E2E Created Helpdesk Queue",
+        "shortDescription": "E2E Created Helpdesk Queue",
         "internal": False,
     }
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Fixes the helpdesk E2E `queue_data` fixture, which built the queue creation payload with the key `description`. The MPT helpdesk queues API expects `shortDescription` — the camelCase field used consistently by the other resources (e.g. [`extensions`](mpt_api_client/resources/integration/extensions.py) and [`products`](mpt_api_client/resources/catalog/products.py)). With the wrong key, the value was never applied to the created queue and the fixture sent a malformed payload.

## Changes

- `tests/e2e/helpdesk/conftest.py`: rename the `queue_data` payload key `description` → `shortDescription`.

## Testing

- `make check` (ruff format/check, flake8, mypy, `uv lock --check`) — passed.
- Running the helpdesk E2E suite requires live MPT credentials and was not executed as part of this change.

Jira: MPT-22084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22084](https://softwareone.atlassian.net/browse/MPT-22084)

- Fixed helpdesk E2E `queue_data` fixture to use correct API field name `shortDescription` instead of `description`
- Ensures queue creation payload conforms to MPT helpdesk queues API expectations, consistent with other resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22084]: https://softwareone.atlassian.net/browse/MPT-22084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ