### PR TITLE
MPT-23362 Add mpt-cli based authentication in client

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,7 +39,7 @@ MPT_API_BASE_URL=<YOUR_MPT_API_BASE_URL>
 
 ## Authentication
 
-Authentication is provided through an `Authentication` provider passed to the client. Two
+Authentication is provided through an `Authentication` provider passed to the client. Three
 implementations are available:
 
 - `BearerTokenAuthentication` — a single, long-lived token.
@@ -49,6 +49,12 @@ implementations are available:
   `401`. Request bodies are buffered in memory before sending so the `401` retry can
   replay one-shot streamed bodies intact. Pass `account_id` to request a token scoped to
   a specific account (`?account.id=<id>`); use one provider instance per account scope.
+- `CLIAccountAuthentication` — reuses the login of the SoftwareOne Marketplace CLI
+  (`mpt-cli`). It reads `~/.swocli/accounts.json` (override with `file_path`) and
+  authenticates with the token of the active account, or of a specific account when
+  `account_id` is passed. The account's API URL is exposed as `environment` so the client
+  base URL can be wired from the same source. Raises `CLIAccountError` when the file is
+  missing or no usable account matches.
 
 ## Instantiate The Client
 
@@ -83,6 +89,18 @@ client = MPTClient.from_config(
         account_id="<account-id>",
     ),
     base_url="https://api.s1.show/public",
+)
+```
+
+With the account you are logged into the marketplace CLI with:
+
+```python
+from mpt_api_client import CLIAccountAuthentication, MPTClient
+
+authentication = CLIAccountAuthentication()
+client = MPTClient.from_config(
+    authentication=authentication,
+    base_url=authentication.environment,
 )
 ```
 

--- a/mpt_api_client/__init__.py
+++ b/mpt_api_client/__init__.py
@@ -1,6 +1,9 @@
 from mpt_api_client.auth import (
     Authentication,
     BearerTokenAuthentication,
+    CLIAccount,
+    CLIAccountAuthentication,
+    CLIAccountError,
     ExtensionFrameworkAuthentication,
 )
 from mpt_api_client.mpt_client import AsyncMPTClient, MPTClient
@@ -10,6 +13,9 @@ __all__ = [  # noqa: WPS410
     "AsyncMPTClient",
     "Authentication",
     "BearerTokenAuthentication",
+    "CLIAccount",
+    "CLIAccountAuthentication",
+    "CLIAccountError",
     "ExtensionFrameworkAuthentication",
     "MPTClient",
     "RQLQuery",

--- a/mpt_api_client/auth/__init__.py
+++ b/mpt_api_client/auth/__init__.py
@@ -1,8 +1,16 @@
 from mpt_api_client.auth.base import Authentication, BearerTokenAuthentication
+from mpt_api_client.auth.cli_account import (
+    CLIAccount,
+    CLIAccountAuthentication,
+    CLIAccountError,
+)
 from mpt_api_client.auth.extension_framework import ExtensionFrameworkAuthentication
 
 __all__ = [  # noqa: WPS410
     "Authentication",
     "BearerTokenAuthentication",
+    "CLIAccount",
+    "CLIAccountAuthentication",
+    "CLIAccountError",
     "ExtensionFrameworkAuthentication",
 ]

--- a/mpt_api_client/auth/cli_account.py
+++ b/mpt_api_client/auth/cli_account.py
@@ -1,0 +1,199 @@
+"""Authentication using accounts managed by the SoftwareOne Marketplace CLI.
+
+The `mpt-cli` tool stores its accounts in ``~/.swocli/accounts.json``. This provider reads
+that file and authenticates with the stored bearer token of the active account (or of an
+explicitly selected account), so scripts can reuse the CLI login without copying tokens.
+"""
+
+import json
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import override
+from urllib.parse import urlsplit
+
+from mpt_api_client.auth.base import BearerTokenAuthentication
+from mpt_api_client.exceptions import MPTError
+
+DEFAULT_ACCOUNTS_FILE_PATH = Path.home() / ".swocli" / "accounts.json"
+
+
+class CLIAccountError(MPTError):
+    """Raised when the CLI accounts file is missing, invalid, or has no usable account."""
+
+
+@dataclass(frozen=True)
+class CLIAccount:
+    """Account entry stored by the SoftwareOne Marketplace CLI."""
+
+    id: str  # noqa: WPS125
+    name: str
+    type: str  # noqa: WPS125
+    token: str
+    token_id: str
+    environment: str
+    is_active: bool
+
+
+class CLIAccountAuthentication(BearerTokenAuthentication):
+    """Authenticate with the bearer token of an account stored by the marketplace CLI.
+
+    By default the active account (``is_active: true``) from ``~/.swocli/accounts.json``
+    is used; pass ``account_id`` to select a specific account instead. The accounts file
+    is read once, eagerly, at construction time.
+
+    The account's API URL is exposed as :attr:`environment` so callers can wire the client
+    base URL from the same source:
+
+        >>> authentication = CLIAccountAuthentication()
+        >>> client = MPTClient.from_config(
+        ...     authentication=authentication,
+        ...     base_url=authentication.environment,
+        ... )
+    """
+
+    def __init__(
+        self,
+        file_path: Path | str | None = None,
+        account_id: str | None = None,
+    ) -> None:
+        """Load the account and initialize the bearer token.
+
+        Args:
+            file_path: Accounts file to read. Defaults to ``~/.swocli/accounts.json``.
+            account_id: When set, select this account instead of the active one.
+
+        Raises:
+            CLIAccountError: If the file is missing or invalid, or no usable account
+                matches the selection.
+        """
+        path = Path(file_path) if file_path else DEFAULT_ACCOUNTS_FILE_PATH
+        accounts = _load_accounts(path)
+        self._account = _select_account(accounts, account_id, path)
+        super().__init__(self._account.token)
+
+    @property
+    def account(self) -> CLIAccount:
+        """The selected CLI account."""
+        return self._account
+
+    @property
+    def environment(self) -> str:
+        """The API base URL stored with the selected account."""
+        return self._account.environment
+
+    @override
+    def configure(self, *, base_url: str, timeout: float, retries: int) -> None:
+        """Warn when the owning client targets a different host than the account.
+
+        Args:
+            base_url: Resolved base URL of the owning client.
+            timeout: HTTP request timeout in seconds.
+            retries: Number of retries configured on the owning client.
+        """
+        client_host = urlsplit(base_url).hostname
+        account_host = urlsplit(self._account.environment).hostname
+        account_id = self._account.id
+        if client_host != account_host:
+            message = (
+                f"The client base URL host ({client_host}) differs from the CLI account "
+                f"'{account_id}' environment host ({account_host}); the account token "
+                "may not be valid there."
+            )
+            warnings.warn(message, UserWarning, stacklevel=2)
+
+
+def _load_accounts(path: Path) -> list[dict[str, object]]:
+    """Read and validate the raw accounts list from the accounts file.
+
+    Args:
+        path: Accounts file to read.
+
+    Returns:
+        The raw account entries.
+
+    Raises:
+        CLIAccountError: If the file is missing, is not valid JSON, or is not a list.
+    """
+    try:
+        raw_content = path.read_text(encoding="utf-8")
+    except OSError:
+        raise CLIAccountError(
+            f"CLI accounts file not found at {path}. "
+            "Log in with the marketplace CLI (`mpt-cli accounts add`) first.",
+        ) from None
+    try:
+        accounts = json.loads(raw_content)
+    except json.JSONDecodeError as decode_error:
+        raise CLIAccountError(
+            f"CLI accounts file {path} is not valid JSON: {decode_error}.",
+        ) from decode_error
+    if not isinstance(accounts, list):
+        raise CLIAccountError(f"CLI accounts file {path} must contain a JSON list of accounts.")
+    return accounts
+
+
+def _select_account(
+    accounts: list[dict[str, object]],
+    account_id: str | None,
+    path: Path,
+) -> CLIAccount:
+    """Select the requested account entry and parse it.
+
+    Args:
+        accounts: Raw account entries from the accounts file.
+        account_id: When set, select this account; otherwise select the active one.
+        path: Accounts file the entries were read from, used in error messages.
+
+    Returns:
+        The selected account.
+
+    Raises:
+        CLIAccountError: If no account (or more than one active account) matches.
+    """
+    if account_id is not None:
+        matches = [entry for entry in accounts if entry.get("id") == account_id]
+        if not matches:
+            raise CLIAccountError(f"Account '{account_id}' not found in {path}.")
+        return _parse_account(matches[0], path)
+    active = [entry for entry in accounts if entry.get("is_active")]
+    if not active:
+        raise CLIAccountError(
+            f"No active account found in {path}. "
+            "Activate one with the marketplace CLI (`mpt-cli accounts activate <id>`).",
+        )
+    if len(active) > 1:
+        active_ids = ", ".join(str(entry.get("id")) for entry in active)
+        raise CLIAccountError(f"Multiple active accounts found in {path}: {active_ids}.")
+    return _parse_account(active[0], path)
+
+
+def _parse_account(entry: dict[str, object], path: Path) -> CLIAccount:
+    """Build a ``CLIAccount`` from a raw entry, requiring token and environment.
+
+    Args:
+        entry: Raw account entry.
+        path: Accounts file the entry was read from, used in error messages.
+
+    Returns:
+        The parsed account.
+
+    Raises:
+        CLIAccountError: If the entry is missing ``token`` or ``environment``.
+    """
+    account_id = str(entry.get("id", ""))
+    token = entry.get("token")
+    environment = entry.get("environment")
+    if not token or not environment:
+        raise CLIAccountError(
+            f"Account '{account_id}' in {path} is missing its token or environment.",
+        )
+    return CLIAccount(
+        id=account_id,
+        name=str(entry.get("name", "")),
+        type=str(entry.get("type", "")),
+        token=str(token),
+        token_id=str(entry.get("token_id", "")),
+        environment=str(environment),
+        is_active=bool(entry.get("is_active")),
+    )

--- a/tests/unit/auth/test_cli_account.py
+++ b/tests/unit/auth/test_cli_account.py
@@ -1,0 +1,158 @@
+import json
+
+import httpx
+import pytest
+
+from mpt_api_client.auth import CLIAccountAuthentication, CLIAccountError
+from mpt_api_client.auth.cli_account import CLIAccount
+from mpt_api_client.http import HTTPClient
+from tests.unit.conftest import API_URL
+
+
+@pytest.fixture
+def active_account():
+    return {
+        "id": "ACC-0000-0001",
+        "name": "SoftwareOne",
+        "type": "Operations",
+        "token": "idt:TKN-0000-0001:active-secret",
+        "token_id": "TKN-0000-0001",
+        "environment": "https://api.example.com/public/v1",
+        "is_active": True,
+    }
+
+
+@pytest.fixture
+def inactive_account():
+    return {
+        "id": "ACC-0000-0002",
+        "name": "Vendor",
+        "type": "Vendor",
+        "token": "idt:TKN-0000-0002:inactive-secret",
+        "token_id": "TKN-0000-0002",
+        "environment": "https://api.other.example.com/public/v1",
+        "is_active": False,
+    }
+
+
+def write_accounts_file(tmp_path, accounts):
+    file_path = tmp_path / "accounts.json"
+    file_path.write_text(json.dumps(accounts))
+    return file_path
+
+
+def create_authentication(tmp_path, accounts, account_id=None):
+    file_path = write_accounts_file(tmp_path, accounts)
+    return CLIAccountAuthentication(file_path=file_path, account_id=account_id)
+
+
+def test_active_account_sets_bearer_header(tmp_path, active_account, inactive_account):
+    authentication = create_authentication(tmp_path, [inactive_account, active_account])
+    request = httpx.Request("GET", f"{API_URL}/")
+
+    sent = next(authentication.auth_flow(request))  # act
+
+    assert sent.headers["Authorization"] == "Bearer idt:TKN-0000-0001:active-secret"
+
+
+def test_exposes_account_and_environment(tmp_path, active_account):
+    authentication = create_authentication(tmp_path, [active_account])  # act
+
+    assert authentication.account == CLIAccount(**active_account)
+    assert authentication.environment == "https://api.example.com/public/v1"
+
+
+def test_selects_account_by_id(tmp_path, active_account, inactive_account):
+    authentication = create_authentication(  # act
+        tmp_path,
+        [active_account, inactive_account],
+        account_id="ACC-0000-0002",
+    )
+
+    assert authentication.account.token == "idt:TKN-0000-0002:inactive-secret"
+
+
+def test_file_missing_raises_error(tmp_path):
+    file_path = tmp_path / "missing.json"
+
+    with pytest.raises(CLIAccountError, match="not found"):
+        CLIAccountAuthentication(file_path=file_path)  # act
+
+
+def test_invalid_json_raises_error(tmp_path):
+    file_path = tmp_path / "accounts.json"
+    file_path.write_text("not-json{")
+
+    with pytest.raises(CLIAccountError, match="not valid JSON"):
+        CLIAccountAuthentication(file_path=file_path)  # act
+
+
+def test_non_list_payload_raises_error(tmp_path):
+    with pytest.raises(CLIAccountError, match="JSON list"):
+        create_authentication(tmp_path, {"id": "ACC-0000-0001"})  # act
+
+
+def test_no_active_account_raises_error(tmp_path, inactive_account):
+    with pytest.raises(CLIAccountError, match="No active account"):
+        create_authentication(tmp_path, [inactive_account])  # act
+
+
+def test_multiple_active_accounts_raise_error(tmp_path, active_account, inactive_account):
+    accounts = [active_account, {**inactive_account, "is_active": True}]
+
+    with pytest.raises(CLIAccountError, match="Multiple active accounts"):
+        create_authentication(tmp_path, accounts)  # act
+
+
+@pytest.mark.parametrize("missing_field", ["token", "environment"])
+def test_missing_required_field_raises_error(tmp_path, active_account, missing_field):
+    active_account.pop(missing_field)
+
+    with pytest.raises(CLIAccountError, match="missing its token or environment"):
+        create_authentication(tmp_path, [active_account])  # act
+
+
+def test_unknown_account_id_raises_error(tmp_path, active_account):
+    with pytest.raises(CLIAccountError, match="'ACC-9999-9999' not found"):
+        create_authentication(tmp_path, [active_account], account_id="ACC-9999-9999")  # act
+
+
+def test_unknown_extra_fields_are_tolerated(tmp_path, active_account):
+    accounts = [{**active_account, "extra": "field"}]
+
+    authentication = create_authentication(tmp_path, accounts)  # act
+
+    assert authentication.account.id == "ACC-0000-0001"
+
+
+def test_configure_warns_on_host_mismatch(tmp_path, active_account):
+    authentication = create_authentication(tmp_path, [active_account])
+
+    with pytest.warns(UserWarning, match="differs from the CLI account"):
+        HTTPClient(base_url="https://api.elsewhere.com", authentication=authentication)  # act
+
+
+def test_configure_does_not_warn_on_matching_host(tmp_path, active_account, recwarn):
+    authentication = create_authentication(tmp_path, [active_account])
+
+    HTTPClient(  # act
+        base_url="https://api.example.com/public/v1",
+        authentication=authentication,
+    )
+
+    user_warnings = [warning for warning in recwarn if warning.category is UserWarning]
+    assert not user_warnings
+
+
+def test_default_path_reads_home_swocli(tmp_path, active_account, mocker):
+    swocli_dir = tmp_path / ".swocli"
+    swocli_dir.mkdir()
+    (swocli_dir / "accounts.json").write_text(json.dumps([active_account]))
+    mocker.patch(
+        "mpt_api_client.auth.cli_account.DEFAULT_ACCOUNTS_FILE_PATH",
+        swocli_dir / "accounts.json",
+    )
+
+    authentication = CLIAccountAuthentication()  # act
+
+    assert authentication.account.id == "ACC-0000-0001"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Adds `CLIAccountAuthentication`, a new authentication provider that reuses the SoftwareOne Marketplace CLI (`mpt-cli`) login so scripts can run against the account selected in the CLI without copying tokens:

```python
from mpt_api_client import CLIAccountAuthentication, MPTClient

auth = CLIAccountAuthentication()
client = MPTClient.from_config(authentication=auth, base_url=auth.environment)
```

- Reads `~/.swocli/accounts.json` (override with `file_path`) eagerly at construction and authenticates with the bearer token of the active account, or of a specific account when `account_id` is passed.
- Extends `BearerTokenAuthentication`, so it works with both `MPTClient` and `AsyncMPTClient`.
- Exposes the selected account and its API URL (`account`, `environment` properties) so the client base URL can be wired from the same source.
- Emits a `UserWarning` when the owning client's base URL host differs from the account's environment host.
- Raises `CLIAccountError` with actionable messages for: missing file, invalid JSON, non-list payload, no active account, multiple active accounts, missing token/environment, unknown account id.
- Exported from the package root and `mpt_api_client.auth`; documented in `docs/usage.md`.

## Testing

- 15 new unit tests in `tests/unit/auth/test_cli_account.py` covering header injection, account selection, all error paths, the host-mismatch warning, and the default path.
- Full validation passes: `ruff format --check`, `ruff check`, `flake8`, `mypy`, `uv lock --check`, and the full unit suite (2327 passed).
- Smoke-tested end-to-end against a real `~/.swocli/accounts.json`: client built from the active account fetched a products page successfully.

MPT-23362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23362](https://softwareone.atlassian.net/browse/MPT-23362)

- Added `CLIAccountAuthentication` using `mpt-cli` account data from `~/.swocli/accounts.json`.
- Supports active or explicit account selection and exposes account/environment details.
- Added validation, account errors, and environment host mismatch warnings.
- Exported CLI authentication types from the package root and `mpt_api_client.auth`.
- Documented usage and added comprehensive unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23362]: https://softwareone.atlassian.net/browse/MPT-23362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ