### PR TITLE
MPT-23360 Add progress reporting to iterate() and stream() with console logger

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,20 +121,39 @@ for invoice in client.billing.invoices.iterate():
 Report progress while iterating by passing an object that implements the `Progress`
 protocol (`mpt_api_client.models.Progress`). `set_total_items` is called after each
 page fetch, `item_processed` once per record, and `completed` when iteration finishes.
-The client ships `ConsoleLoggerProgress`, which prints `Fetched X of Y - P%` to stderr
+The client ships `ConsoleProgress`, which prints `Fetched X of Y - P%` to stderr
 at most once per configurable interval:
 
 ```python
 import datetime as dt
 
-from mpt_api_client.models import ConsoleLoggerProgress
+from mpt_api_client.models import ConsoleProgress
 
-progress = ConsoleLoggerProgress(interval=dt.timedelta(seconds=5))
+progress = ConsoleProgress(interval=dt.timedelta(seconds=5))
 for invoice in client.billing.invoices.iterate(batch_size=50, progress=progress):
     print(invoice.id)
 ```
 
-Any object implementing the three protocol methods works the same way.
+Any object implementing the three protocol methods works the same way. For custom
+renderers, extend one of the abstract `ProgressReport` bases instead of implementing
+the protocol from scratch: `TimeProgressReport` reports at most once per time interval
+and `BatchProgressReport` once every `batch_size` records. Both track the count and
+total for you — implement only `report(current, total, *, completed)`:
+
+```python
+from mpt_api_client.models import BatchProgressReport
+
+
+class LogProgress(BatchProgressReport):
+    def report(self, current, total, *, completed):
+        logger.info("Processed %s of %s records", current, total)
+
+
+for invoice in client.billing.invoices.iterate(progress=LogProgress(batch_size=1000)):
+    print(invoice.id)
+```
+
+`report` is called with `completed=True` exactly once, when iteration finishes.
 
 > **Note:** when a response carries no pagination total (missing `$meta`),
 > `set_total_items` is still called but receives `0` — treat a total of `0` as
@@ -144,7 +163,8 @@ The `progress` parameter is also accepted by `stream()` on JSONL endpoints; ther
 `set_total_items` is never called because JSONL responses carry no total, so design
 progress implementations for an unknown total. The async `iterate()` and `stream()` accept an
 `AsyncProgress` implementation whose methods are `async def` and are awaited —
-`AsyncConsoleLoggerProgress` is the shipped counterpart.
+`AsyncConsoleProgress` is the shipped counterpart, with `AsyncProgressReport`,
+`AsyncTimeProgressReport`, and `AsyncBatchProgressReport` as the async abstract bases.
 
 ## Asynchronous Usage Patterns
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,6 +118,34 @@ for invoice in client.billing.invoices.iterate():
     print(invoice.id)
 ```
 
+Report progress while iterating by passing an object that implements the `Progress`
+protocol (`mpt_api_client.models.Progress`). `set_total_items` is called after each
+page fetch, `item_processed` once per record, and `completed` when iteration finishes.
+The client ships `ConsoleLoggerProgress`, which prints `Fetched X of Y - P%` to stderr
+at most once per configurable interval:
+
+```python
+import datetime as dt
+
+from mpt_api_client.models import ConsoleLoggerProgress
+
+progress = ConsoleLoggerProgress(interval=dt.timedelta(seconds=5))
+for invoice in client.billing.invoices.iterate(batch_size=50, progress=progress):
+    print(invoice.id)
+```
+
+Any object implementing the three protocol methods works the same way.
+
+> **Note:** when a response carries no pagination total (missing `$meta`),
+> `set_total_items` is still called but receives `0` — treat a total of `0` as
+> unknown when rendering progress.
+
+The `progress` parameter is also accepted by `stream()` on JSONL endpoints; there
+`set_total_items` is never called because JSONL responses carry no total, so design
+progress implementations for an unknown total. The async `iterate()` and `stream()` accept an
+`AsyncProgress` implementation whose methods are `async def` and are awaited —
+`AsyncConsoleLoggerProgress` is the shipped counterpart.
+
 ## Asynchronous Usage Patterns
 
 ```python

--- a/mpt_api_client/http/mixins/collection_mixin.py
+++ b/mpt_api_client/http/mixins/collection_mixin.py
@@ -2,8 +2,14 @@ from collections.abc import AsyncIterator, Iterator
 
 from mpt_api_client.http.mixins.queryable_mixin import QueryableMixin
 from mpt_api_client.http.types import Response
+from mpt_api_client.models import AsyncProgress, ModelCollection, Progress
 from mpt_api_client.models import Model as BaseModel
-from mpt_api_client.models import ModelCollection
+
+
+def _pagination_total[Model: BaseModel](items_collection: ModelCollection[Model]) -> int:
+    if items_collection.meta:
+        return items_collection.meta.pagination.total
+    return 0
 
 
 class CollectionMixin[Model: BaseModel](QueryableMixin):
@@ -39,11 +45,17 @@ class CollectionMixin[Model: BaseModel](QueryableMixin):
 
         return resource_list[0]  # type: ignore[no-any-return]
 
-    def iterate(self, batch_size: int = 100) -> Iterator[Model]:
+    def iterate(
+        self, batch_size: int = 100, *, progress: Progress | None = None
+    ) -> Iterator[Model]:
         """Iterate over all resources, yielding GenericResource objects.
 
         Args:
             batch_size: Number of resources to fetch per request
+            progress: Optional progress receiver. `set_total_items` is called after
+                each page fetch with the current pagination total (0 when unknown),
+                `item_processed` once per record before it is yielded, and
+                `completed` once when iteration finishes normally.
 
         Returns:
             Iterator of resources.
@@ -54,13 +66,26 @@ class CollectionMixin[Model: BaseModel](QueryableMixin):
         while True:
             response = self._fetch_page_as_response(limit=limit, offset=offset)
             items_collection = self.make_collection(response)  # type: ignore[attr-defined]
-            yield from items_collection
+            yield from self._iterate_page(items_collection, progress)
 
             if not items_collection.meta:
                 break
             if not items_collection.meta.pagination.has_next():
                 break
             offset = items_collection.meta.pagination.next_offset()
+
+        if progress:
+            progress.completed()
+
+    def _iterate_page(
+        self, items_collection: ModelCollection[Model], progress: Progress | None
+    ) -> Iterator[Model]:
+        if progress:
+            progress.set_total_items(_pagination_total(items_collection))
+        for resource in items_collection:
+            if progress:
+                progress.item_processed()
+            yield resource
 
     def _fetch_page_as_response(self, limit: int = 100, offset: int = 0) -> Response:
         """Fetch one page of resources.
@@ -108,11 +133,17 @@ class AsyncCollectionMixin[Model: BaseModel](QueryableMixin):
 
         return resource_list[0]  # type: ignore[no-any-return]
 
-    async def iterate(self, batch_size: int = 100) -> AsyncIterator[Model]:
+    async def iterate(
+        self, batch_size: int = 100, *, progress: AsyncProgress | None = None
+    ) -> AsyncIterator[Model]:
         """Iterate over all resources, yielding GenericResource objects.
 
         Args:
             batch_size: Number of resources to fetch per request
+            progress: Optional progress receiver. `set_total_items` is awaited after
+                each page fetch with the current pagination total (0 when unknown),
+                `item_processed` once per record before it is yielded, and
+                `completed` once when iteration finishes normally.
 
         Returns:
             Iterator of resources.
@@ -123,7 +154,7 @@ class AsyncCollectionMixin[Model: BaseModel](QueryableMixin):
         while True:
             response = await self._fetch_page_as_response(limit=limit, offset=offset)
             items_collection = self.make_collection(response)  # type: ignore[attr-defined]
-            for resource in items_collection:
+            async for resource in self._iterate_page(items_collection, progress):
                 yield resource
 
             if not items_collection.meta:
@@ -131,6 +162,19 @@ class AsyncCollectionMixin[Model: BaseModel](QueryableMixin):
             if not items_collection.meta.pagination.has_next():
                 break
             offset = items_collection.meta.pagination.next_offset()
+
+        if progress:
+            await progress.completed()
+
+    async def _iterate_page(
+        self, items_collection: ModelCollection[Model], progress: AsyncProgress | None
+    ) -> AsyncIterator[Model]:
+        if progress:
+            await progress.set_total_items(_pagination_total(items_collection))
+        for resource in items_collection:
+            if progress:
+                await progress.item_processed()  # noqa: WPS476
+            yield resource
 
     async def _fetch_page_as_response(self, limit: int = 100, offset: int = 0) -> Response:
         """Fetch one page of resources.

--- a/mpt_api_client/http/mixins/stream_jsonl_mixin.py
+++ b/mpt_api_client/http/mixins/stream_jsonl_mixin.py
@@ -3,18 +3,25 @@ from collections.abc import AsyncIterator, Iterator
 
 from mpt_api_client.constants import APPLICATION_JSONL
 from mpt_api_client.http.mixins.queryable_mixin import QueryableMixin
+from mpt_api_client.models import AsyncProgress, Progress
 from mpt_api_client.models import Model as BaseModel
 
 
 class StreamJSONLMixin[Model: BaseModel](QueryableMixin):
     """Mixin providing JSONL (NDJSON) streaming of a collection line by line."""
 
-    def stream(self) -> Iterator[Model]:
+    def stream(self, *, progress: Progress | None = None) -> Iterator[Model]:
         """Stream resources from a JSONL endpoint, yielding one model per line.
 
         Unlike ``iterate()``, which paginates and deserializes full pages, this
         consumes a ``application/jsonl`` response line by line without buffering the
         whole body in memory.
+
+        Args:
+            progress: Optional progress receiver. `item_processed` is called once
+                per line before the model is yielded and `completed` once when the
+                response body is fully consumed. `set_total_items` is never called
+                because JSONL responses carry no total.
 
         Yields:
             Resources, one per non-empty line of the response.
@@ -25,19 +32,31 @@ class StreamJSONLMixin[Model: BaseModel](QueryableMixin):
             headers={"Accept": APPLICATION_JSONL},
         ) as response:
             for line in response.iter_lines():
-                if line.strip():
-                    yield self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if not line.strip():
+                    continue
+                model = self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if progress:
+                    progress.item_processed()
+                yield model
+        if progress:
+            progress.completed()
 
 
 class AsyncStreamJSONLMixin[Model: BaseModel](QueryableMixin):
     """Async mixin providing JSONL (NDJSON) streaming of a collection line by line."""
 
-    async def stream(self) -> AsyncIterator[Model]:
+    async def stream(self, *, progress: AsyncProgress | None = None) -> AsyncIterator[Model]:
         """Stream resources from a JSONL endpoint, yielding one model per line.
 
         Unlike ``iterate()``, which paginates and deserializes full pages, this
         consumes a ``application/jsonl`` response line by line without buffering the
         whole body in memory.
+
+        Args:
+            progress: Optional progress receiver. `item_processed` is awaited once
+                per line before the model is yielded and `completed` once when the
+                response body is fully consumed. `set_total_items` is never called
+                because JSONL responses carry no total.
 
         Yields:
             Resources, one per non-empty line of the response.
@@ -48,5 +67,11 @@ class AsyncStreamJSONLMixin[Model: BaseModel](QueryableMixin):
             headers={"Accept": APPLICATION_JSONL},
         ) as response:
             async for line in response.aiter_lines():
-                if line.strip():
-                    yield self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if not line.strip():
+                    continue
+                model = self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if progress:
+                    await progress.item_processed()  # noqa: WPS476
+                yield model
+        if progress:
+            await progress.completed()

--- a/mpt_api_client/models/__init__.py
+++ b/mpt_api_client/models/__init__.py
@@ -6,10 +6,19 @@ from mpt_api_client.models.media_model import MediaModel
 from mpt_api_client.models.meta import Meta, Pagination
 from mpt_api_client.models.model import Model, ResourceData
 from mpt_api_client.models.model_collection import ModelCollection
+from mpt_api_client.models.progress import (
+    AsyncConsoleLoggerProgress,
+    AsyncProgress,
+    ConsoleLoggerProgress,
+    Progress,
+)
 from mpt_api_client.models.term_variant_model import TermVariantModel
 
 __all__ = [  # noqa: WPS410
+    "AsyncConsoleLoggerProgress",
+    "AsyncProgress",
     "AttachmentModel",
+    "ConsoleLoggerProgress",
     "DocumentModel",
     "FileModel",
     "FileResourceModel",
@@ -18,6 +27,7 @@ __all__ = [  # noqa: WPS410
     "Model",
     "ModelCollection",
     "Pagination",
+    "Progress",
     "ResourceData",
     "TermVariantModel",
 ]

--- a/mpt_api_client/models/__init__.py
+++ b/mpt_api_client/models/__init__.py
@@ -7,18 +7,28 @@ from mpt_api_client.models.meta import Meta, Pagination
 from mpt_api_client.models.model import Model, ResourceData
 from mpt_api_client.models.model_collection import ModelCollection
 from mpt_api_client.models.progress import (
-    AsyncConsoleLoggerProgress,
+    AsyncBatchProgressReport,
+    AsyncConsoleProgress,
     AsyncProgress,
-    ConsoleLoggerProgress,
+    AsyncProgressReport,
+    AsyncTimeProgressReport,
+    BatchProgressReport,
+    ConsoleProgress,
     Progress,
+    ProgressReport,
+    TimeProgressReport,
 )
 from mpt_api_client.models.term_variant_model import TermVariantModel
 
 __all__ = [  # noqa: WPS410
-    "AsyncConsoleLoggerProgress",
+    "AsyncBatchProgressReport",
+    "AsyncConsoleProgress",
     "AsyncProgress",
+    "AsyncProgressReport",
+    "AsyncTimeProgressReport",
     "AttachmentModel",
-    "ConsoleLoggerProgress",
+    "BatchProgressReport",
+    "ConsoleProgress",
     "DocumentModel",
     "FileModel",
     "FileResourceModel",
@@ -28,6 +38,8 @@ __all__ = [  # noqa: WPS410
     "ModelCollection",
     "Pagination",
     "Progress",
+    "ProgressReport",
     "ResourceData",
     "TermVariantModel",
+    "TimeProgressReport",
 ]

--- a/mpt_api_client/models/progress.py
+++ b/mpt_api_client/models/progress.py
@@ -1,0 +1,121 @@
+import datetime as dt
+import sys
+import time
+from collections.abc import Callable
+from typing import Protocol, TextIO, runtime_checkable
+
+DEFAULT_PROGRESS_INTERVAL = dt.timedelta(seconds=5)
+
+
+@runtime_checkable
+class Progress(Protocol):
+    """Receives iteration progress events from sync `iterate()` and `stream()`."""
+
+    def set_total_items(self, total: int) -> None:
+        """Called after each page fetch with the current pagination total."""
+
+    def item_processed(self) -> None:
+        """Called once per record, just before it is yielded."""
+
+    def completed(self) -> None:
+        """Called once when iteration finishes normally."""
+
+
+@runtime_checkable
+class AsyncProgress(Protocol):
+    """Receives iteration progress events from async `iterate()` and `stream()`."""
+
+    async def set_total_items(self, total: int) -> None:
+        """Called after each page fetch with the current pagination total."""
+
+    async def item_processed(self) -> None:
+        """Called once per record, just before it is yielded."""
+
+    async def completed(self) -> None:
+        """Called once when iteration finishes normally."""
+
+
+class ConsoleLoggerProgress:
+    """Progress implementation printing `Fetched X of Y - P%`, throttled by an interval.
+
+    `item_processed` writes at most once per `interval` (the first item always
+    writes); `completed` always writes a final newline-terminated line. A total of
+    0 is treated as unknown and rendered as 0%.
+    """
+
+    def __init__(
+        self,
+        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
+        output: TextIO = sys.stderr,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize the console progress logger.
+
+        Args:
+            interval: Minimum time between two progress lines.
+            output: Text stream the progress lines are written to.
+            clock: Monotonic time source in seconds, injectable for testing.
+                Defaults to `time.monotonic` when not provided.
+        """
+        self._interval_seconds = interval.total_seconds()
+        self._output = output
+        self._clock = clock or time.monotonic
+        self._total = 0
+        self._count = 0
+        self._last_write: float | None = None
+
+    def set_total_items(self, total: int) -> None:
+        """Store the current pagination total."""
+        self._total = total
+
+    def item_processed(self) -> None:
+        """Count the record and write a progress line when the interval elapsed."""
+        self._count += 1
+        now = self._clock()
+        if self._last_write is None or now - self._last_write >= self._interval_seconds:
+            self._last_write = now
+            self._write_progress("\r")
+
+    def completed(self) -> None:
+        """Write the final progress line."""
+        self._write_progress("\n")
+
+    def _write_progress(self, end: str) -> None:
+        pct: float = 0
+        if self._total:
+            pct = 100 * self._count / self._total
+        message = f"Fetched {self._count} of {self._total} - {pct:.0f}%"
+        self._output.write(message + end)
+        self._output.flush()
+
+
+class AsyncConsoleLoggerProgress:
+    """Async counterpart of `ConsoleLoggerProgress` for async `iterate()` and `stream()`."""
+
+    def __init__(
+        self,
+        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
+        output: TextIO = sys.stderr,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize the async console progress logger.
+
+        Args:
+            interval: Minimum time between two progress lines.
+            output: Text stream the progress lines are written to.
+            clock: Monotonic time source in seconds, injectable for testing.
+                Defaults to `time.monotonic` when not provided.
+        """
+        self._progress = ConsoleLoggerProgress(interval=interval, output=output, clock=clock)
+
+    async def set_total_items(self, total: int) -> None:
+        """Store the current pagination total."""
+        self._progress.set_total_items(total)
+
+    async def item_processed(self) -> None:
+        """Count the record and write a progress line when the interval elapsed."""
+        self._progress.item_processed()
+
+    async def completed(self) -> None:
+        """Write the final progress line."""
+        self._progress.completed()

--- a/mpt_api_client/models/progress.py
+++ b/mpt_api_client/models/progress.py
@@ -1,10 +1,12 @@
+import abc
 import datetime as dt
 import sys
 import time
 from collections.abc import Callable
-from typing import Protocol, TextIO, runtime_checkable
+from typing import Protocol, TextIO, override, runtime_checkable
 
 DEFAULT_PROGRESS_INTERVAL = dt.timedelta(seconds=5)
+DEFAULT_PROGRESS_BATCH_SIZE = 100
 
 
 @runtime_checkable
@@ -35,62 +37,199 @@ class AsyncProgress(Protocol):
         """Called once when iteration finishes normally."""
 
 
-class ConsoleLoggerProgress:
-    """Progress implementation printing `Fetched X of Y - P%`, throttled by an interval.
+class _TimeThrottle:
+    """Allows the first report and then at most one report per interval."""
 
-    `item_processed` writes at most once per `interval` (the first item always
-    writes); `completed` always writes a final newline-terminated line. A total of
-    0 is treated as unknown and rendered as 0%.
+    def __init__(self, interval: dt.timedelta, clock: Callable[[], float] | None) -> None:
+        self._interval_seconds = interval.total_seconds()
+        self._clock = clock or time.monotonic
+        self._last_report: float | None = None
+
+    def should_report(self) -> bool:
+        now = self._clock()
+        if self._last_report is None or now - self._last_report >= self._interval_seconds:
+            self._last_report = now
+            return True
+        return False
+
+
+def _write_progress(output: TextIO, current: int, total: int, *, completed: bool) -> None:
+    """Write one `Fetched X of Y - P%` line; a total of 0 renders as 0%."""
+    pct: float = 0
+    if total:
+        pct = 100 * current / total
+    end = "\n" if completed else "\r"
+    output.write(f"Fetched {current} of {total} - {pct:.0f}%{end}")
+    output.flush()
+
+
+class ProgressReport(abc.ABC):
+    """Base `Progress` implementation that throttles calls to `report()`.
+
+    Tracks the record count and pagination total, and calls the abstract
+    `report()` whenever the throttling policy (`_should_report`) allows it.
+    `completed()` always reports, with `completed=True`.
     """
 
-    def __init__(
-        self,
-        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
-        output: TextIO = sys.stderr,
-        clock: Callable[[], float] | None = None,
-    ) -> None:
-        """Initialize the console progress logger.
-
-        Args:
-            interval: Minimum time between two progress lines.
-            output: Text stream the progress lines are written to.
-            clock: Monotonic time source in seconds, injectable for testing.
-                Defaults to `time.monotonic` when not provided.
-        """
-        self._interval_seconds = interval.total_seconds()
-        self._output = output
-        self._clock = clock or time.monotonic
+    def __init__(self) -> None:
+        """Initialize the count and total to zero."""
         self._total = 0
         self._count = 0
-        self._last_write: float | None = None
 
     def set_total_items(self, total: int) -> None:
         """Store the current pagination total."""
         self._total = total
 
     def item_processed(self) -> None:
-        """Count the record and write a progress line when the interval elapsed."""
+        """Count the record and report when the throttling policy allows it."""
         self._count += 1
-        now = self._clock()
-        if self._last_write is None or now - self._last_write >= self._interval_seconds:
-            self._last_write = now
-            self._write_progress("\r")
+        if self._should_report():
+            self.report(self._count, self._total, completed=False)
 
     def completed(self) -> None:
-        """Write the final progress line."""
-        self._write_progress("\n")
+        """Report the final progress state."""
+        self.report(self._count, self._total, completed=True)
 
-    def _write_progress(self, end: str) -> None:
-        pct: float = 0
-        if self._total:
-            pct = 100 * self._count / self._total
-        message = f"Fetched {self._count} of {self._total} - {pct:.0f}%"
-        self._output.write(message + end)
-        self._output.flush()
+    @abc.abstractmethod
+    def report(self, current: int, total: int, *, completed: bool) -> None:
+        """Render one progress update.
+
+        Args:
+            current: Number of records processed so far.
+            total: Current pagination total, 0 when unknown.
+            completed: True only for the final report emitted by `completed()`.
+        """
+
+    @abc.abstractmethod
+    def _should_report(self) -> bool:
+        """Decide whether `item_processed` should report now."""
 
 
-class AsyncConsoleLoggerProgress:
-    """Async counterpart of `ConsoleLoggerProgress` for async `iterate()` and `stream()`."""
+class TimeProgressReport(ProgressReport, abc.ABC):
+    """Abstract `ProgressReport` reporting at most once per time interval.
+
+    The first processed record always reports.
+    """
+
+    def __init__(
+        self,
+        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize the time-based progress report.
+
+        Args:
+            interval: Minimum time between two reports.
+            clock: Monotonic time source in seconds, injectable for testing.
+                Defaults to `time.monotonic` when not provided.
+        """
+        super().__init__()
+        self._throttle = _TimeThrottle(interval, clock)
+
+    @override
+    def _should_report(self) -> bool:
+        return self._throttle.should_report()
+
+
+class BatchProgressReport(ProgressReport, abc.ABC):
+    """Abstract `ProgressReport` reporting once every `batch_size` records."""
+
+    def __init__(self, batch_size: int = DEFAULT_PROGRESS_BATCH_SIZE) -> None:
+        """Initialize the batch-based progress report.
+
+        Args:
+            batch_size: Number of records between two reports.
+        """
+        super().__init__()
+        self._batch_size = batch_size
+
+    @override
+    def _should_report(self) -> bool:
+        return self._count % self._batch_size == 0
+
+
+class AsyncProgressReport(abc.ABC):
+    """Async counterpart of `ProgressReport` for async `iterate()` and `stream()`."""
+
+    def __init__(self) -> None:
+        """Initialize the count and total to zero."""
+        self._total = 0
+        self._count = 0
+
+    async def set_total_items(self, total: int) -> None:
+        """Store the current pagination total."""
+        self._total = total
+
+    async def item_processed(self) -> None:
+        """Count the record and report when the throttling policy allows it."""
+        self._count += 1
+        if self._should_report():
+            await self.report(self._count, self._total, completed=False)
+
+    async def completed(self) -> None:
+        """Report the final progress state."""
+        await self.report(self._count, self._total, completed=True)
+
+    @abc.abstractmethod
+    async def report(self, current: int, total: int, *, completed: bool) -> None:
+        """Render one progress update.
+
+        Args:
+            current: Number of records processed so far.
+            total: Current pagination total, 0 when unknown.
+            completed: True only for the final report emitted by `completed()`.
+        """
+
+    @abc.abstractmethod
+    def _should_report(self) -> bool:
+        """Decide whether `item_processed` should report now."""
+
+
+class AsyncTimeProgressReport(AsyncProgressReport, abc.ABC):
+    """Abstract `AsyncProgressReport` reporting at most once per time interval.
+
+    The first processed record always reports.
+    """
+
+    def __init__(
+        self,
+        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize the async time-based progress report.
+
+        Args:
+            interval: Minimum time between two reports.
+            clock: Monotonic time source in seconds, injectable for testing.
+                Defaults to `time.monotonic` when not provided.
+        """
+        super().__init__()
+        self._throttle = _TimeThrottle(interval, clock)
+
+    @override
+    def _should_report(self) -> bool:
+        return self._throttle.should_report()
+
+
+class AsyncBatchProgressReport(AsyncProgressReport, abc.ABC):
+    """Abstract `AsyncProgressReport` reporting once every `batch_size` records."""
+
+    def __init__(self, batch_size: int = DEFAULT_PROGRESS_BATCH_SIZE) -> None:
+        """Initialize the async batch-based progress report.
+
+        Args:
+            batch_size: Number of records between two reports.
+        """
+        super().__init__()
+        self._batch_size = batch_size
+
+    @override
+    def _should_report(self) -> bool:
+        return self._count % self._batch_size == 0
+
+
+class ConsoleProgress(TimeProgressReport):
+    """Time-throttled progress printing `Fetched X of Y - P%` to a text stream."""
 
     def __init__(
         self,
@@ -98,7 +237,7 @@ class AsyncConsoleLoggerProgress:
         output: TextIO = sys.stderr,
         clock: Callable[[], float] | None = None,
     ) -> None:
-        """Initialize the async console progress logger.
+        """Initialize the console progress.
 
         Args:
             interval: Minimum time between two progress lines.
@@ -106,16 +245,36 @@ class AsyncConsoleLoggerProgress:
             clock: Monotonic time source in seconds, injectable for testing.
                 Defaults to `time.monotonic` when not provided.
         """
-        self._progress = ConsoleLoggerProgress(interval=interval, output=output, clock=clock)
+        super().__init__(interval=interval, clock=clock)
+        self._output = output
 
-    async def set_total_items(self, total: int) -> None:
-        """Store the current pagination total."""
-        self._progress.set_total_items(total)
+    @override
+    def report(self, current: int, total: int, *, completed: bool) -> None:
+        """Write one progress line, newline-terminated on completion."""
+        _write_progress(self._output, current, total, completed=completed)
 
-    async def item_processed(self) -> None:
-        """Count the record and write a progress line when the interval elapsed."""
-        self._progress.item_processed()
 
-    async def completed(self) -> None:
-        """Write the final progress line."""
-        self._progress.completed()
+class AsyncConsoleProgress(AsyncTimeProgressReport):
+    """Async counterpart of `ConsoleProgress` for async `iterate()` and `stream()`."""
+
+    def __init__(
+        self,
+        interval: dt.timedelta = DEFAULT_PROGRESS_INTERVAL,
+        output: TextIO = sys.stderr,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        """Initialize the async console progress.
+
+        Args:
+            interval: Minimum time between two progress lines.
+            output: Text stream the progress lines are written to.
+            clock: Monotonic time source in seconds, injectable for testing.
+                Defaults to `time.monotonic` when not provided.
+        """
+        super().__init__(interval=interval, clock=clock)
+        self._output = output
+
+    @override
+    async def report(self, current: int, total: int, *, completed: bool) -> None:
+        """Write one progress line, newline-terminated on completion."""
+        _write_progress(self._output, current, total, completed=completed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,9 @@ show-source = true
 statistics = false
 per-file-ignores = [
   "mpt_api_client/auth/extension_framework.py: WPS214",
+  "mpt_api_client/models/__init__.py: WPS235",
   "mpt_api_client/models/model.py: WPS215 WPS110",
+  "mpt_api_client/models/progress.py: WPS202",
   "mpt_api_client/mpt_client.py: WPS214 WPS235",
   "mpt_api_client/resources/*: WPS215",
   "mpt_api_client/resources/accounts/*.py: WPS202 WPS215 WPS214 WPS235 WPS453",

--- a/tests/unit/http/conftest.py
+++ b/tests/unit/http/conftest.py
@@ -33,6 +33,48 @@ class AsyncDummyService(  # noqa: WPS215
     _model_class = DummyModel
 
 
+class RecordingProgress:
+    """Progress fake recording every event as a tuple, in call order."""
+
+    def __init__(self):
+        self.events = []
+
+    def set_total_items(self, total):
+        self.events.append(("set_total_items", total))
+
+    def item_processed(self):
+        self.events.append(("item_processed",))
+
+    def completed(self):
+        self.events.append(("completed",))
+
+
+class AsyncRecordingProgress:
+    """AsyncProgress fake recording every event as a tuple, in call order."""
+
+    def __init__(self):
+        self.events = []
+
+    async def set_total_items(self, total):
+        self.events.append(("set_total_items", total))
+
+    async def item_processed(self):
+        self.events.append(("item_processed",))
+
+    async def completed(self):
+        self.events.append(("completed",))
+
+
+@pytest.fixture
+def recording_progress():
+    return RecordingProgress()
+
+
+@pytest.fixture
+def async_recording_progress():
+    return AsyncRecordingProgress()
+
+
 @pytest.fixture
 def dummy_service(http_client):
     return DummyService(http_client=http_client)

--- a/tests/unit/http/mixins/test_collection_mixin.py
+++ b/tests/unit/http/mixins/test_collection_mixin.py
@@ -4,7 +4,26 @@ import respx
 
 from mpt_api_client import RQLQuery
 from mpt_api_client.exceptions import MPTAPIError
-from tests.unit.http.conftest import AsyncDummyService, DummyService
+from tests.unit.http.conftest import (
+    AsyncDummyService,
+    AsyncRecordingProgress,
+    DummyService,
+    RecordingProgress,
+)
+
+
+class FailingProgress(RecordingProgress):
+    """Progress fake raising when an item is processed."""
+
+    def item_processed(self):
+        raise RuntimeError("progress failure")
+
+
+class AsyncFailingProgress(AsyncRecordingProgress):
+    """AsyncProgress fake raising when an item is processed."""
+
+    async def item_processed(self):
+        raise RuntimeError("progress failure")
 
 
 def test_col_mx_fetch_one_success(
@@ -257,6 +276,113 @@ def test_col_mx_iterate_handles_api_errors(dummy_service: DummyService) -> None:
             list(iterator)
 
 
+def test_col_mx_iterate_progress_one_page(
+    dummy_service: DummyService,
+    single_page_response: httpx.Response,
+    recording_progress: RecordingProgress,
+) -> None:
+    """Test progress events while iterating over a single page."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+
+        list(dummy_service.iterate(progress=recording_progress))  # act
+
+    assert recording_progress.events == [
+        ("set_total_items", 2),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+def test_col_mx_iterate_progress_multi_page(
+    dummy_service: DummyService,
+    multi_page_response_page1: httpx.Response,
+    multi_page_response_page2: httpx.Response,
+    recording_progress: RecordingProgress,
+) -> None:
+    """Test progress events while iterating over multiple pages."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test", params={"limit": 2, "offset": 0}).mock(
+            return_value=multi_page_response_page1
+        )
+        respx.get("https://api.example.com/api/v1/test", params={"limit": 2, "offset": 2}).mock(
+            return_value=multi_page_response_page2
+        )
+
+        list(dummy_service.iterate(2, progress=recording_progress))  # act
+
+    assert recording_progress.events == [
+        ("set_total_items", 4),
+        ("item_processed",),
+        ("item_processed",),
+        ("set_total_items", 4),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+def test_col_mx_iterate_progress_empty(
+    dummy_service: DummyService,
+    empty_response: httpx.Response,
+    recording_progress: RecordingProgress,
+) -> None:
+    """Test progress events while iterating over an empty set of resources."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=empty_response)
+
+        list(dummy_service.iterate(progress=recording_progress))  # act
+
+    assert recording_progress.events == [("set_total_items", 0), ("completed",)]
+
+
+def test_col_mx_iterate_progress_no_meta(
+    dummy_service: DummyService,
+    no_meta_response: httpx.Response,
+    recording_progress: RecordingProgress,
+) -> None:
+    """Test progress events when the response carries no metadata."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=no_meta_response)
+
+        list(dummy_service.iterate(progress=recording_progress))  # act
+
+    assert recording_progress.events == [
+        ("set_total_items", 0),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+def test_col_mx_iterate_progress_abandoned(
+    dummy_service: DummyService,
+    single_page_response: httpx.Response,
+    recording_progress: RecordingProgress,
+) -> None:
+    """Test that completed is not reported when iteration is abandoned early."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+        iterator = dummy_service.iterate(progress=recording_progress)
+        next(iterator)
+
+        iterator.close()  # act
+
+    assert recording_progress.events == [("set_total_items", 2), ("item_processed",)]
+
+
+def test_col_mx_iterate_progress_error(
+    dummy_service: DummyService, single_page_response: httpx.Response
+) -> None:
+    """Test that exceptions raised by the progress receiver propagate."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+
+        with pytest.raises(RuntimeError, match="progress failure"):
+            list(dummy_service.iterate(progress=FailingProgress()))
+
+
 async def test_async_col_mx_fetch_one_success(
     async_dummy_service: AsyncDummyService, single_result_response: httpx.Response
 ) -> None:
@@ -507,3 +633,125 @@ async def test_async_col_mx_iterate_handles_api_errors(
 
         with pytest.raises(MPTAPIError):
             [resource async for resource in async_dummy_service.iterate()]
+
+
+async def test_async_col_mx_iterate_progress_one_page(
+    async_dummy_service: AsyncDummyService,
+    single_page_response: httpx.Response,
+    async_recording_progress: AsyncRecordingProgress,
+) -> None:
+    """Test progress events while iterating over a single page."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+
+        [
+            resource
+            async for resource in async_dummy_service.iterate(progress=async_recording_progress)
+        ]
+
+    assert async_recording_progress.events == [
+        ("set_total_items", 2),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+async def test_async_col_mx_iterate_progress_multi_page(
+    async_dummy_service: AsyncDummyService,
+    multi_page_response_page1: httpx.Response,
+    multi_page_response_page2: httpx.Response,
+    async_recording_progress: AsyncRecordingProgress,
+) -> None:
+    """Test progress events while iterating over multiple pages."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test", params={"limit": 2, "offset": 0}).mock(
+            return_value=multi_page_response_page1
+        )
+        respx.get("https://api.example.com/api/v1/test", params={"limit": 2, "offset": 2}).mock(
+            return_value=multi_page_response_page2
+        )
+
+        [
+            resource
+            async for resource in async_dummy_service.iterate(2, progress=async_recording_progress)
+        ]
+
+    assert async_recording_progress.events == [
+        ("set_total_items", 4),
+        ("item_processed",),
+        ("item_processed",),
+        ("set_total_items", 4),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+async def test_async_col_mx_iterate_progress_empty(
+    async_dummy_service: AsyncDummyService,
+    empty_response: httpx.Response,
+    async_recording_progress: AsyncRecordingProgress,
+) -> None:
+    """Test progress events while iterating over an empty set of resources."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=empty_response)
+
+        [
+            resource
+            async for resource in async_dummy_service.iterate(progress=async_recording_progress)
+        ]
+
+    assert async_recording_progress.events == [("set_total_items", 0), ("completed",)]
+
+
+async def test_async_col_mx_iterate_progress_no_meta(
+    async_dummy_service: AsyncDummyService,
+    no_meta_response: httpx.Response,
+    async_recording_progress: AsyncRecordingProgress,
+) -> None:
+    """Test progress events when the response carries no metadata."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=no_meta_response)
+
+        [
+            resource
+            async for resource in async_dummy_service.iterate(progress=async_recording_progress)
+        ]
+
+    assert async_recording_progress.events == [
+        ("set_total_items", 0),
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+async def test_async_col_mx_iterate_progress_abandoned(
+    async_dummy_service: AsyncDummyService,
+    single_page_response: httpx.Response,
+    async_recording_progress: AsyncRecordingProgress,
+) -> None:
+    """Test that completed is not reported when iteration is abandoned early."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+        iterator = async_dummy_service.iterate(progress=async_recording_progress)
+
+        await anext(iterator)
+        await iterator.aclose()
+
+    assert async_recording_progress.events == [("set_total_items", 2), ("item_processed",)]
+
+
+async def test_async_col_mx_iterate_progress_error(
+    async_dummy_service: AsyncDummyService, single_page_response: httpx.Response
+) -> None:
+    """Test that exceptions raised by the progress receiver propagate."""
+    with respx.mock:
+        respx.get("https://api.example.com/api/v1/test").mock(return_value=single_page_response)
+
+        with pytest.raises(RuntimeError, match="progress failure"):
+            [
+                resource
+                async for resource in async_dummy_service.iterate(progress=AsyncFailingProgress())
+            ]

--- a/tests/unit/http/mixins/test_stream_jsonl_mixin.py
+++ b/tests/unit/http/mixins/test_stream_jsonl_mixin.py
@@ -6,8 +6,10 @@ from mpt_api_client import RQLQuery
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import AsyncStreamJSONLMixin, StreamJSONLMixin
 from tests.unit.conftest import API_URL, DummyModel
+from tests.unit.http.conftest import AsyncRecordingProgress, RecordingProgress
 
 JSONL_BODY = b'{"id": "ID-1", "name": "Charge 1"}\n\n{"id": "ID-2", "name": "Charge 2"}\n'
+MALFORMED_JSONL_BODY = b'not-json\n{"id": "ID-1", "name": "Charge 1"}\n'
 
 
 class DummyStreamService(  # noqa: WPS215
@@ -64,6 +66,47 @@ def test_stream_applies_query_filters(stream_service):
 
 
 @respx.mock
+def test_stream_progress_events(stream_service, recording_progress: RecordingProgress):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=JSONL_BODY)
+    )
+
+    list(stream_service.stream(progress=recording_progress))  # act
+
+    assert recording_progress.events == [
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+@respx.mock
+def test_stream_progress_early_break(stream_service, recording_progress: RecordingProgress):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=JSONL_BODY)
+    )
+    iterator = stream_service.stream(progress=recording_progress)
+    next(iterator)
+
+    iterator.close()  # act
+
+    assert recording_progress.events == [("item_processed",)]
+
+
+@respx.mock
+def test_stream_progress_malformed_line(stream_service, recording_progress: RecordingProgress):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=MALFORMED_JSONL_BODY)
+    )
+    iterator = stream_service.stream(progress=recording_progress)
+
+    with pytest.raises(ValueError, match="Expecting value"):
+        next(iterator)
+
+    assert recording_progress.events == []
+
+
+@respx.mock
 async def test_async_stream_yields_models(async_stream_service):
     route = respx.get(f"{API_URL}/api/v1/charges").mock(
         return_value=httpx.Response(httpx.codes.OK, content=JSONL_BODY)
@@ -75,3 +118,50 @@ async def test_async_stream_yields_models(async_stream_service):
     assert [charge.id for charge in result] == ["ID-1", "ID-2"]
     assert all(isinstance(charge, DummyModel) for charge in result)
     assert request.headers["Accept"] == "application/jsonl"
+
+
+@respx.mock
+async def test_async_stream_progress_events(
+    async_stream_service, async_recording_progress: AsyncRecordingProgress
+):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=JSONL_BODY)
+    )
+
+    [charge async for charge in async_stream_service.stream(progress=async_recording_progress)]
+
+    assert async_recording_progress.events == [
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+@respx.mock
+async def test_async_stream_progress_early_break(
+    async_stream_service, async_recording_progress: AsyncRecordingProgress
+):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=JSONL_BODY)
+    )
+    iterator = async_stream_service.stream(progress=async_recording_progress)
+
+    await anext(iterator)
+    await iterator.aclose()
+
+    assert async_recording_progress.events == [("item_processed",)]
+
+
+@respx.mock
+async def test_async_stream_progress_malformed_line(
+    async_stream_service, async_recording_progress: AsyncRecordingProgress
+):
+    respx.get(f"{API_URL}/api/v1/charges").mock(
+        return_value=httpx.Response(httpx.codes.OK, content=MALFORMED_JSONL_BODY)
+    )
+    iterator = async_stream_service.stream(progress=async_recording_progress)
+
+    with pytest.raises(ValueError, match="Expecting value"):
+        await anext(iterator)
+
+    assert async_recording_progress.events == []

--- a/tests/unit/models/test_progress.py
+++ b/tests/unit/models/test_progress.py
@@ -4,10 +4,14 @@ import io
 import pytest
 
 from mpt_api_client.models import (
-    AsyncConsoleLoggerProgress,
+    AsyncBatchProgressReport,
+    AsyncConsoleProgress,
     AsyncProgress,
-    ConsoleLoggerProgress,
+    AsyncTimeProgressReport,
+    BatchProgressReport,
+    ConsoleProgress,
     Progress,
+    TimeProgressReport,
 )
 
 
@@ -19,6 +23,50 @@ class FakeClock:
 
     def __call__(self):
         return self.now
+
+
+class RecordingTimeProgress(TimeProgressReport):
+    """Concrete time-based report recording every `report()` call."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reports = []
+
+    def report(self, current, total, *, completed):
+        self.reports.append((current, total, completed))
+
+
+class RecordingBatchProgress(BatchProgressReport):
+    """Concrete batch-based report recording every `report()` call."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reports = []
+
+    def report(self, current, total, *, completed):
+        self.reports.append((current, total, completed))
+
+
+class AsyncRecordingTimeProgress(AsyncTimeProgressReport):
+    """Concrete async time-based report recording every `report()` call."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reports = []
+
+    async def report(self, current, total, *, completed):
+        self.reports.append((current, total, completed))
+
+
+class AsyncRecordingBatchProgress(AsyncBatchProgressReport):
+    """Concrete async batch-based report recording every `report()` call."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.reports = []
+
+    async def report(self, current, total, *, completed):
+        self.reports.append((current, total, completed))
 
 
 @pytest.fixture
@@ -33,16 +81,32 @@ def clock():
 
 @pytest.fixture
 def console_progress(output, clock):
-    return ConsoleLoggerProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
+    return ConsoleProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
 
 
 @pytest.fixture
 def async_console_progress(output, clock):
-    return AsyncConsoleLoggerProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
+    return AsyncConsoleProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
+
+
+@pytest.fixture
+def time_progress(clock):
+    return RecordingTimeProgress(interval=dt.timedelta(seconds=5), clock=clock)
+
+
+@pytest.fixture
+def batch_progress():
+    return RecordingBatchProgress(batch_size=2)
 
 
 def test_console_progress_satisfies_protocol(console_progress):
     result = isinstance(console_progress, Progress)
+
+    assert result is True
+
+
+def test_batch_progress_satisfies_protocol(batch_progress):
+    result = isinstance(batch_progress, Progress)
 
     assert result is True
 
@@ -53,8 +117,66 @@ def test_async_console_progress_is_protocol(async_console_progress):
     assert result is True
 
 
+def test_time_progress_first_item_reports(time_progress):
+    time_progress.set_total_items(4)
+
+    time_progress.item_processed()  # act
+
+    assert time_progress.reports == [(1, 4, False)]
+
+
+def test_time_progress_throttles_in_interval(time_progress, clock):
+    time_progress.set_total_items(4)
+    time_progress.item_processed()
+    clock.now = 4.9
+
+    time_progress.item_processed()  # act
+
+    assert time_progress.reports == [(1, 4, False)]
+
+
+def test_time_progress_reports_after_interval(time_progress, clock):
+    time_progress.set_total_items(4)
+    time_progress.item_processed()
+    clock.now = 5.0
+
+    time_progress.item_processed()  # act
+
+    assert time_progress.reports == [(1, 4, False), (2, 4, False)]
+
+
+def test_time_progress_completed_always_reports(time_progress):
+    time_progress.set_total_items(2)
+    time_progress.item_processed()
+    time_progress.item_processed()
+
+    time_progress.completed()  # act
+
+    assert time_progress.reports == [(1, 2, False), (2, 2, True)]
+
+
+def test_batch_progress_reports_every_batch(batch_progress):
+    batch_progress.set_total_items(5)
+    batch_progress.item_processed()
+    batch_progress.item_processed()
+    batch_progress.item_processed()
+
+    batch_progress.item_processed()  # act
+
+    assert batch_progress.reports == [(2, 5, False), (4, 5, False)]
+
+
+def test_batch_progress_completed_always_reports(batch_progress):
+    batch_progress.set_total_items(3)
+    batch_progress.item_processed()
+
+    batch_progress.completed()  # act
+
+    assert batch_progress.reports == [(1, 3, True)]
+
+
 def test_console_progress_default_clock(output):
-    progress = ConsoleLoggerProgress(output=output)
+    progress = ConsoleProgress(output=output)
 
     progress.item_processed()  # act
 
@@ -105,10 +227,30 @@ def test_console_progress_completed_always_writes(console_progress, output):
     assert output.getvalue() == "Fetched 1 of 2 - 50%\rFetched 2 of 2 - 100%\n"
 
 
+async def test_async_time_progress_reports(clock):
+    progress = AsyncRecordingTimeProgress(interval=dt.timedelta(seconds=5), clock=clock)
+    await progress.set_total_items(2)
+    await progress.item_processed()
+
+    await progress.completed()  # act
+
+    assert progress.reports == [(1, 2, False), (1, 2, True)]
+
+
+async def test_async_batch_progress_reports():
+    progress = AsyncRecordingBatchProgress(batch_size=2)
+    await progress.set_total_items(4)
+    await progress.item_processed()
+
+    await progress.item_processed()  # act
+
+    assert progress.reports == [(2, 4, False)]
+
+
 async def test_async_console_progress_writes(async_console_progress, output):
     await async_console_progress.set_total_items(2)
     await async_console_progress.item_processed()
 
-    await async_console_progress.completed()
+    await async_console_progress.completed()  # act
 
     assert output.getvalue() == "Fetched 1 of 2 - 50%\rFetched 1 of 2 - 50%\n"

--- a/tests/unit/models/test_progress.py
+++ b/tests/unit/models/test_progress.py
@@ -1,0 +1,114 @@
+import datetime as dt
+import io
+
+import pytest
+
+from mpt_api_client.models import (
+    AsyncConsoleLoggerProgress,
+    AsyncProgress,
+    ConsoleLoggerProgress,
+    Progress,
+)
+
+
+class FakeClock:
+    """Deterministic monotonic clock advanced manually by tests."""
+
+    def __init__(self):
+        self.now: float = 0
+
+    def __call__(self):
+        return self.now
+
+
+@pytest.fixture
+def output():
+    return io.StringIO()
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def console_progress(output, clock):
+    return ConsoleLoggerProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
+
+
+@pytest.fixture
+def async_console_progress(output, clock):
+    return AsyncConsoleLoggerProgress(interval=dt.timedelta(seconds=5), output=output, clock=clock)
+
+
+def test_console_progress_satisfies_protocol(console_progress):
+    result = isinstance(console_progress, Progress)
+
+    assert result is True
+
+
+def test_async_console_progress_is_protocol(async_console_progress):
+    result = isinstance(async_console_progress, AsyncProgress)
+
+    assert result is True
+
+
+def test_console_progress_default_clock(output):
+    progress = ConsoleLoggerProgress(output=output)
+
+    progress.item_processed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 0 - 0%\r"
+
+
+def test_console_progress_first_item_writes(console_progress, output):
+    console_progress.set_total_items(4)
+
+    console_progress.item_processed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 4 - 25%\r"
+
+
+def test_console_progress_throttles_in_interval(console_progress, output, clock):
+    console_progress.set_total_items(4)
+    console_progress.item_processed()
+    clock.now = 4.9
+
+    console_progress.item_processed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 4 - 25%\r"
+
+
+def test_console_progress_writes_after_interval(console_progress, output, clock):
+    console_progress.set_total_items(4)
+    console_progress.item_processed()
+    clock.now = 5.0
+
+    console_progress.item_processed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 4 - 25%\rFetched 2 of 4 - 50%\r"
+
+
+def test_console_progress_unknown_total(console_progress, output):
+    console_progress.item_processed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 0 - 0%\r"
+
+
+def test_console_progress_completed_always_writes(console_progress, output):
+    console_progress.set_total_items(2)
+    console_progress.item_processed()
+    console_progress.item_processed()
+
+    console_progress.completed()  # act
+
+    assert output.getvalue() == "Fetched 1 of 2 - 50%\rFetched 2 of 2 - 100%\n"
+
+
+async def test_async_console_progress_writes(async_console_progress, output):
+    await async_console_progress.set_total_items(2)
+    await async_console_progress.item_processed()
+
+    await async_console_progress.completed()
+
+    assert output.getvalue() == "Fetched 1 of 2 - 50%\rFetched 1 of 2 - 50%\n"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Adds progress reporting to collection iteration and JSONL streaming, so consumers can render progress such as `X of Y - P%` ([MPT-23360](https://softwareone.atlassian.net/browse/MPT-23360)).

The feature is layered in three levels, all in `mpt_api_client/models/progress.py` and exported from `mpt_api_client.models`:

- **Protocols** — `Progress` / `AsyncProgress` with three methods: `set_total_items(total)`, `item_processed()`, `completed()`. Any object implementing them can be passed to `iterate()`/`stream()`.
- **Abstract report bases** — `ProgressReport` / `AsyncProgressReport` track the record count and pagination total and call a single abstract `report(current, total, *, completed)` per a throttling policy. Two policies are shipped as abstract subclasses: `TimeProgressReport` (at most once per configurable `timedelta` interval, default 5s; first record always reports) and `BatchProgressReport` (once every `batch_size` records, default 100). `completed()` always reports with `completed=True`. Custom renderers extend one of these and implement only `report()`.
- **Console renderers** — `ConsoleProgress` / `AsyncConsoleProgress` extend the time-based report and print `Fetched X of Y - P%` to a stream (default stderr). The clock (default `time.monotonic`) and output stream are injectable for deterministic tests.

Integration points:

- `CollectionMixin.iterate()` / `AsyncCollectionMixin.iterate()` accept an optional keyword-only `progress` receiver: `set_total_items` after each page fetch (`0` when the response carries no pagination total — treat as unknown), `item_processed` once per record before it is yielded, `completed` once when iteration finishes normally (not on early break or escaped exception).
- `StreamJSONLMixin.stream()` / `AsyncStreamJSONLMixin.stream()` accept the same parameter; `set_total_items` is never called because JSONL responses carry no total. Models are constructed before `item_processed` fires, so a malformed line raises without emitting an item event.
- `docs/usage.md` documents the feature with `ConsoleProgress` and a custom `BatchProgressReport` renderer example, including a note on unknown-total behavior.

Fully backward compatible: `progress` defaults to `None` and changes nothing; exceptions raised by progress receivers propagate and are never swallowed.

The ticket was filed against the Extension Python SDK; it is implemented here instead because the pagination loop and `$meta` parsing live in this client — the SDK inherits the feature through its `mpt-api-client` dependency with no SDK code changes.

## Testing

- Event-order tests via recorder fakes for `iterate()` and `stream()`: single page, multiple pages, empty results, missing `$meta` (reports total `0`), malformed JSONL line (no item event), early consumer break (no `completed`), progress exception propagation, and async mirrors proving methods are awaited.
- Throttling-policy tests via recording subclasses: time-based first-report/throttle/interval-elapse behavior with an injected fake clock, batch-based every-Nth-record behavior, and `completed=True` always reporting, sync and async.
- `ConsoleProgress` tests use an injected fake clock and `StringIO` output: immediate first write, throttling within the interval, write after the interval elapses, unknown-total fallback, final line on `completed`, default-clock path, and protocol `isinstance` checks.
- Full suite: 2348 unit tests pass; `ruff format`, `ruff check`, `flake8`, and `mypy` are clean for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-23360]: https://softwareone.atlassian.net/browse/MPT-23360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
