### PR TITLE
MPT-22436 Use freshly created product for e2e media tests

### DIFF
--- a/tests/e2e/catalog/product/media/test_async_media.py
+++ b/tests/e2e/catalog/product/media/test_async_media.py
@@ -6,13 +6,13 @@ pytestmark = [pytest.mark.flaky]
 
 
 @pytest.fixture
-def async_media_service(async_mpt_vendor, product_id):
-    return async_mpt_vendor.catalog.products.media(product_id)
+def async_media_service(async_mpt_vendor, async_created_product):
+    return async_mpt_vendor.catalog.products.media(async_created_product.id)
 
 
 @pytest.fixture
-def async_vendor_media_service(async_mpt_vendor, product_id):
-    return async_mpt_vendor.catalog.products.media(product_id)
+def async_vendor_media_service(async_mpt_vendor, async_created_product):
+    return async_mpt_vendor.catalog.products.media(async_created_product.id)
 
 
 @pytest.fixture

--- a/tests/e2e/catalog/product/media/test_sync_media.py
+++ b/tests/e2e/catalog/product/media/test_sync_media.py
@@ -6,8 +6,8 @@ pytestmark = [pytest.mark.flaky]
 
 
 @pytest.fixture
-def vendor_media_service(mpt_vendor, product_id):
-    return mpt_vendor.catalog.products.media(product_id)
+def vendor_media_service(mpt_vendor, created_product):
+    return mpt_vendor.catalog.products.media(created_product.id)
 
 
 @pytest.fixture


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fixes the e2e media tests (sync **and** async) that failed at setup with `400 Bad Request — Cannot create additional media as the maximum number of media items has been reached`.

The media service fixtures built their service against the hardcoded product id from `e2e_config` (`catalog.product.id`, e.g. `PRD-7255-3950`). That product had reached its maximum number of media items, so every `MediaService.create` returned 400 and broke the media tests during fixture setup.

## Changes

Point the media service fixtures at the shared `created_product` / `async_created_product` fixtures (already present in the product-level `conftest.py`) instead of the hardcoded `product_id`, so each run starts from a freshly created, empty product:

- sync: `vendor_media_service` → `created_product.id`
- async: `async_media_service` and `async_vendor_media_service` → `async_created_product.id` (pytest caches the fixture per test, so both share the same fresh product)

The `created_product` fixtures keep uploading the icon (`file=logo_fd`) — product creation requires it (see review thread), so the shared `create_fixture_resource_and_delete` helper can't be used here as-is.

## Testing

- Ran the related e2e suite against the live API (`tests/e2e/catalog/product/media` + `tests/e2e/catalog/product` product tests): **28 passed**.
- `ruff check`, `ruff format --check`, and `flake8` (incl. wemake / flake8-aaa) pass on the changed files.

Jira: https://softwareone.atlassian.net/browse/MPT-22436

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22436](https://softwareone.atlassian.net/browse/MPT-22436)

## Changes

- Fixed failing e2e media tests (sync and async) that were hitting maximum media capacity on a hardcoded product ID
- Moved `created_product` and `async_created_product` fixtures to shared `conftest.py` to enable reuse across test modules
- Refactored product fixtures to use shared `create_fixture_resource_and_delete` and `async_create_fixture_resource_and_delete` helpers
- Updated media service fixtures to use freshly created products (`created_product.id` and `async_created_product.id`) instead of hardcoded product ID from configuration
- Removed unused `MPTAPIError` imports from product test files
- Each test now runs with an empty, isolated product that is cleaned up after execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22436]: https://softwareone.atlassian.net/browse/MPT-22436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ