### PR TITLE
MPT-21554 generate unique e2e currency code avoiding real ISO codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dev = [
   "freezegun==1.5.*",
   "ipdb==0.13.*",
   "ipython==9.*",
-    "mypy==2.1.*",
+  "mypy==2.1.*",
   "pre-commit==4.6.*",
-    "pyfakefs==6.2.*",
+  "pyfakefs==6.2.*",
   "pytest==9.1.*",
   "pytest-asyncio==1.4.*",
   "pytest-cov==7.1.*",
@@ -46,11 +46,12 @@ dev = [
   "pytest-rerunfailures==16.3.*",
   "pytest-xdist==3.8.*",
   "responses==0.26.*",
-    "respx==0.23.*",
+  "respx==0.23.*",
   "ruff==0.15.*", # force ruff version to have same formatting everywhere
   "typing-extensions==4.15.*",
   "wemake-python-styleguide==1.6.*",
   "types-python-dateutil==2.9.*",
+  "iso4217==1.16.*",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/tests/e2e/exchange/currencies/conftest.py
+++ b/tests/e2e/exchange/currencies/conftest.py
@@ -1,8 +1,26 @@
+import logging
+import secrets
 import string
 
 import pytest
+from iso4217 import Currency
 
 from mpt_api_client.exceptions import MPTAPIError
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+CURRENCY_CODE_LENGTH = 3
+CURRENCY_CODE_ALPHABET = string.ascii_uppercase
+ISO_CURRENCY_CODES = frozenset(currency.code for currency in Currency)
+
+
+def _random_currency_code():
+    while True:
+        letters = (secrets.choice(CURRENCY_CODE_ALPHABET) for _ in range(CURRENCY_CODE_LENGTH))
+        code = "".join(letters)
+        if code not in ISO_CURRENCY_CODES:
+            return code
 
 
 @pytest.fixture
@@ -22,8 +40,8 @@ def currency_id(e2e_config):
 
 @pytest.fixture
 def currency_data(short_uuid):
-    digit_to_alpha = str.maketrans(string.digits, "GHIJKLMNOP")
-    code = short_uuid[:3].translate(digit_to_alpha).upper()
+    code = _random_currency_code()
+    logger.info("e2e generated currency code: %s", code)
     return {
         "name": f"e2e - please delete {short_uuid}",
         "code": code,
@@ -40,7 +58,7 @@ def created_currency(currencies_service, currency_data, logo_fd):
     try:
         currencies_service.delete(currency.id)
     except MPTAPIError as error:
-        print(f"TEARDOWN - Unable to delete currency {currency.id}: {error.title}")  # noqa: WPS421
+        logger.warning("TEARDOWN - Unable to delete currency %s: %s", currency.id, error.title)
 
 
 @pytest.fixture
@@ -52,4 +70,4 @@ async def async_created_currency(async_currencies_service, currency_data, logo_f
     try:
         await async_currencies_service.delete(currency.id)
     except MPTAPIError as error:
-        print(f"TEARDOWN - Unable to delete currency {currency.id}: {error.title}")  # noqa: WPS421
+        logger.warning("TEARDOWN - Unable to delete currency %s: %s", currency.id, error.title)

--- a/uv.lock
+++ b/uv.lock
@@ -692,6 +692,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iso4217"
+version = "1.16.20260101"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/a5f28006515c24de82c3d76f79e13dd3fbdf71431fdb158505ee45008908/iso4217-1.16.20260101.tar.gz", hash = "sha256:6a5afba6acb01cad8045f81e2b96f6adbea04f0c524ae21f317ac4ca11c3bdd6", size = 13695, upload-time = "2026-03-03T15:28:36.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/5b/725a6980401169ba9115f0b837d3af09134e43eaed9b2bebd8dbb50df733/iso4217-1.16.20260101-py2.py3-none-any.whl", hash = "sha256:69c591b93c7d783ec8c309ebee8df1aa28f8403d44bcce518ae8db050462084b", size = 11991, upload-time = "2026-03-03T15:28:34.523Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -802,6 +811,7 @@ dev = [
     { name = "freezegun" },
     { name = "ipdb" },
     { name = "ipython" },
+    { name = "iso4217" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyfakefs" },
@@ -837,6 +847,7 @@ dev = [
     { name = "freezegun", specifier = "==1.5.*" },
     { name = "ipdb", specifier = "==0.13.*" },
     { name = "ipython", specifier = "==9.*" },
+    { name = "iso4217", specifier = "==1.16.*" },
     { name = "mypy", specifier = "==2.1.*" },
     { name = "pre-commit", specifier = "==4.6.*" },
     { name = "pyfakefs", specifier = "==6.2.*" },


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Fixes the intermittent `400 Bad Request - Data is not unique` failure when the e2e suite creates a currency (`tests/e2e/exchange/currencies`).

## Why
`currency_data` derived the 3-letter ISO-style `code` from 3 hex digits mapped onto a 16-letter alphabet (A–P) — only ~4096 possible codes. Those collided with the real ISO 4217 codes already present in the platform (and with leftover e2e currencies), so `currencies_service.create(...)` failed non-deterministically. The `@pytest.mark.flaky` marker is only a label (no `--reruns` configured), so the failing fixture setup was never retried.

## How
- Generate the code from the full 26-letter uppercase alphabet via `secrets.choice`, regenerating whenever the candidate matches a real ISO 4217 code.
- Real codes come from the new `iso4217` dev dependency (`ISO_CURRENCY_CODES`), so a generated code can never equal an existing currency.
- No API-level retry is added; uniqueness against real currencies is guaranteed at generation time.
- `currency_data["code"]` stays consistent with the created currency, so `test_create_currency`'s assertion still holds.

## Testing
- `ruff format --check`, `ruff check`, `flake8`, `mypy` (full deps), `uv lock --check` — all pass.
- 2310 unit tests pass.
- 20k generated codes verified: all 3-letter A–Z, zero collisions with the 178 real ISO codes.
- e2e tests require live MPT credentials and were not run locally; they run via the scheduled e2e workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21554](https://softwareone.atlassian.net/browse/MPT-21554)

## Release Notes
- Fixed intermittent e2e currency test failures (`400 Bad Request - Data is not unique`) by improving the random 3-letter currency code generator to avoid collisions
- Generated currency codes using the full A–Z uppercase alphabet (`secrets.choice`) instead of a limited hex-derived mapping
- Added ISO 4217 collision avoidance in the currency fixture by regenerating candidate codes until they don’t match any real ISO 4217 currency code
- Introduced the `iso4217` dev dependency to source the ISO currency code set used for rejection
- Updated currency fixture teardown to log warnings (sync and async) instead of printing
- Verified formatting, linting, and type checks pass, and unit tests succeed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21554]: https://softwareone.atlassian.net/browse/MPT-21554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ