### PR TITLE
MPT-22959 Buffer streamed bodies before 401 retry in extension framework auth

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,8 +46,9 @@ implementations are available:
 - `ExtensionFrameworkAuthentication` — a short-lived installation or account-scoped token
   fetched from an extension secret via `POST /installations/-/token`. It refreshes
   proactively once the token nears its JWT `exp` (default leeway 60s) and reactively on
-  `401`. Pass `account_id` to request a token scoped to a specific account
-  (`?account.id=<id>`); use one provider instance per account scope.
+  `401`. Request bodies are buffered in memory before sending so the `401` retry can
+  replay one-shot streamed bodies intact. Pass `account_id` to request a token scoped to
+  a specific account (`?account.id=<id>`); use one provider instance per account scope.
 
 ## Instantiate The Client
 

--- a/mpt_api_client/auth/extension_framework.py
+++ b/mpt_api_client/auth/extension_framework.py
@@ -40,6 +40,12 @@ class ExtensionFrameworkAuthentication(Authentication):
     account scopes should construct one provider per scope.
     """
 
+    # The 401 retry re-sends the request, so one-shot streamed bodies (raw iterators,
+    # non-seekable files) must be buffered before the first send; otherwise the retry
+    # replays an already-consumed stream. httpx only honours this flag in the default
+    # ``auth_flow`` wrappers, so the overridden flows below also buffer explicitly.
+    requires_request_body = True
+
     def __init__(
         self,
         secret: str,
@@ -76,6 +82,7 @@ class ExtensionFrameworkAuthentication(Authentication):
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
         """Attach a cached token, refreshing it proactively and on 401."""
+        request.read()
         if self._token is None or self._is_expired():
             self._refresh_sync()
         request.headers["Authorization"] = f"Bearer {self._token}"
@@ -90,6 +97,7 @@ class ExtensionFrameworkAuthentication(Authentication):
         self, request: httpx.Request
     ) -> AsyncGenerator[httpx.Request, httpx.Response]:
         """Attach a cached token, refreshing it proactively and on 401."""
+        await request.aread()
         if self._token is None or self._is_expired():
             await self._refresh_async()
         request.headers["Authorization"] = f"Bearer {self._token}"

--- a/tests/unit/auth/test_extension_framework.py
+++ b/tests/unit/auth/test_extension_framework.py
@@ -1,6 +1,7 @@
 import base64
 import datetime as dt
 import json
+from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
@@ -16,6 +17,18 @@ TOKEN_URL = f"{API_URL}/public/v1/integration/installations/-/token"
 ORDERS_URL = f"{API_URL}/orders"
 
 
+@pytest.fixture
+def extension_http_client() -> HTTPClient:
+    return HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
+
+
+@pytest.fixture
+def async_extension_http_client() -> AsyncHTTPClient:
+    return AsyncHTTPClient(
+        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
+    )
+
+
 def _jwt_with_exp(expires_at: dt.datetime, subject: str = "token") -> str:
     def encode(payload: object) -> str:
         raw = json.dumps(payload).encode("utf-8")
@@ -26,14 +39,13 @@ def _jwt_with_exp(expires_at: dt.datetime, subject: str = "token") -> str:
 
 
 @respx.mock
-def test_extension_framework_fetches_and_applies_token():
+def test_extension_framework_fetches_and_applies_token(extension_http_client):
     token_route = respx.post(TOKEN_URL).mock(
         return_value=httpx.Response(200, json={"token": "installation-token"})
     )
     target_route = respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    client.request("GET", "/orders")  # act
+    extension_http_client.request("GET", "/orders")  # act
 
     token_request = token_route.calls.last.request
     target_request = target_route.calls.last.request
@@ -42,22 +54,21 @@ def test_extension_framework_fetches_and_applies_token():
 
 
 @respx.mock
-def test_extension_framework_caches_token_across_requests():
+def test_extension_framework_caches_token_across_requests(extension_http_client):
     token_route = respx.post(TOKEN_URL).mock(
         return_value=httpx.Response(200, json={"token": "installation-token"})
     )
     respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    client.request("GET", "/orders")  # first call populates the cache
+    extension_http_client.request("GET", "/orders")  # first call populates the cache
 
-    client.request("GET", "/orders")  # act
+    extension_http_client.request("GET", "/orders")  # act
 
     assert token_route.call_count == 1
 
 
 @respx.mock
-def test_extension_framework_refreshes_expired_token():
+def test_extension_framework_refreshes_expired_token(extension_http_client):
     token_route = respx.post(TOKEN_URL).mock(
         side_effect=[
             httpx.Response(200, json={"token": "stale-token"}),
@@ -70,9 +81,8 @@ def test_extension_framework_refreshes_expired_token():
             httpx.Response(200, json={"data": []}),
         ]
     )
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    response = client.request("GET", "/orders")  # act
+    response = extension_http_client.request("GET", "/orders")  # act
 
     target_request = target_route.calls.last.request
     assert response.status_code == httpx.codes.OK
@@ -81,7 +91,9 @@ def test_extension_framework_refreshes_expired_token():
 
 
 @respx.mock
-def test_extension_framework_retries_non_idempotent_request_on_unauthorized():
+def test_extension_framework_retries_non_idempotent_request_on_unauthorized(
+    extension_http_client,
+):
     token_route = respx.post(TOKEN_URL).mock(
         side_effect=[
             httpx.Response(200, json={"token": "stale-token"}),
@@ -94,9 +106,8 @@ def test_extension_framework_retries_non_idempotent_request_on_unauthorized():
             httpx.Response(201, json={"id": "ORD-1"}),
         ]
     )
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    response = client.request("POST", "/orders", json={"x": 1})  # act
+    response = extension_http_client.request("POST", "/orders", json={"x": 1})  # act
 
     target_request = target_route.calls.last.request
     assert response.status_code == httpx.codes.CREATED
@@ -106,31 +117,54 @@ def test_extension_framework_retries_non_idempotent_request_on_unauthorized():
 
 
 @respx.mock
-def test_extension_framework_surfaces_repeated_unauthorized():
+def test_extension_framework_retry_resends_streamed_body(extension_http_client):
+    token_route = respx.post(TOKEN_URL).mock(
+        side_effect=[
+            httpx.Response(200, json={"token": "stale-token"}),
+            httpx.Response(200, json={"token": "fresh-token"}),
+        ]
+    )
+    target_route = respx.post(ORDERS_URL).mock(
+        side_effect=[
+            httpx.Response(401, json={"error": "expired"}),
+            httpx.Response(201, json={"id": "ORD-1"}),
+        ]
+    )
+
+    result = extension_http_client.httpx_client.request(
+        "POST", "/orders", content=iter([b"chunk-1", b"chunk-2"])
+    )
+
+    target_request = target_route.calls.last.request
+    assert result.status_code == httpx.codes.CREATED
+    assert token_route.call_count == 2
+    assert target_route.call_count == 2
+    assert target_request.headers["Authorization"] == "Bearer fresh-token"
+    assert target_request.content == b"chunk-1chunk-2"
+
+
+@respx.mock
+def test_extension_framework_surfaces_repeated_unauthorized(extension_http_client):
     respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={"token": "any-token"}))
     target_route = respx.get(ORDERS_URL).mock(
         return_value=httpx.Response(401, json={"error": "nope"})
     )
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
     with pytest.raises(MPTAPIError) as exc_info:  # act
-        client.request("GET", "/orders")
+        extension_http_client.request("GET", "/orders")
 
     assert exc_info.value.status_code == httpx.codes.UNAUTHORIZED
     assert target_route.call_count == 2  # original + exactly one retry, then surfaced
 
 
 @respx.mock
-async def test_extension_framework_works_with_async_client():
+async def test_extension_framework_works_with_async_client(async_extension_http_client):
     token_route = respx.post(TOKEN_URL).mock(
         return_value=httpx.Response(200, json={"token": "installation-token"})
     )
     target_route = respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = AsyncHTTPClient(
-        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
-    )
 
-    await client.request("GET", "/orders")  # act
+    await async_extension_http_client.request("GET", "/orders")  # act
 
     target_request = target_route.calls.last.request
     assert token_route.called
@@ -138,24 +172,23 @@ async def test_extension_framework_works_with_async_client():
 
 
 @respx.mock
-async def test_extension_framework_caches_token_across_requests_async():
+async def test_extension_framework_caches_token_across_requests_async(
+    async_extension_http_client,
+):
     token_route = respx.post(TOKEN_URL).mock(
         return_value=httpx.Response(200, json={"token": "installation-token"})
     )
     respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = AsyncHTTPClient(
-        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
-    )
 
-    await client.request("GET", "/orders")  # first call populates the cache
+    await async_extension_http_client.request("GET", "/orders")  # first call populates the cache
 
-    await client.request("GET", "/orders")  # act
+    await async_extension_http_client.request("GET", "/orders")  # act
 
     assert token_route.call_count == 1
 
 
 @respx.mock
-async def test_extension_framework_refreshes_expired_token_async():
+async def test_extension_framework_refreshes_expired_token_async(async_extension_http_client):
     token_route = respx.post(TOKEN_URL).mock(
         side_effect=[
             httpx.Response(200, json={"token": "stale-token"}),
@@ -168,11 +201,8 @@ async def test_extension_framework_refreshes_expired_token_async():
             httpx.Response(200, json={"data": []}),
         ]
     )
-    client = AsyncHTTPClient(
-        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
-    )
 
-    response = await client.request("GET", "/orders")  # act
+    response = await async_extension_http_client.request("GET", "/orders")  # act
 
     target_request = target_route.calls.last.request
     assert response.status_code == httpx.codes.OK
@@ -181,7 +211,9 @@ async def test_extension_framework_refreshes_expired_token_async():
 
 
 @respx.mock
-async def test_extension_framework_retries_non_idempotent_request_on_unauthorized_async():
+async def test_extension_framework_retries_non_idempotent_request_on_unauthorized_async(
+    async_extension_http_client,
+):
     token_route = respx.post(TOKEN_URL).mock(
         side_effect=[
             httpx.Response(200, json={"token": "stale-token"}),
@@ -194,11 +226,8 @@ async def test_extension_framework_retries_non_idempotent_request_on_unauthorize
             httpx.Response(201, json={"id": "ORD-1"}),
         ]
     )
-    client = AsyncHTTPClient(
-        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
-    )
 
-    response = await client.request("POST", "/orders", json={"x": 1})  # act
+    response = await async_extension_http_client.request("POST", "/orders", json={"x": 1})  # act
 
     target_request = target_route.calls.last.request
     assert response.status_code == httpx.codes.CREATED
@@ -208,29 +237,59 @@ async def test_extension_framework_retries_non_idempotent_request_on_unauthorize
 
 
 @respx.mock
-async def test_extension_framework_surfaces_repeated_unauthorized_async():
+async def test_extension_framework_retry_resends_streamed_body_async(async_extension_http_client):
+    token_route = respx.post(TOKEN_URL).mock(
+        side_effect=[
+            httpx.Response(200, json={"token": "stale-token"}),
+            httpx.Response(200, json={"token": "fresh-token"}),
+        ]
+    )
+    target_route = respx.post(ORDERS_URL).mock(
+        side_effect=[
+            httpx.Response(401, json={"error": "expired"}),
+            httpx.Response(201, json={"id": "ORD-1"}),
+        ]
+    )
+
+    # httpx AsyncClient requires an async iterable for streamed content
+    async def stream_body() -> AsyncGenerator[bytes]:  # noqa: RUF029
+        yield b"chunk-1"
+        yield b"chunk-2"
+
+    result = await async_extension_http_client.httpx_client.request(
+        "POST", "/orders", content=stream_body()
+    )
+
+    target_request = target_route.calls.last.request
+    assert result.status_code == httpx.codes.CREATED
+    assert token_route.call_count == 2
+    assert target_route.call_count == 2
+    assert target_request.headers["Authorization"] == "Bearer fresh-token"
+    assert target_request.content == b"chunk-1chunk-2"
+
+
+@respx.mock
+async def test_extension_framework_surfaces_repeated_unauthorized_async(
+    async_extension_http_client,
+):
     respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={"token": "any-token"}))
     target_route = respx.get(ORDERS_URL).mock(
         return_value=httpx.Response(401, json={"error": "nope"})
     )
-    client = AsyncHTTPClient(
-        base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET)
-    )
 
     with pytest.raises(MPTAPIError) as exc_info:  # act
-        await client.request("GET", "/orders")
+        await async_extension_http_client.request("GET", "/orders")
 
     assert exc_info.value.status_code == httpx.codes.UNAUTHORIZED
     assert target_route.call_count == 2  # original + exactly one retry, then surfaced
 
 
 @respx.mock
-def test_extension_framework_token_error():
+def test_extension_framework_token_error(extension_http_client):
     respx.post(TOKEN_URL).mock(return_value=httpx.Response(403, json={"error": "forbidden"}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
     with pytest.raises(MPTError):  # act
-        client.request("GET", "/orders")
+        extension_http_client.request("GET", "/orders")
 
 
 def test_extension_framework_requires_configuration():
@@ -242,12 +301,11 @@ def test_extension_framework_requires_configuration():
 
 
 @respx.mock
-def test_extension_framework_rejects_empty_token():
+def test_extension_framework_rejects_empty_token(extension_http_client):
     respx.post(TOKEN_URL).mock(return_value=httpx.Response(200, json={"token": None}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
     with pytest.raises(MPTError):  # act
-        client.request("GET", "/orders")
+        extension_http_client.request("GET", "/orders")
 
 
 @respx.mock
@@ -268,7 +326,7 @@ def test_extension_framework_account_scoped_token_request():
 
 
 @respx.mock
-def test_extension_framework_refreshes_proactively_before_expiry():
+def test_extension_framework_refreshes_proactively_before_expiry(extension_http_client):
     near_expiry = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=10)
     far_expiry = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
     token_route = respx.post(TOKEN_URL).mock(
@@ -278,26 +336,24 @@ def test_extension_framework_refreshes_proactively_before_expiry():
         ]
     )
     respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    client.request("GET", "/orders")  # first call caches a near-expiry token
+    extension_http_client.request("GET", "/orders")  # first call caches a near-expiry token
 
-    client.request("GET", "/orders")  # act: token within leeway -> proactive refresh
+    extension_http_client.request("GET", "/orders")  # act: token within leeway -> refresh
 
     assert token_route.call_count == 2
 
 
 @respx.mock
-def test_extension_framework_reuses_unexpired_token():
+def test_extension_framework_reuses_unexpired_token(extension_http_client):
     far_expiry = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
     token_route = respx.post(TOKEN_URL).mock(
         return_value=httpx.Response(200, json={"token": _jwt_with_exp(far_expiry)})
     )
     respx.get(ORDERS_URL).mock(return_value=httpx.Response(200, json={"data": []}))
-    client = HTTPClient(base_url=API_URL, authentication=ExtensionFrameworkAuthentication(SECRET))
 
-    client.request("GET", "/orders")  # caches a long-lived token
+    extension_http_client.request("GET", "/orders")  # caches a long-lived token
 
-    client.request("GET", "/orders")  # act
+    extension_http_client.request("GET", "/orders")  # act
 
     assert token_route.call_count == 1


### PR DESCRIPTION
## **User description**
🤖 AI-generated PR — Please review carefully.

## What was done

`ExtensionFrameworkAuthentication` retries requests on `401 Unauthorized` in both
`sync_auth_flow` and `async_auth_flow`, but one-shot streamed request bodies (raw
iterators, non-seekable file objects) were consumed by the first send, so the retry
re-sent an already-consumed stream: multipart parts backed by non-seekable files were
silently truncated and raw iterator bodies raised `httpx.StreamConsumed`.

- Buffer the request body at the start of both auth flows (`request.read()` /
  `await request.aread()`), which makes httpx replace the one-shot stream with an
  in-memory replayable `ByteStream`, so the `401` retry always re-sends the intact body.
- Set `requires_request_body = True` for consistency with the httpx convention
  ([httpx custom authentication docs](https://www.python-httpx.org/advanced/authentication/));
  httpx only honours the flag in its default auth-flow wrappers, which this class
  overrides, so the explicit buffering above is what enforces it (comment added in code).
- Add sync and async regression tests that stream a body through a `401` → `200`
  sequence and assert the retried request carries the fresh token and the intact body.
- Document the buffering behaviour in `docs/usage.md`.

Same issue as MPT-22954 in the extension SDK (`AccountScopedAuthentication`,
softwareone-platform/mpt-extension-sdk#246).

Jira: [MPT-22959](https://softwareone.atlassian.net/browse/MPT-22959)

## Testing

- New regression tests: `test_extension_framework_retry_resends_streamed_body` (sync)
  and `test_extension_framework_retry_resends_streamed_body_async`; both fail without
  the fix (empty retried body) and pass with it.
- `make check-all` green: 2312 unit tests, ruff, flake8, mypy, `uv lock --check`.


[MPT-22959]: https://softwareone.atlassian.net/browse/MPT-22959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **CodeAnt-AI Description**
Keep streamed request bodies intact when a 401 retry happens

### What Changed
- Requests that are retried after a 401 now keep their original streamed body instead of sending an empty or broken body
- This fixes uploads and other one-shot request bodies, including bodies built from non-seekable files or iterators
- Sync and async request flows now both cover this retry case, and the usage guide now mentions the buffering behavior

### Impact
`✅ Reliable 401 retries for streamed uploads`
`✅ Fewer broken multipart requests`
`✅ Clearer behavior for one-shot request bodies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22959](https://softwareone.atlassian.net/browse/MPT-22959)

- Buffers request bodies in `ExtensionFrameworkAuthentication` before any token refresh/`401 Unauthorized` retry so streamed one-shot bodies can be replayed in both synchronous and asynchronous auth flows.
- Sets `requires_request_body = True` to align with `httpx` authentication conventions.
- Adds sync and async regression tests covering `401` retries that (a) refresh the bearer token and (b) preserve/resend streamed request bodies, including retry behavior for a non-idempotent POST.
- Refactors `tests/unit/auth/test_extension_framework.py` to use shared sync/async `HTTPClient` fixtures for `ExtensionFrameworkAuthentication`.
- Updates `docs/usage.md` to document request-body buffering for retries and account-scoped token retrieval via `?account.id=<id>`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->