### PR TITLE
MPT-22199 use camelCase documentType key in product document fixtures

### DIFF
--- a/tests/e2e/catalog/product/documents/test_async_document.py
+++ b/tests/e2e/catalog/product/documents/test_async_document.py
@@ -13,7 +13,7 @@ def async_document_service(async_mpt_vendor, product_id):
 
 @pytest.fixture
 async def created_document_from_file_async(async_document_service, document_data, pdf_fd):
-    document_data["documenttype"] = "File"
+    document_data["documentType"] = "File"
     document = await async_document_service.create(document_data, file=pdf_fd)
     yield document
     try:

--- a/tests/e2e/catalog/product/documents/test_sync_document.py
+++ b/tests/e2e/catalog/product/documents/test_sync_document.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.flaky]
 
 @pytest.fixture
 def created_document_from_file(vendor_document_service, document_data, pdf_fd):
-    document_data["documenttype"] = "File"
+    document_data["documentType"] = "File"
     document = vendor_document_service.create(document_data, pdf_fd)
     yield document
     try:


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fix a wrong-cased dictionary key in the product-document e2e fixtures.

The sync and async product-document fixtures set `document_data["documenttype"] = "File"` using an all-lowercase key. The MPT API expects the camelCase field `documentType`, which the rest of the suite already uses (e.g. `tests/e2e/integration/extension_documents/conftest.py`, `tests/e2e/program/program/document/conftest.py`). With the wrong-cased key the `documentType` value was never sent, so the `created_document_from_file` / `created_document_from_file_async` fixtures created documents without a type and the product-document e2e tests failed.

## Changed files

- `tests/e2e/catalog/product/documents/test_sync_document.py`
- `tests/e2e/catalog/product/documents/test_async_document.py`

## Testing

- `make check` (Docker): `ruff format --check`, `ruff check`, `flake8`, `mypy`, `uv lock --check` — all pass on the project tree.
- `make test` (Docker): **2285 unit tests passed**.
- The product-document e2e tests themselves require live MPT API credentials and were not run locally; they run in CI.

Closes [MPT-22199](https://softwareone.atlassian.net/browse/MPT-22199)


[MPT-22199]: https://softwareone.atlassian.net/browse/MPT-22199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22199](https://softwareone.atlassian.net/browse/MPT-22199)

- Fixed casing of `documentType` key in product-document e2e fixtures (`test_sync_document.py` and `test_async_document.py`)
- Changed from lowercase `documenttype` to camelCase `documentType` to match the MPT API's expected field name
- This resolves an issue where product-document e2e tests were failing because the document type was not being properly sent to the API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->