### PR TITLE
MPT-22084 send both description and shortDescription in helpdesk queue fixture

### DIFF
--- a/tests/e2e/helpdesk/conftest.py
+++ b/tests/e2e/helpdesk/conftest.py
@@ -13,6 +13,7 @@ def queue_data(short_uuid):
     return {
         "name": f"E2E Queue {short_uuid}",
         "shortDescription": "E2E Created Helpdesk Queue",
+        "description": "E2E Created Helpdesk Queue",
         "internal": False,
     }
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Follow-up to #344 (MPT-22084). The first fix renamed the helpdesk `queue_data` fixture payload key `description` → `shortDescription`, which dropped coverage of the still-valid `description` field.

The MPT public OpenAPI `Queue` schema (`https://api.s1.show/public/v1/openapi.json`) defines **both** `description` and `shortDescription` as valid string fields (the helpdesk queue convention differs from products/extensions, which use `shortDescription`/`longDescription`). This restores `description` alongside `shortDescription` so the fixture sends the complete, valid payload.

## Changes

- `tests/e2e/helpdesk/conftest.py`: add `description` back to the `queue_data` fixture, alongside `shortDescription`.

## Testing

- `make check` (ruff format/check, flake8, mypy, `uv lock --check`) — passed.
- Running the helpdesk E2E suite requires live MPT credentials and was not executed as part of this change.

Jira: MPT-22084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22084](https://softwareone.atlassian.net/browse/MPT-22084)

- Restored the `description` field in the helpdesk `queue_data` fixture alongside `shortDescription` to ensure complete coverage of valid OpenAPI `Queue` schema fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22084]: https://softwareone.atlassian.net/browse/MPT-22084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ