### PR TITLE
[BACKPORT] MPT-23517 use shared coderabbit config on release/5

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Backports the shared CodeRabbit configuration switch to `release/5`. Closes [MPT-23517](https://softwareone.atlassian.net/browse/MPT-23517).

## Root cause

`release/5` points `.coderabbit.yaml` at the playground config `swo-extension-playground/.coderabbit.yaml`, which **itself** contains another `remote_config` pointing to `mpt-extension-skills`.

CodeRabbit resolves only one hop: it honors the local `remote_config` and loads the playground file, but does **not** follow the playground file's nested `remote_config`. As a result it (a) flags that nested key as `Unrecognized key: "remote_config"`, and (b) never applies the real `mpt-extension-skills` shared settings.

`main` points `.coderabbit.yaml` directly to `mpt-extension-skills` (single hop, complete config, no nested `remote_config`), so it works cleanly. That switch was made on `main` (commit `d096d1ac`, 2026-06-04, part of the MPT-21850 shared-config migration) but was never backported to `release/5`.

> Note: the public CodeRabbit JSON schema does not document `remote_config`, but CodeRabbit does honor it as a directive to pull a shared config from a URL — the warning's `(via .coderabbit.yaml)` proves the local directive was followed. The warning is about the *nested* `remote_config` in the fetched playground file, not the top-level directive.

## Change

Point `release/5`'s `.coderabbit.yaml` directly to the `mpt-extension-skills` shared config, making it byte-identical to `main`:

```diff
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"
```

This removes the double indirection, so the `Unrecognized key: "remote_config"` warning disappears and the shared config is actually applied — including `auto_review.base_branches: [main, release/.*]`, which enables CodeRabbit review on `release/*` PRs, matching `main`'s behaviour.

## Testing

No code change; `.coderabbit.yaml` is now byte-identical to `main`.


[MPT-23517]: https://softwareone.atlassian.net/browse/MPT-23517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ