### PR TITLE
MPT-24293 drop inert inline WPS215 suppressions

### DIFF
--- a/mpt_api_client/resources/catalog/pricing_policies.py
+++ b/mpt_api_client/resources/catalog/pricing_policies.py
@@ -54,7 +54,7 @@ class PricingPoliciesServiceConfig:
     _collection_key = "data"
 
 
-class PricingPoliciesService(  # noqa: WPS215
+class PricingPoliciesService(
     ManagedResourceMixin[PricingPolicy],
     CollectionMixin[PricingPolicy],
     Service[PricingPolicy],

--- a/mpt_api_client/resources/commerce/orders.py
+++ b/mpt_api_client/resources/commerce/orders.py
@@ -100,7 +100,7 @@ class OrdersServiceConfig:
     _collection_key = "data"
 
 
-class OrdersService(  # noqa: WPS215 WPS214
+class OrdersService(  # noqa: WPS214
     RenderMixin[Order],
     TemplateMixin[Order],
     ManagedResourceMixin[Order],
@@ -205,7 +205,7 @@ class OrdersService(  # noqa: WPS215 WPS214
         )
 
 
-class AsyncOrdersService(  # noqa: WPS215 WPS214
+class AsyncOrdersService(  # noqa: WPS214
     AsyncRenderMixin[Order],
     AsyncTemplateMixin[Order],
     AsyncManagedResourceMixin[Order],

--- a/mpt_api_client/resources/commerce/orders_asset.py
+++ b/mpt_api_client/resources/commerce/orders_asset.py
@@ -44,7 +44,7 @@ class OrdersAssetServiceConfig:
     _collection_key = "data"
 
 
-class OrdersAssetService(  # noqa: WPS215
+class OrdersAssetService(
     RenderMixin[OrdersAsset],
     ManagedResourceMixin[OrdersAsset],
     CollectionMixin[OrdersAsset],
@@ -54,7 +54,7 @@ class OrdersAssetService(  # noqa: WPS215
     """Orders Asset service."""
 
 
-class AsyncOrdersAssetService(  # noqa: WPS215
+class AsyncOrdersAssetService(
     AsyncRenderMixin[OrdersAsset],
     AsyncManagedResourceMixin[OrdersAsset],
     AsyncCollectionMixin[OrdersAsset],

--- a/mpt_api_client/resources/commerce/orders_subscription.py
+++ b/mpt_api_client/resources/commerce/orders_subscription.py
@@ -55,7 +55,7 @@ class OrderSubscriptionsServiceConfig:
     _collection_key = "data"
 
 
-class OrderSubscriptionsService(  # noqa: WPS215
+class OrderSubscriptionsService(
     ManagedResourceMixin[OrderSubscription],
     CollectionMixin[OrderSubscription],
     Service[OrderSubscription],
@@ -64,7 +64,7 @@ class OrderSubscriptionsService(  # noqa: WPS215
     """Orders Subscription service."""
 
 
-class AsyncOrderSubscriptionsService(  # noqa: WPS215
+class AsyncOrderSubscriptionsService(
     AsyncManagedResourceMixin[OrderSubscription],
     AsyncCollectionMixin[OrderSubscription],
     AsyncService[OrderSubscription],

--- a/mpt_api_client/resources/commerce/subscriptions.py
+++ b/mpt_api_client/resources/commerce/subscriptions.py
@@ -78,7 +78,7 @@ class SubscriptionsServiceConfig:
     _collection_key = "data"
 
 
-class SubscriptionsService(  # noqa: WPS215
+class SubscriptionsService(
     CreateMixin[Subscription],
     UpdateMixin[Subscription],
     GetMixin[Subscription],
@@ -91,7 +91,7 @@ class SubscriptionsService(  # noqa: WPS215
     """Subscription service."""
 
 
-class AsyncSubscriptionsService(  # noqa: WPS215
+class AsyncSubscriptionsService(
     AsyncCreateMixin[Subscription],
     AsyncUpdateMixin[Subscription],
     AsyncGetMixin[Subscription],

--- a/tests/unit/http/conftest.py
+++ b/tests/unit/http/conftest.py
@@ -15,7 +15,7 @@ from mpt_api_client.http.mixins import (
 from tests.unit.conftest import DummyModel
 
 
-class DummyService(  # noqa: WPS215
+class DummyService(
     ManagedResourceMixin[DummyModel],
     CollectionMixin[DummyModel],
     Service[DummyModel],
@@ -24,7 +24,7 @@ class DummyService(  # noqa: WPS215
     _model_class = DummyModel
 
 
-class AsyncDummyService(  # noqa: WPS215
+class AsyncDummyService(
     AsyncManagedResourceMixin[DummyModel],
     AsyncCollectionMixin[DummyModel],
     AsyncService[DummyModel],

--- a/tests/unit/http/mixins/test_stream_jsonl_mixin.py
+++ b/tests/unit/http/mixins/test_stream_jsonl_mixin.py
@@ -12,7 +12,7 @@ JSONL_BODY = b'{"id": "ID-1", "name": "Charge 1"}\n\n{"id": "ID-2", "name": "Cha
 MALFORMED_JSONL_BODY = b'not-json\n{"id": "ID-1", "name": "Charge 1"}\n'
 
 
-class DummyStreamService(  # noqa: WPS215
+class DummyStreamService(
     StreamJSONLMixin[DummyModel],
     Service[DummyModel],
 ):
@@ -20,7 +20,7 @@ class DummyStreamService(  # noqa: WPS215
     _model_class = DummyModel
 
 
-class AsyncDummyStreamService(  # noqa: WPS215
+class AsyncDummyStreamService(
     AsyncStreamJSONLMixin[DummyModel],
     AsyncService[DummyModel],
 ):

--- a/tests/unit/http/test_base_service.py
+++ b/tests/unit/http/test_base_service.py
@@ -4,7 +4,7 @@ from tests.unit.conftest import DummyModel
 from tests.unit.http.conftest import DummyService
 
 
-class ParametrisedDummyService(  # noqa: WPS215
+class ParametrisedDummyService(
     Service[DummyModel],
 ):
     _endpoint = "/api/{version}/test/{tenant}"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Removes all 14 inline `# noqa: WPS215` comments in the repository. Comment-only change; no behaviour change.

WPS215 ("too many base classes") has a default limit of 3 and fires only *above* 3. Each suppression was inert for one of two reasons, checked per site.

### Dead on base-class count (tests)

| Site | Base classes |
| --- | --- |
| `tests/unit/http/test_base_service.py` — `ParametrisedDummyService` | 1 |
| `tests/unit/http/conftest.py` — `DummyService` | 3 (at the limit) |
| `tests/unit/http/conftest.py` — `AsyncDummyService` | 3 |
| `tests/unit/http/mixins/test_stream_jsonl_mixin.py` — `DummyStreamService` | 2 |
| `tests/unit/http/mixins/test_stream_jsonl_mixin.py` — `AsyncDummyStreamService` | 2 |

### Redundant with file-level `per-file-ignores`

The nine remaining sites all sit under `mpt_api_client/resources/`, which `[tool.flake8] per-file-ignores` already covers with `mpt_api_client/resources/*: WPS215`. The inline comment adds nothing there even where the class genuinely exceeds the limit: `pricing_policies.py`, `orders_asset.py` (×2), `subscriptions.py` (×2), `orders_subscription.py` (×2), `orders.py` (×2).

`orders.py` keeps `# noqa: WPS214` — only the WPS215 token is dropped. The `commerce/*.py` entry grants `WPS235 WPS215` but **not** WPS214, and both order services do exceed the method limit, so that half is load-bearing.

### Why this is evidence and not inference

WPS215 is confirmed active: `select` includes `WPS`, `extend-ignore` lists only WPS226/WPS412, and there is no `max-base-classes` override. So `flake8` passing after removal means the rule ran and found nothing — not that it was switched off. That also empirically confirms the file-level glob really does reach `resources/<domain>/*.py`, rather than relying on reading the pattern.

### Overlap with #380

The two `test_stream_jsonl_mixin.py` hunks are byte-identical to the same removal on the MPT-24248 branch (fb85f9b, #380) — same blob hashes — so they merge cleanly whichever lands first. Included here deliberately so `main` does not keep the dead suppressions if #380 slips.

### Follow-up, not in this PR

11 `per-file-ignores` entries mention WPS215, and the nine narrower `resources/<domain>/*.py` ones are subsumed by the broad `resources/*` entry. Dropping the broad entry would re-expose every class under `resources/`, so it needs its own change and validation run. Noted on MPT-24293.

### Testing

`make check-all` green: ruff format (741 files), ruff check, flake8/WPS, mypy (199 source files), `uv lock --check`, and 2336 unit tests passing.

Note on hooks: `pre-commit` is a broken shim in my local environment (`ModuleNotFoundError: No module named 'pre_commit'`) and no `pre-commit` git hook was installed in the clone, so the automatic hook run did not happen. Every hook's check was verified another way — ruff/flake8/mypy/uv-lock via `make check`, and trailing-whitespace, end-of-file, merge-conflict-marker and branch-pattern checks run directly against the committed files, all clean. CI remains the authoritative run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Removed all 14 inline `# noqa: WPS215` comments.
- Preserved the load-bearing `# noqa: WPS214` comments in `orders.py`.
- Introduced no behavior changes.
- Confirmed that `make check-all` passes, including 2,336 unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->