### PR TITLE
MPT-24254 Resolve timeouts per connection phase

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,11 @@ class ProductsService(
 
 Transport-level settings (`base_url`, `timeout`, `retries`) are grouped in the
 `TransportSettings` dataclass (`http/transport_settings.py`), passed to the client
-constructors as `transport=TransportSettings(...)`. To resolve the base URL from the
+constructors as `transport=TransportSettings(...)`. Timeouts resolve per connection phase:
+`connect_timeout`, `read_timeout`, `write_timeout` and `pool_timeout` each fall back to
+`timeout`, and the dataclass exposes two profiles — `request_timeout` for regular requests and
+`stream_timeout`, which substitutes the longer `stream_read_timeout` for the read phase because
+a streamed response defers its first byte until the server has built the result set. To resolve the base URL from the
 `MPT_API_BASE_URL` environment variable instead, pass `EnvTransportSettings()` (the
 default when no transport is given); the clients themselves never read the environment.
 The resolved settings are handed to the authentication provider through

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,43 @@ client = MPTClient.from_config(
 
 `from_config` also accepts a `timeout` argument (HTTP request timeout in seconds, default `60.0`).
 
+### Timeouts
+
+`timeout` sets every connection phase at once. To tune them separately, pass a
+`TransportSettings` instance and set only the phases you care about; each unset phase falls
+back to `timeout`:
+
+```python
+from mpt_api_client import BearerTokenAuthentication, MPTClient, TransportSettings
+from mpt_api_client.http import HTTPClient
+
+client = MPTClient(
+    http_client=HTTPClient(
+        transport=TransportSettings(
+            base_url="https://api.s1.show/public",
+            timeout=20.0,
+            connect_timeout=5.0,
+            read_timeout=60.0,
+        ),
+        authentication=BearerTokenAuthentication("<token>"),
+    )
+)
+```
+
+Two things are worth knowing:
+
+- The **read** timeout, not the connect timeout, governs how long the client waits for a
+  response to start arriving. A server that accepts the connection and then thinks before
+  replying is bounded by `read_timeout`.
+- Streaming requests use `stream_read_timeout` (default `120.0`) in place of the regular read
+  timeout, because a streamed response commits its status only after the server has built the
+  result set — so the first byte can be deferred far longer than for a regular call. The
+  effective streaming read timeout is never lower than `read_timeout`, so raising that raises
+  both.
+
+No total-duration timeout is applied. A long export runs for as long as the server keeps
+sending; the limits are per phase, not overall.
+
 ## Synchronous Usage Patterns
 
 Read a single resource:

--- a/mpt_api_client/http/async_client.py
+++ b/mpt_api_client/http/async_client.py
@@ -42,7 +42,7 @@ class AsyncHTTPClient:
             base_url=self._transport.url,
             headers={"User-Agent": "swo-marketplace-client/1.0"},
             auth=authentication,
-            timeout=self._transport.timeout,
+            timeout=self._transport.request_timeout,
             transport=RetryTransport(retry=self._transport.retry),
             follow_redirects=True,
         )
@@ -143,7 +143,11 @@ class AsyncHTTPClient:
         params_str = get_query_params(query_params, options)
         try:
             async with self.httpx_client.stream(
-                method, url, params=params_str or None, headers=headers
+                method,
+                url,
+                params=params_str or None,
+                headers=headers,
+                timeout=self._transport.stream_timeout,
             ) as response:
                 if response.is_error:
                     await response.aread()

--- a/mpt_api_client/http/client.py
+++ b/mpt_api_client/http/client.py
@@ -52,7 +52,7 @@ class HTTPClient:
             base_url=self._transport.url,
             headers={"User-Agent": "swo-marketplace-client/1.0"},
             auth=authentication,
-            timeout=self._transport.timeout,
+            timeout=self._transport.request_timeout,
             transport=RetryTransport(retry=self._transport.retry),
             follow_redirects=True,
         )
@@ -152,7 +152,11 @@ class HTTPClient:
         params_str = get_query_params(query_params, options)
         try:
             with self.httpx_client.stream(
-                method, url, params=params_str or None, headers=headers
+                method,
+                url,
+                params=params_str or None,
+                headers=headers,
+                timeout=self._transport.stream_timeout,
             ) as response:
                 if response.is_error:
                     response.read()

--- a/mpt_api_client/http/transport_settings.py
+++ b/mpt_api_client/http/transport_settings.py
@@ -2,12 +2,15 @@ import os
 from dataclasses import dataclass
 from typing import cast, override
 
+from httpx import Timeout
 from httpx_retries import Retry
 
 from mpt_api_client.http.client_utils import validate_base_url
 
 RETRY_ALLOWED_METHODS = frozenset(("DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"))
 ENV_BASE_URL = "MPT_API_BASE_URL"
+DEFAULT_TIMEOUT = 20.0
+DEFAULT_STREAM_READ_TIMEOUT = 120.0
 
 
 @dataclass
@@ -18,14 +21,35 @@ class TransportSettings:
         base_url: Base URL of the MPT API; validated and sanitized at construction
             time. Use ``EnvTransportSettings`` to resolve it from the environment
             instead of passing it explicitly.
-        timeout: HTTP request timeout in seconds.
+        timeout: Default timeout in seconds applied to every connection phase that
+            does not set its own value.
+        connect_timeout: Timeout for establishing the connection. Falls back to
+            ``timeout``.
+        read_timeout: Timeout for a single socket read, which includes waiting for the
+            response status line. Falls back to ``timeout``.
+        write_timeout: Timeout for a single socket write. Falls back to ``timeout``.
+        pool_timeout: Timeout for acquiring a connection from the pool. Falls back to
+            ``timeout``.
+        stream_read_timeout: Read timeout applied to streaming requests instead of the
+            regular read timeout. Streaming responses commit their status only after
+            the server has built the result set, so the first byte can be deferred far
+            longer than a regular response; the default covers that wait with headroom.
+            The effective streaming read timeout is never lower than ``read_timeout``.
         retries: Retry policy; either the number of retries for failed requests or a
             fully configured ``httpx_retries.Retry`` instance used as is. Normalized
             to a ``Retry`` instance at construction time.
+
+    No total-duration timeout is applied. A streamed export runs for as long as the
+    server keeps sending, bounded per phase rather than overall.
     """
 
     base_url: str | None = None
-    timeout: float = 20.0
+    timeout: float = DEFAULT_TIMEOUT
+    connect_timeout: float | None = None
+    read_timeout: float | None = None
+    write_timeout: float | None = None
+    pool_timeout: float | None = None
+    stream_read_timeout: float = DEFAULT_STREAM_READ_TIMEOUT
     retries: int | Retry = 5
 
     def __post_init__(self) -> None:
@@ -46,6 +70,30 @@ class TransportSettings:
     def retry(self) -> Retry:
         """Normalized retry policy."""
         return cast("Retry", self.retries)
+
+    @property
+    def request_timeout(self) -> Timeout:
+        """Per-phase timeout for regular requests."""
+        return Timeout(
+            connect=self._phase_timeout(self.connect_timeout),
+            read=self._phase_timeout(self.read_timeout),
+            write=self._phase_timeout(self.write_timeout),
+            pool=self._phase_timeout(self.pool_timeout),
+        )
+
+    @property
+    def stream_timeout(self) -> Timeout:
+        """Per-phase timeout for streaming requests, with a longer read timeout."""
+        return Timeout(
+            connect=self._phase_timeout(self.connect_timeout),
+            read=max(self.stream_read_timeout, self._phase_timeout(self.read_timeout)),
+            write=self._phase_timeout(self.write_timeout),
+            pool=self._phase_timeout(self.pool_timeout),
+        )
+
+    def _phase_timeout(self, phase_value: float | None) -> float:
+        """Return the phase timeout, falling back to the default timeout when unset."""
+        return self.timeout if phase_value is None else phase_value
 
     def _build_retry(self) -> Retry:
         """Return the retry policy, building one when ``retries`` is a plain count."""

--- a/tests/unit/http/test_async_client.py
+++ b/tests/unit/http/test_async_client.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 import respx
-from httpx import ConnectTimeout, Request, Response, codes
+from httpx import ConnectTimeout, Request, Response, Timeout, codes
 
 from mpt_api_client.auth import BearerTokenAuthentication
 from mpt_api_client.exceptions import MPTAPIError, MPTError, MPTMaxRetryError
@@ -36,7 +36,7 @@ def test_async_http_initialization(mocker):
         follow_redirects=True,
         headers={"User-Agent": "swo-marketplace-client/1.0"},
         auth=authentication,
-        timeout=20.0,
+        timeout=Timeout(connect=20.0, read=20.0, write=20.0, pool=20.0),
         transport=mocker.ANY,
     )
 
@@ -52,7 +52,7 @@ def test_async_env_base_url_initialization(monkeypatch, mocker):
         follow_redirects=True,
         headers={"User-Agent": "swo-marketplace-client/1.0"},
         auth=mocker.ANY,
-        timeout=20.0,
+        timeout=Timeout(connect=20.0, read=20.0, write=20.0, pool=20.0),
         transport=mocker.ANY,
     )
 

--- a/tests/unit/http/test_client.py
+++ b/tests/unit/http/test_client.py
@@ -3,14 +3,20 @@ import json
 
 import pytest
 import respx
-from httpx import ConnectTimeout, Response, codes
+from httpx import ConnectTimeout, Response, Timeout, codes
 
 from mpt_api_client.auth import BearerTokenAuthentication
 from mpt_api_client.exceptions import MPTAPIError, MPTMaxRetryError
 from mpt_api_client.http.client import HTTPClient
 from mpt_api_client.http.query_options import QueryOptions
-from mpt_api_client.http.transport_settings import TransportSettings
+from mpt_api_client.http.transport_settings import (
+    DEFAULT_STREAM_READ_TIMEOUT,
+    TransportSettings,
+)
 from tests.unit.conftest import API_TOKEN, API_URL
+
+STREAM_PATH = "/api/v1/stream"
+STREAM_URL = f"{API_URL}{STREAM_PATH}"
 
 
 def test_http_initialization(mocker):
@@ -24,7 +30,7 @@ def test_http_initialization(mocker):
         follow_redirects=True,
         headers={"User-Agent": "swo-marketplace-client/1.0"},
         auth=authentication,
-        timeout=20.0,
+        timeout=Timeout(connect=20.0, read=20.0, write=20.0, pool=20.0),
         transport=mocker.ANY,
     )
 
@@ -40,7 +46,7 @@ def test_env_base_url_initialization(monkeypatch, mocker):
         follow_redirects=True,
         headers={"User-Agent": "swo-marketplace-client/1.0"},
         auth=mocker.ANY,
-        timeout=20.0,
+        timeout=Timeout(connect=20.0, read=20.0, write=20.0, pool=20.0),
         transport=mocker.ANY,
     )
 
@@ -160,3 +166,37 @@ def test_request_with_render_and_query_params(mocker, http_client, mock_httpx_re
     result = parent_request.call_args[1]
 
     assert result["params"] == "select=id%2Cname&render()"
+
+
+def test_client_uses_request_timeout_profile():
+    transport = TransportSettings(base_url=API_URL, timeout=11.0, read_timeout=33.0)
+
+    client = HTTPClient(  # act
+        transport=transport, authentication=BearerTokenAuthentication(API_TOKEN)
+    )
+
+    assert client.httpx_client.timeout == transport.request_timeout
+    assert client.httpx_client.timeout.read == pytest.approx(33.0)
+
+
+def read_stream(client):
+    """Open and fully consume a streaming response."""
+    with client.stream("GET", STREAM_PATH) as response:
+        return response.read()
+
+
+@respx.mock
+def test_stream_uses_the_longer_stream_timeout(mocker):
+    client = HTTPClient(
+        transport=TransportSettings(base_url=API_URL, timeout=11.0),
+        authentication=BearerTokenAuthentication(API_TOKEN),
+    )
+    respx.get(STREAM_URL).mock(return_value=Response(codes.OK, content=b"{}\n"))
+    spy = mocker.spy(client.httpx_client, "stream")
+
+    read_stream(client)  # act
+
+    passed_timeout = spy.call_args.kwargs["timeout"]
+    assert passed_timeout.read == pytest.approx(DEFAULT_STREAM_READ_TIMEOUT)
+    assert passed_timeout.read > client.httpx_client.timeout.read
+    assert passed_timeout.connect == pytest.approx(11.0)

--- a/tests/unit/http/test_transport_settings.py
+++ b/tests/unit/http/test_transport_settings.py
@@ -2,12 +2,16 @@ import pytest
 from httpx_retries import Retry
 
 from mpt_api_client.http.transport_settings import (
+    DEFAULT_STREAM_READ_TIMEOUT,
+    DEFAULT_TIMEOUT,
     ENV_BASE_URL,
     RETRY_ALLOWED_METHODS,
     EnvTransportSettings,
     TransportSettings,
 )
 from tests.unit.conftest import API_URL
+
+PHASE_ONE_FIRST_BYTE_SLO = 60.0
 
 
 def test_retries_count_is_normalized_to_retry():
@@ -58,3 +62,68 @@ def test_env_transport_missing_env_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="Base URL is required"):  # act
         EnvTransportSettings()
+
+
+def test_request_timeout_defaults_all_phases():
+    settings = TransportSettings(base_url=API_URL)  # act
+
+    request_timeout = settings.request_timeout
+    assert request_timeout.connect == pytest.approx(DEFAULT_TIMEOUT)
+    assert request_timeout.read == pytest.approx(DEFAULT_TIMEOUT)
+    assert request_timeout.write == pytest.approx(DEFAULT_TIMEOUT)
+    assert request_timeout.pool == pytest.approx(DEFAULT_TIMEOUT)
+
+
+def test_timeout_is_the_fallback_for_unset_phases():
+    settings = TransportSettings(base_url=API_URL, timeout=7.0, read_timeout=31.0)  # act
+
+    request_timeout = settings.request_timeout
+    assert request_timeout.read == pytest.approx(31.0)
+    assert request_timeout.connect == pytest.approx(7.0)
+    assert request_timeout.write == pytest.approx(7.0)
+    assert request_timeout.pool == pytest.approx(7.0)
+
+
+def test_phase_timeouts_set_independently():
+    settings = TransportSettings(
+        base_url=API_URL,
+        connect_timeout=1.0,
+        read_timeout=2.0,
+        write_timeout=3.0,
+        pool_timeout=4.0,
+    )  # act
+
+    request_timeout = settings.request_timeout
+    assert request_timeout.connect == pytest.approx(1.0)
+    assert request_timeout.read == pytest.approx(2.0)
+    assert request_timeout.write == pytest.approx(3.0)
+    assert request_timeout.pool == pytest.approx(4.0)
+
+
+def test_stream_timeout_extends_read_phase_only():
+    settings = TransportSettings(base_url=API_URL, timeout=9.0)  # act
+
+    stream_timeout = settings.stream_timeout
+    assert stream_timeout.read == pytest.approx(DEFAULT_STREAM_READ_TIMEOUT)
+    assert stream_timeout.connect == pytest.approx(9.0)
+    assert stream_timeout.write == pytest.approx(9.0)
+    assert stream_timeout.pool == pytest.approx(9.0)
+
+
+def test_stream_read_covers_deferred_byte():
+    settings = TransportSettings(base_url=API_URL)  # act
+
+    assert settings.request_timeout.read < PHASE_ONE_FIRST_BYTE_SLO
+    assert settings.stream_timeout.read >= PHASE_ONE_FIRST_BYTE_SLO
+
+
+def test_stream_read_timeout_is_configurable():
+    settings = TransportSettings(base_url=API_URL, stream_read_timeout=600.0)  # act
+
+    assert settings.stream_timeout.read == pytest.approx(600.0)
+
+
+def test_stream_never_lowers_explicit_read():
+    settings = TransportSettings(base_url=API_URL, read_timeout=900.0)  # act
+
+    assert settings.stream_timeout.read == pytest.approx(900.0)


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Splits the single transport timeout into per-connection-phase values.

`TransportSettings` gains `connect_timeout`, `read_timeout`, `write_timeout` and
`pool_timeout` — each falling back to `timeout` when unset — and exposes two resolved
profiles:

| Profile | Used by | Read phase |
|---|---|---|
| `request_timeout` | regular requests | `read_timeout`, else `timeout` |
| `stream_timeout` | `stream()` | `max(stream_read_timeout, read_timeout)`, default **120s** |

`HTTPClient` / `AsyncHTTPClient` apply `request_timeout` at construction and pass
`stream_timeout` on streaming calls.

## The defect this fixes

`timeout` was a scalar (`20.0`) handed to httpx, which applies it to **every** phase —
including read. It's the **read** timeout, not connect, that bounds how long a client waits
for a response to *begin* arriving. A server that accepts the connection and then thinks
before replying is bounded by `read_timeout`.

That matters for streaming: per
[TDR - Streaming API](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7751598153),
a streamed response commits its status only after the server has built the key snapshot,
with a **60s phase-1 first-byte SLO** and load balancers recommended at ≥120s. A 20s read
timeout kills those exports client-side well before the server is late — the exact trap the
TDR asks consumer SDKs to document.

I verified the mechanism rather than assuming it. The first attempt used `httpx.MockTransport`
and produced a false negative, because mock transports bypass the network stack and never
enforce timeouts. Re-run against a real socket that accepts and then holds silent:

```
read=0.5s vs 2s delay -> ReadTimeout   <- deferred first byte hits READ, not connect
read=5.0s vs 2s delay -> OK 200
```

## Design notes

**Streaming gets its own read timeout rather than raising the global one.** Raising the
global read default would slow failure detection on every ordinary request. Streaming has
genuinely different needs, so only it pays the longer wait.

**`stream_timeout` never lowers an explicit `read_timeout`.** A caller who sets
`read_timeout=900` keeps 900 on streams, via `max()`.

**No total-duration timeout is introduced.** A long export is bounded per phase, not
overall, so a healthy slow stream is never cut short.

## Pre-existing tests updated

Four client-initialization tests pinned `timeout=20.0` in the asserted `Client(...)` kwargs.
The clients no longer pass a scalar, so those assertions were pinning the old design; they
now assert the resolved `Timeout` object. Flagging explicitly so it does not read as
unexplained test churn.

## Testing

- 7 new `TransportSettings` tests: per-phase defaults, fallback behaviour, independent
  phases, the streaming read substitution, that the regular read sits below and the stream
  read above the 60s SLO, configurability, and the never-lower guarantee
- 2 new client tests: the httpx client uses `request_timeout`, and `stream()` passes the
  longer `stream_timeout`
- `make check-all` green: ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, 2345 tests

## Documentation

- `docs/usage.md` — new **Timeouts** subsection, including that read (not connect) governs
  the wait for a response to start, and the streaming substitution
- `docs/architecture.md` — the two resolved profiles on `TransportSettings`

The documented example is executed, not just written: it yields
`Timeout(connect=5.0, read=60.0, write=20.0, pool=20.0)`, and all 9 Python blocks in
`usage.md` compile.

## Relationship to #380

Independent — branched from `main` and touches no file #380 changes (`transport_settings.py`,
`client.py`, `async_client.py` vs #380's `streaming_mixin.py` and friends). The two compose:
once both land, `stream()` in streaming mode gets the longer read timeout automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Replaced the single transport timeout with separate connect, read, write, and pool timeouts.
- Added resolved `request_timeout` and `stream_timeout` profiles to `TransportSettings`.
- Applied timeout profiles to synchronous and asynchronous HTTP clients.
- Set streaming reads to at least the configured read timeout or the 120-second default.
- Added documentation and tests for timeout resolution and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->