### PR TITLE
MPT-23413 Adopt ruff 0.15.22 conventions and drop RUF105/RUF201 ignores

### DIFF
--- a/mpt_api_client/rql/query_builder.py
+++ b/mpt_api_client/rql/query_builder.py
@@ -283,7 +283,7 @@ class RQLQuery:
             expr=self.expr,
             negated=True,
         )
-        inverted_query._append(self)  # noqa: SLF001
+        inverted_query._append(self)  # ruff:ignore[private-member-access]
         return inverted_query
 
     def __getattr__(self, name: str) -> Self:
@@ -443,7 +443,7 @@ class RQLQuery:
         """
         return self._list("in", value)
 
-    def null(self, value: bool) -> Self:  # noqa: FBT001
+    def null(self, value: bool) -> Self:  # ruff:ignore[boolean-type-hint-positional-argument]
         """Applies the `null` operator to the field this `RQLQuery` object refers to.
 
         Args:
@@ -458,7 +458,7 @@ class RQLQuery:
         """
         return self._bool("null", value)
 
-    def empty(self, value: bool = True) -> Self:  # noqa: FBT001 FBT002
+    def empty(self, value: bool = True) -> Self:  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
         """Apply the `empty` operator to the field this `RQLQuery` object refers to.
 
         Args:
@@ -555,8 +555,8 @@ class RQLQuery:
             return self._copy(other)
 
         query = self.new(op=op)
-        query._append(self)  # noqa: SLF001
-        query._append(other)  # noqa: SLF001
+        query._append(self)  # ruff:ignore[private-member-access]
+        query._append(other)  # ruff:ignore[private-member-access]
         return query
 
     def _append(self, query: "RQLQuery") -> "RQLQuery" | Self:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,36 +212,34 @@ select = [
   "SIM", # flake8-simpify
   "SLF", # flake8-self
   "SLOT", # flake8-slots
-  "T100", # flake8-debugger
+  "debugger", # flake8-debugger
   "TRY", # tryceratops
   "UP", # pyupgrade
   "W", # pycodestyle
   "YTT", # flake8-2020
 ]
 ignore = [
-  "A005", # allow to shadow stdlib and builtin module names
-  "B904", # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-  "COM812", # trailing comma, conflicts with `ruff format`
+  "stdlib-module-shadowing", # allow to shadow stdlib and builtin module names
+  "raise-without-from-inside-except", # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+  "missing-trailing-comma", # trailing comma, conflicts with `ruff format`
   # Different doc rules that we don't really care about:
-  "D100",
-  "D104",
-  "D105", # docstring for magic methods
-  "D106",
-  "D107",
-  "D203",
-  "D212",
-  "D401",
-  "D404",
-  "D405",
-  "ISC001", # implicit string concat conflicts with `ruff format`
-  "ISC003", # prefer explicit string concat over implicit concat
+  "undocumented-public-module",
+  "undocumented-public-package",
+  "undocumented-magic-method", # docstring for magic methods
+  "undocumented-public-nested-class",
+  "undocumented-public-init",
+  "incorrect-blank-line-before-class",
+  "multi-line-summary-first-line",
+  "non-imperative-mood",
+  "docstring-starts-with-this",
+  "non-capitalized-section-name",
+  "single-line-implicit-string-concatenation", # implicit string concat conflicts with `ruff format`
+  "explicit-string-concatenation", # prefer explicit string concat over implicit concat
   "PLR09", # we have our own complexity rules
-  "PLR2004", # do not report magic numbers
-  "PLR6301", # do not require classmethod / staticmethod when self not used
-  "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
-  "RUF105", # noqa-comments (preview): allow `# noqa` comments instead of `# ruff:ignore`
-  "RUF201", # rule-codes-in-selectors (preview): allow rule codes instead of names in lint selectors
-  "TRY003", # long exception messages from `tryceratops`
+  "magic-value-comparison", # do not report magic numbers
+  "no-self-use", # do not require classmethod / staticmethod when self not used
+  "pytest-raises-too-broad", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
+  "raise-vanilla-args", # long exception messages from `tryceratops`
 ]
 external = ["AAA", "WPS"]
 
@@ -261,15 +259,15 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-  "D101", # do not require docstrings in public classes
-  "D102", # do not require docstrincs in public method
-  "D103", # missing docstring in public function
-  "PLR2004", # allow magic numbers in tests
-  "S101", # asserts
-  "S105", # hardcoded passwords
-  "S404", # subprocess calls are for tests
-  "S603", # do not require `shell=True`
-  "S607", # partial executable paths
+  "undocumented-public-class", # do not require docstrings in public classes
+  "undocumented-public-method", # do not require docstrincs in public method
+  "undocumented-public-function", # missing docstring in public function
+  "magic-value-comparison", # allow magic numbers in tests
+  "assert", # asserts
+  "hardcoded-password-string", # hardcoded passwords
+  "suspicious-subprocess-import", # subprocess calls are for tests
+  "subprocess-without-shell-equals-true", # do not require `shell=True`
+  "start-process-with-partial-path", # partial executable paths
 ]
 
 [tool.mypy]

--- a/tests/unit/auth/test_extension_framework.py
+++ b/tests/unit/auth/test_extension_framework.py
@@ -252,7 +252,7 @@ async def test_extension_framework_retry_resends_streamed_body_async(async_exten
     )
 
     # httpx AsyncClient requires an async iterable for streamed content
-    async def stream_body() -> AsyncGenerator[bytes]:  # noqa: RUF029
+    async def stream_body() -> AsyncGenerator[bytes]:  # ruff:ignore[unused-async]
         yield b"chunk-1"
         yield b"chunk-2"
 

--- a/tests/unit/models/test_model.py
+++ b/tests/unit/models/test_model.py
@@ -290,7 +290,7 @@ def test_model_list_process_item_scalar():
 def test_base_model_getattr_from_dict():
     model = BaseModel(foo="bar")
 
-    result = model.__getattr__("foo")  # noqa: PLC2801
+    result = model.__getattr__("foo")  # ruff:ignore[unnecessary-dunder-call]
 
     assert result == "bar"
 
@@ -298,14 +298,14 @@ def test_base_model_getattr_from_dict():
 def test_base_model_setattr_private():
     model = BaseModel(foo="bar")
 
-    model._private = "secret"  # noqa: SLF001  # act
+    model._private = "secret"  # ruff:ignore[private-member-access]  # act
 
-    assert model._private == "secret"  # noqa: SLF001
+    assert model._private == "secret"  # ruff:ignore[private-member-access]
 
 
 def test_to_dict_excludes_private_attrs():
     model = BaseModel(foo="bar")
-    model._private = "secret"  # noqa: SLF001
+    model._private = "secret"  # ruff:ignore[private-member-access]
 
     result = model.to_dict()
 

--- a/tests/unit/rql/query_builder/test_rql_dot_path.py
+++ b/tests/unit/rql/query_builder/test_rql_dot_path.py
@@ -30,8 +30,8 @@ def test_dotted_path_comp_bool_and_str(op):
     result = getattr(RQLQuery().asset.id, op)
 
     assert str(result("value")) == f"{op}(asset.id,'value')"
-    assert str(result(True)) == f"{op}(asset.id,true)"  # noqa: FBT003
-    assert str(result(False)) == f"{op}(asset.id,false)"  # noqa: FBT003
+    assert str(result(True)) == f"{op}(asset.id,true)"  # ruff:ignore[boolean-positional-value-in-call]
+    assert str(result(False)) == f"{op}(asset.id,false)"  # ruff:ignore[boolean-positional-value-in-call]
 
 
 @pytest.mark.parametrize("op", ["eq", "ne", "gt", "ge", "le", "lt"])  # noqa: AAA01
@@ -100,4 +100,4 @@ def test_dotted_path_already_evaluated():
     query = RQLQuery().first.second.eq("value")
 
     with pytest.raises(AttributeError):
-        query.third  # noqa: B018
+        query.third  # ruff:ignore[useless-expression]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Removes the temporary `RUF105`/`RUF201` entries from `[tool.ruff.lint].ignore` (added to unblock the ruff `0.15.22` bump) and migrates the code to the conventions those preview rules enforce.

Part of epic MPT-23408 / story MPT-23409.

## Changes

- **RUF201** (rule-codes-in-selectors): rule codes → rule names in `lint.select` / `lint.ignore` / `per-file-ignores`.
- **RUF105** (noqa-comments): `# noqa: X` → `# ruff:ignore[X]` (13 comments, all ruff-only codes).

All migrated via `ruff check --fix` (56 fixes, 0 remaining). flake8 `WPS` suppressions live in flake8 `per-file-ignores` and are untouched. No behavioural change.

## Validation

`make check-all` fully green — ruff format/check, flake8, mypy, `uv lock --check`, **2312 tests passed**.

Jira: MPT-23413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated Ruff configuration to use rule names compatible with Ruff 0.15.22.
- Removed temporary `RUF105` and `RUF201` ignores.
- Migrated 13 Ruff-only `# noqa` comments to `# ruff:ignore[...]` directives.
- Applied 56 automated Ruff fixes without behavioral changes.
- Validation passed with `make check-all` and 2,312 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->