### PR TITLE
MPT-22771: add run-name to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release (v${{ inputs.version }})
 
 # Manually-triggered release pipeline for this Python package. Runs against the
 # branch selected at dispatch time (main -> pre-release, release/* -> latest).


### PR DESCRIPTION
## **User description**
## What

Adds the `run-name` property to the release workflow so each manually-dispatched run shows the version in its title:

```yaml
run-name: Release (v${{ inputs.version }})
```

## Why

Improves traceability of release runs in the GitHub Actions UI — the run is labelled with the released version instead of a generic "Release".

## Notes

- Inserted right below `name: Release`; no other changes.
- The workflow is dispatched manually (`workflow_dispatch`) with a required `version` input, so `inputs.version` is always populated.

Jira: **MPT-22771** (parent MPT-21906)


___

## **CodeAnt-AI Description**
Show the release version in the GitHub Actions run title

### What Changed
- Manually started release runs now display the selected version in the run title instead of a generic name

### Impact
`✅ Easier to spot the correct release run`
`✅ Clearer release tracking in GitHub Actions`
`✅ Less confusion between release runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22771](https://softwareone.atlassian.net/browse/MPT-22771)

- Added a workflow-level `run-name` to the release GitHub Actions workflow so manual release runs display as `Release (v<version>)`.
- Uses `inputs.version` to include the selected release version in the run title for better traceability in the Actions UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22771]: https://softwareone.atlassian.net/browse/MPT-22771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ