### PR TITLE
MPT-22214 exclude .claude so local make check passes with worktrees

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ aaa_act_block_style = "large"
 doctests = true
 extend-ignore = ["WPS226", "WPS412"]
 extend-exclude = [
+  ".claude",
   ".coverage",
   ".github",
   ".idea",


### PR DESCRIPTION
**Jira:** [MPT-22214](https://softwareone.atlassian.net/browse/MPT-22214)

## What

Add `.claude` to the `[tool.flake8] extend-exclude` list in `pyproject.toml` (one line, alongside the existing `.venv` entry).

## Why

`make check` (which runs `flake8 .` in Docker) fails locally whenever git worktrees exist under `.claude/worktrees/` — the directory the Claude Code worktree workflow uses. flake8 scans those nested full-repo checkouts and reports WPS violations (e.g. WPS432 magic numbers, WPS235 too many imports) on paths like `.claude/worktrees/<name>/tests/...`. Those paths don't match any `per-file-ignores` pattern, so the lint fails.

Root cause: `.claude` is gitignored, so ruff (`exclude_gitignore = true`) and mypy skip it, but flake8 has no gitignore awareness and `.claude` was not in `extend-exclude`. **CI is unaffected** because it runs on a clean checkout without nested worktrees — this only impacts local development for anyone using the worktree workflow.

## Verification

flake8 runs inside Docker via `make check`. With a dummy WPS-violating file placed under `.claude/worktrees/_dummy_verify/tests/`:

- **Before** (`.claude` not excluded): flake8 flags the dummy file and exits 1 — bug reproduced.
- **After** (this change): flake8 no longer flags it.
- Full `make check` passes end to end: `ruff format --check`, `ruff check`, `flake8`, `mypy`, and `uv lock --check` all green with a nested worktree present.

Change is minimal and scoped to the flake8 config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MPT-22214]: https://softwareone.atlassian.net/browse/MPT-22214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22214](https://softwareone.atlassian.net/browse/MPT-22214)

**Release Notes**
- Added `.claude` to Flake8’s `[tool.flake8].extend-exclude` in `pyproject.toml` so flake8 ignores nested Claude Code worktree checkouts under `.claude/worktrees/`
- Fixes local `make check` failures caused by flake8 linting code within those worktree directories (CI remains unaffected on clean checkouts)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->