### PR TITLE
MPT-22385 Add Danger PR-formatting check workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,24 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Danger
+        uses: softwareone-platform/one-danger@1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add `.github/workflows/danger.yml` running the shared `softwareone-platform/one-danger@1.1.0` action on pull requests. It enforces the PR-formatting rules (Jira key in title, single commit, size threshold, no merge commits, release-branch markers and release→main linkage) via Danger.

Part of the org-wide rollout (US-3); the same workflow was smoke-tested in `mpt-extension-sdk`.

## Jira

Closes MPT-22385 (subtask of MPT-22376).

## Testing

This PR triggers the new Danger workflow on itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22385](https://softwareone.atlassian.net/browse/MPT-22385)

- Add GitHub Actions workflow to enforce organizational PR-formatting rules using the shared `softwareone-platform/one-danger@1.1.0` action
- Enforce Jira key requirement in PR titles, single commit policy, PR size thresholds, and prevention of merge commits
- Validate release-branch markers and release-to-main branch linkage as part of organization-wide standardization rollout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22385]: https://softwareone.atlassian.net/browse/MPT-22385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ