### PR TITLE
MPT-24249 Type streaming negotiation failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,8 +211,11 @@ Client, transport, and API errors use the following hierarchy:
 
 ```text
 MPTError
-├── MPTStreamingNotEnabledError  # streaming request the API did not answer in streaming mode
-├── MPTMaxRetryError             # retry attempts exhausted
-└── MPTHttpError                 # generic HTTP error (status_code, message, body)
-    └── MPTAPIError              # structured API error (payload, title, detail, trace_id)
+├── MPTStreamingError                    # base for streaming-mode failures
+│   └── MPTStreamingNotEnabledError      # response did not confirm streaming mode
+├── MPTMaxRetryError                     # retry attempts exhausted
+└── MPTHttpError                         # generic HTTP error (status_code, message, body)
+    ├── MPTAPIError                      # structured API error (payload, title, detail, trace_id)
+    ├── MPTStreamingNotSupportedError    # 501, resource cannot stream (also MPTStreamingError)
+    └── MPTStreamingNotAcceptableError   # 406, format unsupported (also MPTStreamingError)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -277,25 +277,46 @@ async def main():
 asyncio.run(main())
 ```
 
-### Streaming Confirmation
+### Streaming Errors
 
-The API confirms streaming mode by echoing the `MPT-Streaming` response header. When it does
-not, the body is an ordinary paged response, and consuming it as a stream would silently
-return only the first page. `stream()` raises `MPTStreamingNotEnabledError` before reading the
-body instead:
+All streaming-specific failures derive from `MPTStreamingError`, so one handler covers them:
+
+| Exception | Raised when |
+|---|---|
+| `MPTStreamingNotEnabledError` | The response does not echo `MPT-Streaming`, so the body is an ordinary paged response |
+| `MPTStreamingNotSupportedError` | `501` — the resource provides no streaming-capable execution strategy |
+| `MPTStreamingNotAcceptableError` | `406` — the requested format cannot be served for this read mode |
 
 ```python
-from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+from mpt_api_client.exceptions import MPTStreamingError
 
 try:
     for order in service.stream():
         print(order.id)
-except MPTStreamingNotEnabledError as error:
-    logger.error("Endpoint did not stream: %s", error)
+except MPTStreamingError as error:
+    logger.error("Streaming unavailable: %s", error)
 ```
 
-Treat this as a request-shape or endpoint-support problem, not a transient failure: retrying
-the same call against an endpoint that does not support streaming mode fails the same way.
+Catch the specific types when the response should differ — for example falling back to
+`iterate()` on `MPTStreamingNotSupportedError`, but treating
+`MPTStreamingNotAcceptableError` as a bug in the request:
+
+```python
+from mpt_api_client.exceptions import MPTStreamingNotSupportedError
+
+try:
+    records = list(service.stream())
+except MPTStreamingNotSupportedError:
+    records = list(service.iterate())
+```
+
+Treat all three as request-shape or endpoint-support problems rather than transient failures:
+retrying the same call against the same endpoint fails the same way. The two HTTP-backed types
+also subclass `MPTHttpError`, so existing `except MPTHttpError` handlers keep working and
+`status_code` remains available. Any other HTTP status passes through unchanged.
+
+`MPTStreamingNotEnabledError` is raised before the body is read, so no partial data is
+consumed.
 
 > **Note:** `StreamJSONLMixin` also exposes `stream()`, but it serves endpoints that assign
 > `application/jsonl` their own meaning outside streaming mode, such as billing statement

--- a/mpt_api_client/exceptions.py
+++ b/mpt_api_client/exceptions.py
@@ -1,16 +1,23 @@
 import json
-from typing import override
+from typing import NoReturn, override
 
-from httpx import HTTPStatusError
+from httpx import HTTPStatusError, codes
 
 from mpt_api_client.constants import MPT_STREAMING_ENABLED, MPT_STREAMING_HEADER
+
+STREAMING_NOT_ACCEPTABLE_STATUS = codes.NOT_ACCEPTABLE
+STREAMING_NOT_IMPLEMENTED_STATUS = codes.NOT_IMPLEMENTED
 
 
 class MPTError(Exception):
     """Represents a generic MPT error."""
 
 
-class MPTStreamingNotEnabledError(MPTError):
+class MPTStreamingError(MPTError):
+    """Base class for failures specific to the streaming read mode."""
+
+
+class MPTStreamingNotEnabledError(MPTStreamingError):
     """Represents a streaming request the API did not answer in streaming mode.
 
     The API confirms streaming mode by echoing the ``MPT-Streaming`` response header.
@@ -36,6 +43,62 @@ class MPTHttpError(MPTError):
         self.status_code = status_code
         self.body = body
         super().__init__(f"HTTP {status_code}: {message}")
+
+
+class MPTStreamingNotSupportedError(MPTStreamingError, MPTHttpError):
+    """Represents a resource whose query service cannot stream.
+
+    The API answers ``501`` when the resource provides no streaming-capable execution
+    strategy, rather than silently degrading to a buffered read. Use ``iterate()`` for
+    such resources.
+    """
+
+    def __init__(self, path: str, body: str):
+        self.path = path
+        MPTHttpError.__init__(
+            self,
+            STREAMING_NOT_IMPLEMENTED_STATUS,
+            f"'{path}' does not support streaming mode: the resource provides no "
+            "streaming-capable execution strategy. Use iterate() instead.",
+            body,
+        )
+
+
+class MPTStreamingNotAcceptableError(MPTStreamingError, MPTHttpError):
+    """Represents a streaming request whose requested format the API cannot serve.
+
+    The API answers ``406`` when the ``Accept`` header cannot be satisfied for the
+    requested read mode.
+    """
+
+    def __init__(self, path: str, body: str):
+        self.path = path
+        MPTHttpError.__init__(
+            self,
+            STREAMING_NOT_ACCEPTABLE_STATUS,
+            f"'{path}' cannot serve the requested streaming format. Check the Accept "
+            "header against the formats the endpoint negotiates for streaming mode.",
+            body,
+        )
+
+
+def raise_streaming_error(http_error: MPTHttpError, path: str) -> NoReturn:
+    """Re-raise an HTTP error as a typed streaming error when it is a negotiation failure.
+
+    Args:
+        http_error: The HTTP error raised while opening the streaming response.
+        path: Requested path, used to build the error message.
+
+    Raises:
+        MPTStreamingNotSupportedError: If the resource cannot stream (``501``).
+        MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
+        MPTHttpError: Unchanged, for any other status.
+    """
+    if http_error.status_code == STREAMING_NOT_IMPLEMENTED_STATUS:
+        raise MPTStreamingNotSupportedError(path, http_error.body) from http_error
+    if http_error.status_code == STREAMING_NOT_ACCEPTABLE_STATUS:
+        raise MPTStreamingNotAcceptableError(path, http_error.body) from http_error
+    raise http_error
 
 
 class MPTMaxRetryError(MPTError):

--- a/mpt_api_client/http/mixins/streaming_mixin.py
+++ b/mpt_api_client/http/mixins/streaming_mixin.py
@@ -75,6 +75,8 @@ class StreamingMixin[Model: BaseModel](QueryableMixin):
             MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
         path = self.build_path()  # type: ignore[attr-defined]
+        # ExitStack scopes the error guard to the stream open: the negotiation failure is
+        # raised by __enter__, and a plain `with` would force the record loop into the try.
         with ExitStack() as stack:
             try:
                 response = stack.enter_context(
@@ -128,6 +130,9 @@ class AsyncStreamingMixin[Model: BaseModel](QueryableMixin):
             MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
         path = self.build_path()  # type: ignore[attr-defined]
+        # AsyncExitStack scopes the error guard to the stream open: the negotiation failure
+        # is raised by __aenter__, and a plain `async with` would force the record loop
+        # into the try.
         async with AsyncExitStack() as stack:
             try:
                 response = await stack.enter_async_context(

--- a/mpt_api_client/http/mixins/streaming_mixin.py
+++ b/mpt_api_client/http/mixins/streaming_mixin.py
@@ -1,12 +1,17 @@
 import json
 from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import AsyncExitStack, ExitStack
 
 from mpt_api_client.constants import (
     APPLICATION_JSONL,
     MPT_STREAMING_ENABLED,
     MPT_STREAMING_HEADER,
 )
-from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+from mpt_api_client.exceptions import (
+    MPTHttpError,
+    MPTStreamingNotEnabledError,
+    raise_streaming_error,
+)
 from mpt_api_client.http.mixins.queryable_mixin import QueryableMixin
 from mpt_api_client.http.types import HeaderTypes
 from mpt_api_client.models import AsyncProgress, Progress
@@ -66,13 +71,21 @@ class StreamingMixin[Model: BaseModel](QueryableMixin):
 
         Raises:
             MPTStreamingNotEnabledError: If the API does not confirm streaming mode.
+            MPTStreamingNotSupportedError: If the resource cannot stream (``501``).
+            MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
         path = self.build_path()  # type: ignore[attr-defined]
-        with self.http_client.stream(  # type: ignore[attr-defined]
-            "GET",
-            path,
-            headers=streaming_request_headers(),
-        ) as response:
+        with ExitStack() as stack:
+            try:
+                response = stack.enter_context(
+                    self.http_client.stream(  # type: ignore[attr-defined]
+                        "GET",
+                        path,
+                        headers=streaming_request_headers(),
+                    )
+                )
+            except MPTHttpError as http_error:
+                raise_streaming_error(http_error, path)
             confirm_streaming_mode(response.headers, path)
             for line in response.iter_lines():
                 if not line.strip():
@@ -111,13 +124,21 @@ class AsyncStreamingMixin[Model: BaseModel](QueryableMixin):
 
         Raises:
             MPTStreamingNotEnabledError: If the API does not confirm streaming mode.
+            MPTStreamingNotSupportedError: If the resource cannot stream (``501``).
+            MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
         path = self.build_path()  # type: ignore[attr-defined]
-        async with self.http_client.stream(  # type: ignore[attr-defined]
-            "GET",
-            path,
-            headers=streaming_request_headers(),
-        ) as response:
+        async with AsyncExitStack() as stack:
+            try:
+                response = await stack.enter_async_context(
+                    self.http_client.stream(  # type: ignore[attr-defined]
+                        "GET",
+                        path,
+                        headers=streaming_request_headers(),
+                    )
+                )
+            except MPTHttpError as http_error:
+                raise_streaming_error(http_error, path)
             confirm_streaming_mode(response.headers, path)
             async for line in response.aiter_lines():
                 if not line.strip():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ per-file-ignores = [
   "mpt_api_client/auth/extension_framework.py: WPS214",
   "mpt_api_client/models/__init__.py: WPS235",
   "mpt_api_client/models/model.py: WPS110",
+  "mpt_api_client/exceptions.py: WPS202",
   "mpt_api_client/models/progress.py: WPS202",
   "mpt_api_client/mpt_client.py: WPS214 WPS235",
   "mpt_api_client/resources/*: WPS215",

--- a/tests/unit/http/mixins/test_streaming_mixin.py
+++ b/tests/unit/http/mixins/test_streaming_mixin.py
@@ -3,7 +3,13 @@ import pytest
 import respx
 
 from mpt_api_client import RQLQuery
-from mpt_api_client.exceptions import MPTStreamingNotEnabledError
+from mpt_api_client.exceptions import (
+    MPTHttpError,
+    MPTStreamingError,
+    MPTStreamingNotAcceptableError,
+    MPTStreamingNotEnabledError,
+    MPTStreamingNotSupportedError,
+)
 from mpt_api_client.http import AsyncService, Service
 from mpt_api_client.http.mixins import AsyncStreamingMixin, StreamingMixin
 from tests.unit.conftest import API_URL, DummyModel
@@ -163,3 +169,72 @@ async def test_async_stream_progress_events(
         ("item_processed",),
         ("completed",),
     ]
+
+
+@respx.mock
+def test_stream_raises_when_not_implemented(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.NOT_IMPLEMENTED))
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotSupportedError, match="does not support streaming mode"):
+        next(iterator)
+
+
+@respx.mock
+def test_stream_raises_when_not_acceptable(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.NOT_ACCEPTABLE))
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotAcceptableError, match="requested streaming format"):
+        next(iterator)
+
+
+@respx.mock
+def test_streaming_errors_stay_catchable_as_http(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.NOT_IMPLEMENTED))
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTHttpError) as raised:
+        next(iterator)
+
+    assert raised.value.status_code == httpx.codes.NOT_IMPLEMENTED
+    assert isinstance(raised.value, MPTStreamingError)
+
+
+@respx.mock
+def test_other_http_errors_are_not_translated(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.FORBIDDEN))
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTHttpError) as raised:
+        next(iterator)
+
+    assert raised.value.status_code == httpx.codes.FORBIDDEN
+    assert not isinstance(raised.value, MPTStreamingError)
+
+
+@respx.mock
+def test_not_enabled_error_is_a_streaming_error(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=jsonl_response())
+    iterator = streaming_service.stream()
+
+    with pytest.raises(MPTStreamingError):
+        next(iterator)
+
+
+@respx.mock
+async def test_async_stream_raises_not_supported(async_streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.NOT_IMPLEMENTED))
+    iterator = async_streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotSupportedError):
+        await anext(iterator)
+
+
+@respx.mock
+async def test_async_stream_raises_not_acceptable(async_streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.NOT_ACCEPTABLE))
+    iterator = async_streaming_service.stream()
+
+    with pytest.raises(MPTStreamingNotAcceptableError):
+        await anext(iterator)


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

> **Stacked on #380.** Base branch is `feature/MPT-24248/...`, not `main`, so this diff shows
> only the error-typing change. Merge #380 first; GitHub will retarget this to `main`.

## What was done

Completes story MPT-24235 by giving streaming negotiation failures their own types.

```text
MPTError
├── MPTStreamingError                    # new base for streaming-mode failures
│   └── MPTStreamingNotEnabledError      # moved under the new base
├── MPTMaxRetryError
└── MPTHttpError
    ├── MPTAPIError
    ├── MPTStreamingNotSupportedError    # 501, also MPTStreamingError
    └── MPTStreamingNotAcceptableError   # 406, also MPTStreamingError
```

| Exception | Raised when |
|---|---|
| `MPTStreamingNotSupportedError` | `501` — the resource provides no streaming-capable execution strategy |
| `MPTStreamingNotAcceptableError` | `406` — the requested format cannot be served for this read mode |

One `except MPTStreamingError` now covers all three streaming failures, which is the point of
introducing the base.

## Design notes

**The two HTTP-backed types also subclass `MPTHttpError`.** Callers already wrapping a stream
in `except MPTHttpError` keep working, and `status_code` stays available. Without this,
introducing typed errors would have been a silent breaking change for existing handlers.

**Only negotiation failures are reinterpreted.** Any other status passes through untranslated,
so a `403` or `500` still arrives as the `MPTHttpError` / `MPTAPIError` it always was. The
mapping stays narrow by design.

**Only the stream open is guarded, not the record loop.** My first attempt wrapped the whole
`with` block, which ruff correctly rejected for try-clause size — and that flagged a real
design flaw, not just a style issue: translating an error raised while consuming the body would
be wrong, because by then the response has already been negotiated, so a late failure is not a
negotiation problem. An `ExitStack` / `AsyncExitStack` scopes the guard to the open alone.

**The original error is preserved as `__cause__`.** The translated types carry `status_code`
and `body` but not `MPTAPIError.payload`; where the server sends structured `problem+json`,
that detail remains reachable through the chained cause.

## One config change

`pyproject.toml` gains `mpt_api_client/exceptions.py: WPS202` (too many module members: 10 > 7).

I considered splitting the module instead, but that would scatter the exception hierarchy that
callers need to find in one place — cohesion is the module's whole purpose. `models/progress.py`
already carries the same exemption for the same reason, so this follows existing precedent
rather than inventing an escape hatch.

## Testing

- 7 new tests: `501` and `406` mapping (sync and async), that the new types remain catchable as
  `MPTHttpError` with `status_code` intact, that other statuses are **not** translated, and that
  `MPTStreamingNotEnabledError` is now an `MPTStreamingError`
- `make check-all` green: ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, 2354 tests
- 100% coverage on `exceptions.py` and `streaming_mixin.py`

Every hierarchy claim in the docs was asserted at runtime rather than eyeballed — subclass
relationships, `status_code` preservation, and the rendered message.

## Documentation

`docs/usage.md`'s streaming section becomes **Streaming Errors**: the table above, a
single-handler example, and a fallback example that catches
`MPTStreamingNotSupportedError` and drops back to `iterate()`. `docs/architecture.md` shows the
updated hierarchy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-24249](https://softwareone.atlassian.net/browse/MPT-24249)

- Add typed exceptions for streaming negotiation failures.
- Map HTTP 501 and 406 responses to streaming-specific exceptions.
- Preserve `MPTHttpError` compatibility and HTTP status codes.
- Translate errors only when opening the stream.
- Add synchronous and asynchronous test coverage.
- Update streaming error documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24249]: https://softwareone.atlassian.net/browse/MPT-24249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ