### PR TITLE
MPT-24248 Add streaming read mode with MPT-Streaming opt-in

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,8 @@ mpt_api_client/
 │       ├── disable_mixin.py
 │       ├── download_file_mixin.py
 │       ├── file_operations_mixin.py
+│       ├── stream_jsonl_mixin.py
+│       ├── streaming_mixin.py
 │       ├── queryable_mixin.py
 │       └── resource_mixins.py
 │
@@ -133,8 +135,20 @@ Services are composed using **mixins** that add HTTP operations:
 | `DownloadFileMixin` | download binary content |
 | `EnableMixin` / `DisableMixin` | enable/disable actions |
 | `QueryableMixin` | `filter()`, `order_by()`, `select()` — RQL query chaining |
-| `StreamJSONLMixin` | `stream()` — stream JSONL records line by line (e.g. billing charges) |
+| `StreamingMixin` | `stream()` — streaming read mode, opted into with the `MPT-Streaming` header |
+| `StreamJSONLMixin` | `stream()` — JSONL endpoints that define their own meaning for `application/jsonl` (billing statement charges) |
 | `FilesOperationsMixin` | combined file create / update / download operations |
+
+The table lists the synchronous names; every mixin except `QueryableMixin`, which is shared,
+has an `Async*` counterpart for composition with `AsyncService`.
+
+The platform streaming contract (`StreamingMixin` / `AsyncStreamingMixin`) and the
+endpoint-specific JSONL contract (`StreamJSONLMixin` / `AsyncStreamJSONLMixin`) both expose
+`stream()`, and a service must compose only one of them. The platform mixins request the
+streaming read mode on a regular collection route and require the API to echo the
+`MPT-Streaming` response header, raising `MPTStreamingNotEnabledError` when it does not. The
+JSONL mixins serve endpoints that assign `application/jsonl` their own meaning outside
+streaming mode.
 
 Example service definition:
 
@@ -193,10 +207,12 @@ See [the RQL guide](rql.md) for the fluent query builder, filter chaining, and u
 
 ### Error Handling — `exceptions.py`
 
-All API errors are wrapped in a hierarchy:
+Client, transport, and API errors use the following hierarchy:
 
 ```text
 MPTError
-├── MPTHttpError          # generic HTTP error (status_code, message, body)
-│   └── MPTAPIError       # structured API error (payload, title, detail, trace_id)
+├── MPTStreamingNotEnabledError  # streaming request the API did not answer in streaming mode
+├── MPTMaxRetryError             # retry attempts exhausted
+└── MPTHttpError                 # generic HTTP error (status_code, message, body)
+    └── MPTAPIError              # structured API error (payload, title, detail, trace_id)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -180,9 +180,10 @@ for invoice in client.billing.invoices.iterate(progress=LogProgress(batch_size=1
 > `set_total_items` is still called but receives `0` — treat a total of `0` as
 > unknown when rendering progress.
 
-The `progress` parameter is also accepted by `stream()` on JSONL endpoints; there
-`set_total_items` is never called because JSONL responses carry no total, so design
-progress implementations for an unknown total. The async `iterate()` and `stream()` accept an
+The `progress` parameter is also accepted by both `stream()` variants described in
+[Streaming Large Result Sets](#streaming-large-result-sets); there `set_total_items` is never
+called because a streamed response carries no pagination total, so design progress
+implementations for an unknown total. The async `iterate()` and `stream()` accept an
 `AsyncProgress` implementation whose methods are `async def` and are awaited —
 `AsyncConsoleProgress` is the shipped counterpart, with `AsyncProgressReport`,
 `AsyncTimeProgressReport`, and `AsyncBatchProgressReport` as the async abstract bases.
@@ -210,6 +211,97 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Streaming Large Result Sets
+
+The platform can return a full filtered result set as a single stream instead of a paged
+collection. Streaming is opted into per request with the `MPT-Streaming` header, which
+`StreamingMixin` and `AsyncStreamingMixin` send on your behalf. Records are yielded one at a
+time without buffering the whole body, so memory stays flat regardless of result size.
+
+No shipped service composes these mixins yet, so compose a service to reach streaming:
+
+```python
+from mpt_api_client import MPTClient, BearerTokenAuthentication, RQLQuery
+from mpt_api_client.http import Service
+from mpt_api_client.http.mixins import StreamingMixin
+from mpt_api_client.models import Model
+
+
+class OrdersStreamService(StreamingMixin[Model], Service[Model]):
+    _endpoint = "/public/v1/commerce/orders"
+    _model_class = Model
+
+
+client = MPTClient.from_config(
+    authentication=BearerTokenAuthentication("your-token"),
+    base_url="https://api.example.com",
+)
+service = OrdersStreamService(http_client=client.http_client)
+
+for order in service.filter(RQLQuery(status="Processing")).stream():
+    print(order.id)
+```
+
+Streaming mixins extend `QueryableMixin`, so `filter()`, `order_by()` and `select()` chain
+before `stream()` exactly as they do before `iterate()`. Membership is fixed when the stream
+opens: records created afterwards are not included.
+
+The async form yields from an async generator:
+
+```python
+import asyncio
+
+from mpt_api_client import AsyncMPTClient, BearerTokenAuthentication
+from mpt_api_client.http import AsyncService
+from mpt_api_client.http.mixins import AsyncStreamingMixin
+from mpt_api_client.models import Model
+
+
+class AsyncOrdersStreamService(AsyncStreamingMixin[Model], AsyncService[Model]):
+    _endpoint = "/public/v1/commerce/orders"
+    _model_class = Model
+
+
+async def main():
+    client = AsyncMPTClient.from_config(
+        authentication=BearerTokenAuthentication("<token>"),
+        base_url="https://api.s1.show/public",
+    )
+    service = AsyncOrdersStreamService(http_client=client.http_client)
+
+    async for order in service.stream():
+        print(order.id)
+
+
+asyncio.run(main())
+```
+
+### Streaming Confirmation
+
+The API confirms streaming mode by echoing the `MPT-Streaming` response header. When it does
+not, the body is an ordinary paged response, and consuming it as a stream would silently
+return only the first page. `stream()` raises `MPTStreamingNotEnabledError` before reading the
+body instead:
+
+```python
+from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+
+try:
+    for order in service.stream():
+        print(order.id)
+except MPTStreamingNotEnabledError as error:
+    logger.error("Endpoint did not stream: %s", error)
+```
+
+Treat this as a request-shape or endpoint-support problem, not a transient failure: retrying
+the same call against an endpoint that does not support streaming mode fails the same way.
+
+> **Note:** `StreamJSONLMixin` also exposes `stream()`, but it serves endpoints that assign
+> `application/jsonl` their own meaning outside streaming mode, such as billing statement
+> charges. It sends no `MPT-Streaming` header and performs no confirmation check. A service
+> composes one streaming mixin or the other, never both. See
+> [architecture.md](architecture.md) for the distinction.
 
 ## Navigate The API Surface
 

--- a/mpt_api_client/constants.py
+++ b/mpt_api_client/constants.py
@@ -1,3 +1,6 @@
 APPLICATION_JSON = "application/json"
 APPLICATION_JSONL = "application/jsonl"
 MIMETYPE_EXCEL_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+MPT_STREAMING_HEADER = "MPT-Streaming"
+MPT_STREAMING_ENABLED = "true"

--- a/mpt_api_client/exceptions.py
+++ b/mpt_api_client/exceptions.py
@@ -3,9 +3,30 @@ from typing import override
 
 from httpx import HTTPStatusError
 
+from mpt_api_client.constants import MPT_STREAMING_ENABLED, MPT_STREAMING_HEADER
+
 
 class MPTError(Exception):
     """Represents a generic MPT error."""
+
+
+class MPTStreamingNotEnabledError(MPTError):
+    """Represents a streaming request the API did not answer in streaming mode.
+
+    The API confirms streaming mode by echoing the ``MPT-Streaming`` response header.
+    Without that confirmation the body is a regular paged response, and consuming it as
+    a stream would yield a silently incomplete result, so the response is not read.
+    """
+
+    def __init__(self, path: str, echoed_value: str | None):
+        self.path = path
+        self.echoed_value = echoed_value
+        received = "no header" if echoed_value is None else f"'{echoed_value}'"
+        super().__init__(
+            f"The API did not confirm streaming mode for '{path}': expected the "
+            f"{MPT_STREAMING_HEADER} response header to be '{MPT_STREAMING_ENABLED}', "
+            f"got {received}. The response body was not consumed."
+        )
 
 
 class MPTHttpError(MPTError):

--- a/mpt_api_client/http/mixins/__init__.py
+++ b/mpt_api_client/http/mixins/__init__.py
@@ -30,6 +30,10 @@ from mpt_api_client.http.mixins.stream_jsonl_mixin import (
     AsyncStreamJSONLMixin,
     StreamJSONLMixin,
 )
+from mpt_api_client.http.mixins.streaming_mixin import (
+    AsyncStreamingMixin,
+    StreamingMixin,
+)
 from mpt_api_client.http.mixins.update_file_mixin import (
     AsyncUpdateFileMixin,
     UpdateFileMixin,
@@ -49,6 +53,7 @@ __all__ = [  # noqa: WPS410
     "AsyncManagedResourceMixin",
     "AsyncModifiableResourceMixin",
     "AsyncStreamJSONLMixin",
+    "AsyncStreamingMixin",
     "AsyncUpdateFileMixin",
     "AsyncUpdateMixin",
     "CollectionMixin",
@@ -64,6 +69,7 @@ __all__ = [  # noqa: WPS410
     "ModifiableResourceMixin",
     "QueryableMixin",
     "StreamJSONLMixin",
+    "StreamingMixin",
     "UpdateFileMixin",
     "UpdateMixin",
 ]

--- a/mpt_api_client/http/mixins/streaming_mixin.py
+++ b/mpt_api_client/http/mixins/streaming_mixin.py
@@ -1,0 +1,130 @@
+import json
+from collections.abc import AsyncIterator, Iterator, Mapping
+
+from mpt_api_client.constants import (
+    APPLICATION_JSONL,
+    MPT_STREAMING_ENABLED,
+    MPT_STREAMING_HEADER,
+)
+from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+from mpt_api_client.http.mixins.queryable_mixin import QueryableMixin
+from mpt_api_client.http.types import HeaderTypes
+from mpt_api_client.models import AsyncProgress, Progress
+from mpt_api_client.models import Model as BaseModel
+
+
+def streaming_request_headers() -> HeaderTypes:
+    """Build the headers that opt a collection request into streaming mode.
+
+    Returns:
+        Headers requesting streaming mode with line-delimited output.
+    """
+    return {
+        "Accept": APPLICATION_JSONL,
+        MPT_STREAMING_HEADER: MPT_STREAMING_ENABLED,
+    }
+
+
+def confirm_streaming_mode(response_headers: Mapping[str, str], path: str) -> None:
+    """Verify the API answered a streaming request in streaming mode.
+
+    Args:
+        response_headers: Headers of the streaming response.
+        path: Requested path, used to build the error message.
+
+    Raises:
+        MPTStreamingNotEnabledError: If the response does not echo the streaming header.
+    """
+    echoed_value = response_headers.get(MPT_STREAMING_HEADER)
+    if echoed_value is None or echoed_value.strip().lower() != MPT_STREAMING_ENABLED:
+        raise MPTStreamingNotEnabledError(path, echoed_value)
+
+
+class StreamingMixin[Model: BaseModel](QueryableMixin):
+    """Mixin providing the platform streaming read mode for a collection endpoint.
+
+    Streaming mode is opted into with the ``MPT-Streaming`` request header on the regular
+    collection route, so the same filters, ordering and field selection apply. It is
+    distinct from `StreamJSONLMixin`, which consumes endpoints that assign
+    ``application/jsonl`` their own meaning outside streaming mode.
+    """
+
+    def stream(self, *, progress: Progress | None = None) -> Iterator[Model]:
+        """Stream the full result set in streaming mode, yielding one model per record.
+
+        Unlike ``iterate()``, which pages through the collection and deserializes whole
+        pages, this consumes a single line-delimited response without buffering the body.
+        Membership is fixed when the stream opens, so records added afterwards are absent.
+
+        Args:
+            progress: Optional progress receiver. `item_processed` is called once per
+                record before it is yielded and `completed` once when the response body
+                is fully consumed. `set_total_items` is never called.
+
+        Yields:
+            Resources, one per non-empty line of the response.
+
+        Raises:
+            MPTStreamingNotEnabledError: If the API does not confirm streaming mode.
+        """
+        path = self.build_path()  # type: ignore[attr-defined]
+        with self.http_client.stream(  # type: ignore[attr-defined]
+            "GET",
+            path,
+            headers=streaming_request_headers(),
+        ) as response:
+            confirm_streaming_mode(response.headers, path)
+            for line in response.iter_lines():
+                if not line.strip():
+                    continue
+                model = self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if progress:
+                    progress.item_processed()
+                yield model
+        if progress:
+            progress.completed()
+
+
+class AsyncStreamingMixin[Model: BaseModel](QueryableMixin):
+    """Async mixin providing the platform streaming read mode for a collection endpoint.
+
+    Streaming mode is opted into with the ``MPT-Streaming`` request header on the regular
+    collection route, so the same filters, ordering and field selection apply. It is
+    distinct from `AsyncStreamJSONLMixin`, which consumes endpoints that assign
+    ``application/jsonl`` their own meaning outside streaming mode.
+    """
+
+    async def stream(self, *, progress: AsyncProgress | None = None) -> AsyncIterator[Model]:
+        """Stream the full result set in streaming mode, yielding one model per record.
+
+        Unlike ``iterate()``, which pages through the collection and deserializes whole
+        pages, this consumes a single line-delimited response without buffering the body.
+        Membership is fixed when the stream opens, so records added afterwards are absent.
+
+        Args:
+            progress: Optional progress receiver. `item_processed` is awaited once per
+                record before it is yielded and `completed` once when the response body
+                is fully consumed. `set_total_items` is never called.
+
+        Yields:
+            Resources, one per non-empty line of the response.
+
+        Raises:
+            MPTStreamingNotEnabledError: If the API does not confirm streaming mode.
+        """
+        path = self.build_path()  # type: ignore[attr-defined]
+        async with self.http_client.stream(  # type: ignore[attr-defined]
+            "GET",
+            path,
+            headers=streaming_request_headers(),
+        ) as response:
+            confirm_streaming_mode(response.headers, path)
+            async for line in response.aiter_lines():
+                if not line.strip():
+                    continue
+                model = self._model_class(json.loads(line))  # type: ignore[attr-defined]
+                if progress:
+                    await progress.item_processed()  # noqa: WPS476
+                yield model
+        if progress:
+            await progress.completed()

--- a/tests/unit/http/mixins/test_streaming_mixin.py
+++ b/tests/unit/http/mixins/test_streaming_mixin.py
@@ -1,0 +1,165 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client import RQLQuery
+from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import AsyncStreamingMixin, StreamingMixin
+from tests.unit.conftest import API_URL, DummyModel
+from tests.unit.http.conftest import AsyncRecordingProgress, RecordingProgress
+
+STREAM_URL = f"{API_URL}/api/v1/orders"
+JSONL_BODY = b'{"id": "ID-1", "name": "Order 1"}\n\n{"id": "ID-2", "name": "Order 2"}\n'
+NOT_CONFIRMED_MATCH = "did not confirm streaming mode"
+
+
+class DummyStreamingService(
+    StreamingMixin[DummyModel],
+    Service[DummyModel],
+):
+    _endpoint = "/api/v1/orders"
+    _model_class = DummyModel
+
+
+class AsyncDummyStreamingService(
+    AsyncStreamingMixin[DummyModel],
+    AsyncService[DummyModel],
+):
+    _endpoint = "/api/v1/orders"
+    _model_class = DummyModel
+
+
+@pytest.fixture
+def streaming_service(http_client):
+    return DummyStreamingService(http_client=http_client)
+
+
+@pytest.fixture
+def async_streaming_service(async_http_client):
+    return AsyncDummyStreamingService(http_client=async_http_client)
+
+
+def streaming_response():
+    return jsonl_response({"MPT-Streaming": "true"})
+
+
+def jsonl_response(headers=None):
+    return httpx.Response(httpx.codes.OK, content=JSONL_BODY, headers=headers)
+
+
+@respx.mock
+def test_stream_sends_streaming_opt_in_headers(streaming_service):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    list(streaming_service.stream())  # act
+
+    request = route.calls[0].request
+    assert request.headers["MPT-Streaming"] == "true"
+    assert request.headers["Accept"] == "application/jsonl"
+
+
+@respx.mock
+def test_stream_yields_models(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    result = list(streaming_service.stream())
+
+    assert [order.id for order in result] == ["ID-1", "ID-2"]
+    assert all(isinstance(order, DummyModel) for order in result)
+
+
+@respx.mock
+def test_stream_applies_query_filters(streaming_service):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    result = list(streaming_service.filter(RQLQuery(status="active")).stream())
+
+    request = route.calls[0].request
+    assert result
+    assert "status" in request.url.query.decode()
+
+
+@respx.mock
+def test_stream_raises_when_not_confirmed(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=jsonl_response())
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotEnabledError, match=NOT_CONFIRMED_MATCH):
+        next(iterator)
+
+
+@respx.mock
+def test_stream_raises_on_false_header(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=jsonl_response({"MPT-Streaming": "false"}))
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotEnabledError, match="got 'false'"):
+        next(iterator)
+
+
+@respx.mock
+def test_stream_accepts_uppercase_value(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=jsonl_response({"MPT-Streaming": "True"}))
+
+    result = list(streaming_service.stream())
+
+    assert [order.id for order in result] == ["ID-1", "ID-2"]
+
+
+@respx.mock
+def test_stream_progress_events(streaming_service, recording_progress: RecordingProgress):
+    respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    list(streaming_service.stream(progress=recording_progress))  # act
+
+    assert recording_progress.events == [
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]
+
+
+@respx.mock
+async def test_async_stream_sends_opt_in_headers(async_streaming_service):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    [order async for order in async_streaming_service.stream()]  # act
+
+    request = route.calls[0].request
+    assert request.headers["MPT-Streaming"] == "true"
+    assert request.headers["Accept"] == "application/jsonl"
+
+
+@respx.mock
+async def test_async_stream_yields_models(async_streaming_service):
+    respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    result = [order async for order in async_streaming_service.stream()]
+
+    assert [order.id for order in result] == ["ID-1", "ID-2"]
+    assert all(isinstance(order, DummyModel) for order in result)
+
+
+@respx.mock
+async def test_async_stream_raises_not_confirmed(async_streaming_service):
+    respx.get(STREAM_URL).mock(return_value=jsonl_response())
+    iterator = async_streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotEnabledError, match=NOT_CONFIRMED_MATCH):
+        await anext(iterator)
+
+
+@respx.mock
+async def test_async_stream_progress_events(
+    async_streaming_service, async_recording_progress: AsyncRecordingProgress
+):
+    respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    [order async for order in async_streaming_service.stream(progress=async_recording_progress)]
+
+    assert async_recording_progress.events == [
+        ("item_processed",),
+        ("item_processed",),
+        ("completed",),
+    ]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Adds `StreamingMixin` / `AsyncStreamingMixin`, which consume the platform streaming read mode
defined by [TDR - Streaming API](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7751598153)
and implemented framework-side in MPT-23798.

Streaming is opted into with the `MPT-Streaming: true` request header on the regular collection
route, so it inherits the existing RQL filters, ordering and field selection. Both mixins extend
`QueryableMixin`, so `.filter(...).stream()` works as expected.

- `mpt_api_client/http/mixins/streaming_mixin.py` — new sync and async mixins
- `mpt_api_client/exceptions.py` — new `MPTStreamingNotEnabledError`
- `mpt_api_client/constants.py` — `MPT_STREAMING_HEADER`, `MPT_STREAMING_ENABLED`
- `docs/architecture.md` — mixin table, module listing, exception hierarchy

## Why the response-echo guard

The API confirms streaming mode by echoing the `MPT-Streaming` response header. Without that
confirmation, the body is a **regular paged response** — so consuming it as a stream would
silently return just the first page and stop, with no error. `MPTStreamingNotEnabledError` is
raised before the body is read, which turns a plausible-looking short result into a visible
failure.

## Why a separate mixin rather than extending `StreamJSONLMixin`

The existing `StreamJSONLMixin` (added under MPT-21666 for the charges-download command) is
**not** an earlier version of this feature. It serves endpoints that assign
`application/jsonl` their own meaning *outside* streaming mode — confirmed by the framework
author as permanent behaviour, and permitted by TDR §4.8. Its contract differs: no
`MPT-Item-Count`, no deletion stubs, no abort-on-error semantics.

Keeping the paths separate means the completeness and stub handling in the follow-up stories can
apply cleanly to streaming mode without weakening the legacy path. `StreamJSONLMixin` is
untouched by this PR.

Both mixins expose `stream()`, so a service must compose only one. This is called out in
`docs/architecture.md`, and is a design input for MPT-24241 (streaming on the collection layer).

## Deliberately out of scope

This is the first of several subtasks under MPT-24235, so the following are intentionally absent:

| Follow-up | Subtask |
|---|---|
| Map `406` / `501` to typed exceptions | MPT-24249 |
| Verify emitted count against `MPT-Item-Count` | MPT-24250 |
| `$meta.deleted` deletion stubs | MPT-24251 |
| Stream-safe retry and truncation detection | MPT-24252, MPT-24253 |

No explicit `limit` is sent: the TDR treats an absent `limit` as the full snapshot, same as
`limit=-1`, so this avoids pre-empting the limit/offset semantics still under discussion in
MPT-24223.

## Testing

- 11 new unit tests covering the opt-in headers, model yielding, RQL pass-through, progress
  events, and three confirmation-failure cases (absent header, `false`, case-insensitive `True`)
- `make check-all` green: ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, 2347 tests
- 100% coverage on the new module

Also removes two dead `# noqa: WPS215` suppressions from the JSONL stream tests — the dummy
services declare two base classes and the rule allows three, so they never applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added synchronous and asynchronous collection streaming with `StreamingMixin` and `AsyncStreamingMixin`.
- Added streaming header constants and response confirmation through `MPTStreamingNotEnabledError`.
- Preserved RQL filtering, ordering, and field selection during streaming.
- Added progress callbacks and JSONL model deserialization without response buffering.
- Updated usage and architecture documentation.
- Added synchronous and asynchronous streaming tests.
- Removed two obsolete `WPS215` suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->