### PR TITLE
MPT-22538 align mypy pre-commit hook env with project runtime deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,5 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - python-box==7.3.2
+          - httpx==0.28.*
+          - httpx-retries==0.5.*


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add the project runtime dependencies (`httpx==0.28.*`, `httpx-retries==0.5.*`) to the `mirrors-mypy` hook's `additional_dependencies` in `.pre-commit-config.yaml`, mirroring the pins in `pyproject.toml` `[project].dependencies`.

## Why

The mypy pre-commit hook runs in an isolated environment that previously installed only `python-box`. With `httpx` missing there, mypy `strict = true` + `ignore_missing_imports = true` made `httpx.Auth` collapse to `Any`, and `disallow_subclassing_any` failed locally on unchanged code:

```
mpt_api_client/auth/base.py:13: error: Class cannot subclass "Auth" (has type "Any")  [misc]
```

CI runs mypy with the full project dependencies (`make check-all` / `uv run mypy .`) and stayed green, so this only bit developers running `pre-commit run` locally. Aligning the hook's environment with the project's runtime deps removes the discrepancy.

## Testing

- `uv run pre-commit run mypy --all-files` → passes
- Full `pre-commit run --all-files`, plus `ruff format --check`, `ruff check`, `flake8`, `mypy`, `uv lock --check` → green
- `pytest tests/unit` → 2310 passed, 99% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22538](https://softwareone.atlassian.net/browse/MPT-22538)

- Added `httpx==0.28.*` and `httpx-retries==0.5.*` to the `mirrors-mypy` hook's `additional_dependencies` in `.pre-commit-config.yaml` to align the mypy pre-commit environment with project runtime dependencies
- Resolves false positive mypy errors triggered locally when running `pre-commit run` due to missing type information for `httpx.Auth` in the isolated pre-commit environment
- Eliminates the discrepancy between local and CI mypy environments, ensuring consistent type checking across workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22538]: https://softwareone.atlassian.net/browse/MPT-22538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ