### PR TITLE
MPT-24300 remove dead WPS215 token from flake8 per-file-ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ statistics = false
 per-file-ignores = [
   "mpt_api_client/auth/extension_framework.py: WPS214",
   "mpt_api_client/models/__init__.py: WPS235",
-  "mpt_api_client/models/model.py: WPS215 WPS110",
+  "mpt_api_client/models/model.py: WPS110",
   "mpt_api_client/models/progress.py: WPS202",
   "mpt_api_client/mpt_client.py: WPS214 WPS235",
   "mpt_api_client/resources/*: WPS215",


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Removed the `WPS215` token from the `mpt_api_client/models/model.py` entry in `[tool.flake8]` per-file-ignores, keeping `WPS110`. One line, configuration only.

```diff
-  "mpt_api_client/models/model.py: WPS215 WPS110",
+  "mpt_api_client/models/model.py: WPS110",
```

That entry is the only per-file-ignores pattern matching the file, and no class anywhere under `mpt_api_client/models/` declares more than three base classes, so the token suppressed nothing. Same category of dead suppression as the inline `# noqa: WPS215` comments removed in MPT-24293 (#381).

## Why only one token, when the ticket asked for ten

MPT-24300 originally scoped this as removing 10 of the 11 WPS215 grants, on the premise that *flake8 unions the codes of every matching per-file-ignores pattern*. That premise is wrong, and the ticket has been corrected.

flake8 selects the **single longest matching pattern** for a file and applies only that entry's codes. A narrower entry therefore **shadows** the broad `mpt_api_client/resources/*: WPS215` entry rather than adding to it — so the nine narrower `resources/` tokens are load-bearing, not redundant.

Measured with `flake8 --select=WPS215` over `mpt_api_client/`:

| Config | WPS215 violations | Where |
| --- | --- | --- |
| Baseline, unmodified | 0 | — |
| Nine narrow tokens dropped, broad entry kept | 180 | only the nine stripped directories |
| Nine narrow tokens dropped, broad entry also dropped | 200 | all twelve directories |

The 20-violation gap between rows 2 and 3 is exactly `audit` (4), `notifications` (10), `spotlight` (4) and `mixins` (2) — the four directories with no narrower entry, reachable only through the broad pattern. So the nine narrow tokens stay, and the broad entry stays because it is the sole suppression for those four directories.

`WPS215` is confirmed active — `select` includes `WPS`, `extend-ignore` lists only WPS226 and WPS412, and there is no `max-base-classes` override — so a clean flake8 run is evidence the removed token was unused, not that the rule is off.

## Reviewer note

Worth knowing when editing this config: because of longest-pattern-wins, adding any narrow per-file-ignores entry for a directory silently drops that directory out of the broad entry's coverage. Flagged on the ticket as a follow-up; not addressed here.

## Testing

`make check-all` green — ruff format, ruff check, flake8, mypy and `uv lock --check` all clean; 2336 unit tests pass.

No behavioural change; no base-class counts were touched.

Jira: https://softwareone.atlassian.net/browse/MPT-24300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Removed the unused `WPS215` suppression for `mpt_api_client/models/model.py`.
- Retained the `WPS110` suppression.
- Confirmed that `make check-all` passes with no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->