### PR TITLE
MPT-24323 Support streaming limit semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,11 @@ streaming read mode on a regular collection route and require the API to echo th
 JSONL mixins serve endpoints that assign `application/jsonl` their own meaning outside
 streaming mode.
 
+`StreamingMixin.stream()` takes `limit` and `offset` and forwards them to the collection route
+unchanged, omitting whichever is unset. Validating them locally is deliberately out of scope:
+the server owns pagination-input validation, and the inputs it accepts in streaming mode are
+still changing.
+
 Example service definition:
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -247,6 +247,26 @@ Streaming mixins extend `QueryableMixin`, so `filter()`, `order_by()` and `selec
 before `stream()` exactly as they do before `iterate()`. Membership is fixed when the stream
 opens: records created afterwards are not included.
 
+### Bounding An Export
+
+By default `stream()` sends no `limit`, which exports the full snapshot; passing `limit=-1`
+requests the same thing explicitly. An explicit `limit=N` bounds the export to the first `N`
+records of the stream order, for a "first 100K by this sort" read that does not page:
+
+```python
+for order in service.order_by("-audit.created.at").stream(limit=100_000):
+    print(order.id)
+```
+
+Under a bounded limit the counts the response reports — the `MPT-Item-Count` header and
+`$meta.pagination.total` — describe the stream itself, `min(matches, N)`, not the uncapped
+number of matches.
+
+`stream()` also accepts `offset`. Pagination inputs are sent exactly as given and are never
+checked locally, because the server owns their validation: it currently rejects `offset` in
+streaming mode with `400`, and support for it is scheduled. Passing through is correct either
+way, so no client release is coupled to that change.
+
 The async form yields from an async generator:
 
 ```python

--- a/mpt_api_client/http/mixins/streaming_mixin.py
+++ b/mpt_api_client/http/mixins/streaming_mixin.py
@@ -30,6 +30,28 @@ def streaming_request_headers() -> HeaderTypes:
     }
 
 
+def streaming_pagination_params(limit: int | None, offset: int | None) -> dict[str, int]:
+    """Build the pagination query parameters of a streaming request.
+
+    Unset values are omitted rather than defaulted, because streaming mode reads an
+    absent ``limit`` as the full snapshot. Supplied values are sent as given: the server
+    owns pagination-input validation, so the client adds no guard of its own.
+
+    Args:
+        limit: Maximum number of records to export, or None to omit the parameter.
+        offset: Offset to send with the request, or None to omit the parameter.
+
+    Returns:
+        Query parameters for the request, without the parameters left unset.
+    """
+    supplied_params = {"limit": limit, "offset": offset}
+    return {
+        param_name: param_value
+        for param_name, param_value in supplied_params.items()
+        if param_value is not None
+    }
+
+
 def confirm_streaming_mode(response_headers: Mapping[str, str], path: str) -> None:
     """Verify the API answered a streaming request in streaming mode.
 
@@ -54,14 +76,26 @@ class StreamingMixin[Model: BaseModel](QueryableMixin):
     ``application/jsonl`` their own meaning outside streaming mode.
     """
 
-    def stream(self, *, progress: Progress | None = None) -> Iterator[Model]:
-        """Stream the full result set in streaming mode, yielding one model per record.
+    def stream(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        progress: Progress | None = None,
+    ) -> Iterator[Model]:
+        """Stream a result set in streaming mode, yielding one model per record.
 
         Unlike ``iterate()``, which pages through the collection and deserializes whole
         pages, this consumes a single line-delimited response without buffering the body.
         Membership is fixed when the stream opens, so records added afterwards are absent.
 
         Args:
+            limit: Number of records to export, counted from the start of the stream
+                order. Left unset by default, which exports the full snapshot, as does
+                an explicit ``-1``. Under a bounded limit the server reports the capped
+                count rather than the uncapped number of matches.
+            offset: Offset to send with the request. Sent as given rather than checked
+                locally, so the server decides whether it is a valid input.
             progress: Optional progress receiver. `item_processed` is called once per
                 record before it is yielded and `completed` once when the response body
                 is fully consumed. `set_total_items` is never called.
@@ -74,7 +108,9 @@ class StreamingMixin[Model: BaseModel](QueryableMixin):
             MPTStreamingNotSupportedError: If the resource cannot stream (``501``).
             MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
-        path = self.build_path()  # type: ignore[attr-defined]
+        path = self.build_path(  # type: ignore[attr-defined]
+            streaming_pagination_params(limit, offset),
+        )
         # ExitStack scopes the error guard to the stream open: the negotiation failure is
         # raised by __enter__, and a plain `with` would force the record loop into the try.
         with ExitStack() as stack:
@@ -109,14 +145,26 @@ class AsyncStreamingMixin[Model: BaseModel](QueryableMixin):
     ``application/jsonl`` their own meaning outside streaming mode.
     """
 
-    async def stream(self, *, progress: AsyncProgress | None = None) -> AsyncIterator[Model]:
-        """Stream the full result set in streaming mode, yielding one model per record.
+    async def stream(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        progress: AsyncProgress | None = None,
+    ) -> AsyncIterator[Model]:
+        """Stream a result set in streaming mode, yielding one model per record.
 
         Unlike ``iterate()``, which pages through the collection and deserializes whole
         pages, this consumes a single line-delimited response without buffering the body.
         Membership is fixed when the stream opens, so records added afterwards are absent.
 
         Args:
+            limit: Number of records to export, counted from the start of the stream
+                order. Left unset by default, which exports the full snapshot, as does
+                an explicit ``-1``. Under a bounded limit the server reports the capped
+                count rather than the uncapped number of matches.
+            offset: Offset to send with the request. Sent as given rather than checked
+                locally, so the server decides whether it is a valid input.
             progress: Optional progress receiver. `item_processed` is awaited once per
                 record before it is yielded and `completed` once when the response body
                 is fully consumed. `set_total_items` is never called.
@@ -129,7 +177,9 @@ class AsyncStreamingMixin[Model: BaseModel](QueryableMixin):
             MPTStreamingNotSupportedError: If the resource cannot stream (``501``).
             MPTStreamingNotAcceptableError: If the requested format is unsupported (``406``).
         """
-        path = self.build_path()  # type: ignore[attr-defined]
+        path = self.build_path(  # type: ignore[attr-defined]
+            streaming_pagination_params(limit, offset),
+        )
         # AsyncExitStack scopes the error guard to the stream open: the negotiation failure
         # is raised by __aenter__, and a plain `async with` would force the record loop
         # into the try.

--- a/tests/unit/http/mixins/test_streaming_mixin.py
+++ b/tests/unit/http/mixins/test_streaming_mixin.py
@@ -18,6 +18,24 @@ from tests.unit.http.conftest import AsyncRecordingProgress, RecordingProgress
 STREAM_URL = f"{API_URL}/api/v1/orders"
 JSONL_BODY = b'{"id": "ID-1", "name": "Order 1"}\n\n{"id": "ID-2", "name": "Order 2"}\n'
 NOT_CONFIRMED_MATCH = "did not confirm streaming mode"
+BOUNDED_LIMIT = 100
+PASSED_OFFSET = 50
+BOUNDED_QUERY = "limit=100&offset=50"
+
+# Pagination inputs reach the server exactly as given, and an unset input is omitted rather
+# than defaulted. Nothing here is validated locally: the server owns pagination-input
+# validation, and offset is scheduled for support there, so a client-side guard would expire.
+PAGINATION_CASES = (
+    pytest.param({}, "", id="unset - absent limit is the full snapshot"),
+    pytest.param({"limit": -1}, "limit=-1", id="-1 - the same thing, said explicitly"),
+    pytest.param({"limit": 0}, "limit=0", id="zero - passed through, not corrected"),
+    pytest.param({"limit": BOUNDED_LIMIT}, "limit=100", id="bounded prefix of the t0 order"),
+    pytest.param({"offset": 0}, "offset=0", id="offset zero is still sent"),
+    pytest.param({"offset": PASSED_OFFSET}, "offset=50", id="offset - the server decides"),
+    pytest.param(
+        {"limit": BOUNDED_LIMIT, "offset": PASSED_OFFSET}, BOUNDED_QUERY, id="both together"
+    ),
+)
 
 
 class DummyStreamingService(
@@ -86,6 +104,37 @@ def test_stream_applies_query_filters(streaming_service):
     assert "status" in request.url.query.decode()
 
 
+@pytest.mark.parametrize(("pagination", "expected_query"), PAGINATION_CASES)
+@respx.mock
+def test_stream_sends_pagination_params(streaming_service, pagination, expected_query):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    list(streaming_service.stream(**pagination))  # act
+
+    request = route.calls[0].request
+    assert request.url.query.decode() == expected_query
+
+
+@respx.mock
+def test_stream_combines_limit_with_query_state(streaming_service):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+    bounded_service = streaming_service.filter(RQLQuery(status="active")).select("id")
+
+    list(bounded_service.stream(limit=BOUNDED_LIMIT))  # act
+
+    request = route.calls[0].request
+    assert request.url.query.decode() == "limit=100&select=id&eq(status,'active')"
+
+
+@respx.mock
+def test_stream_yields_bounded_export(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=streaming_response())
+
+    result = list(streaming_service.stream(limit=BOUNDED_LIMIT))
+
+    assert [order.id for order in result] == ["ID-1", "ID-2"]
+
+
 @respx.mock
 def test_stream_raises_when_not_confirmed(streaming_service):
     respx.get(STREAM_URL).mock(return_value=jsonl_response())
@@ -147,6 +196,20 @@ async def test_async_stream_yields_models(async_streaming_service):
     assert all(isinstance(order, DummyModel) for order in result)
 
 
+@pytest.mark.parametrize(("pagination", "expected_query"), PAGINATION_CASES)
+@respx.mock
+async def test_async_stream_sends_pagination_params(
+    async_streaming_service, pagination, expected_query
+):
+    route = respx.get(STREAM_URL).mock(return_value=streaming_response())
+    stream = async_streaming_service.stream(**pagination)
+
+    [order async for order in stream]  # act
+
+    request = route.calls[0].request
+    assert request.url.query.decode() == expected_query
+
+
 @respx.mock
 async def test_async_stream_raises_not_confirmed(async_streaming_service):
     respx.get(STREAM_URL).mock(return_value=jsonl_response())
@@ -199,6 +262,18 @@ def test_streaming_errors_stay_catchable_as_http(streaming_service):
 
     assert raised.value.status_code == httpx.codes.NOT_IMPLEMENTED
     assert isinstance(raised.value, MPTStreamingError)
+
+
+@respx.mock
+def test_stream_surfaces_offset_response(streaming_service):
+    respx.get(STREAM_URL).mock(return_value=httpx.Response(httpx.codes.BAD_REQUEST))
+    iterator = streaming_service.stream(offset=PASSED_OFFSET)
+
+    with pytest.raises(MPTHttpError) as raised:
+        next(iterator)
+
+    assert raised.value.status_code == httpx.codes.BAD_REQUEST
+    assert not isinstance(raised.value, MPTStreamingError)
 
 
 @respx.mock


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

> **Stacked on #384, which is stacked on #380.** Base branch is `feature/MPT-24249/...`, not
> `main`, so this diff shows only the pagination change. Merge #380 and #384 first; GitHub will
> retarget this as each parent lands.

## What was done

Starts story MPT-24242 by giving `stream()` the limit behaviour the streaming contract defines,
so a caller can take either the whole t0 snapshot or a bounded prefix of it.

| `stream()` call | Sent on the wire | Meaning |
|---|---|---|
| `stream()` | no `limit` parameter | Full t0 snapshot (unchanged default) |
| `stream(limit=-1)` | `limit=-1` | The same thing, in the contract's own spelling |
| `stream(limit=N)` | `limit=N` | First `N` records of the t0 order |
| `stream(offset=N)` | `offset=N` | Passed through; the server decides |

Both mixins gain `limit` and `offset` keyword arguments, forwarded through a new
`streaming_pagination_params()` helper that omits whichever is unset.

## Design notes

**Nothing is validated locally, and that is the point.** `limit=0` and `offset=0` go on the wire
exactly as given. The server owns pagination-input validation, and per MPT-24223 the framework
team has scheduled `offset` support in streaming mode. A client-side guard would be correct for
a few weeks and wrong afterwards — and removing it later would itself be a breaking change for
callers that had adapted to it. Passing through is correct on both sides of that change, so no
client release is coupled to it. This is the parent story's deliberate rescope, and
[the client TDR §4.7](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7818740484/TDR+Python+API+Client+-+Streaming+Support)
records it as a rejected alternative rather than a deferred one.

**No test asserts that `offset` is rejected — one asserts that the server's answer is
surfaced.** `offset` draws a `400` today and that is scheduled to change, so a test encoding the
rejection as a client rule would have an expiry date. Instead the tests assert what the client
puts on the wire, plus that whatever status the server returns for an offset request reaches the
caller untranslated. Both hold before and after the server changes.

**Unset means absent, not defaulted.** An absent `limit` is what the contract reads as the full
snapshot, so the helper omits the parameter rather than sending a stand-in value. Sending
`limit=-1` by default would have been equivalent for the server but would have made every
existing streaming request look different on the wire for no reason.

**No `cursor` argument was added, and I would flag this for review.** MPT-24323 asks for
`offset` *and* cursor inputs to be passed through. Nothing in the client models a cursor, and
the OpenAPI document (checked live at `6.0.1581`) declares no `cursor` parameter on any
endpoint — so there is no cursor input to forward, and adding the argument would mean inventing
a query-parameter name for a server feature that does not exist yet. For cursors, the absence of
a guard is the whole of the behaviour. Say the word if the intent was different.

## Follow-up this sets up

With a bounded `limit=N` the server reports the **capped** count — `MPT-Item-Count` and
`$meta.pagination.total` both equal `min(matches, N)`, describing the stream rather than the
uncapped match total. Nothing reads that header yet, so there is no check to correct here, but
the completeness check in MPT-24236 must compare against the capped value or it will report
truncation on every bounded export. `docs/usage.md` now states this so the next implementer sees
it; it is called out as risk 4 in the client TDR.

## Testing

- 17 new cases across 4 test functions. The wire-level ones share a single parametrised table
  (`PAGINATION_CASES`) driving both the sync and async paths, so neither can drift from the
  other: omission when unset, each `limit` value (`-1`, `0`, `N`), `offset` pass-through
  including `0`, and both together
- Three cases stand alone because their shape differs: composition with `filter()`/`select()`,
  records still yielded under a bounded limit, and the server's status for an offset request
  reaching the caller untranslated
- Every case carries a prose `pytest.param(id=...)`, so a failure prints why the case exists —
  e.g. `[unset - absent limit is the full snapshot]` rather than `[pagination0]`
- `make check-all` green: ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, 2380 tests
- 100% coverage on `streaming_mixin.py`

Assertions are on the query string of the request `respx` actually captured, not on the
arguments handed to a mock, so the parameter names and the omission behaviour are verified end
to end through `build_path()` and `QueryState`.

## Documentation

`docs/usage.md` gains a **Bounding An Export** subsection: the limit spellings, the capped-count
consequence, and why pagination inputs are never checked locally. `docs/architecture.md` notes
the pass-through on `StreamingMixin`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add `limit` and `offset` support to synchronous and asynchronous `stream()` methods.
- Omit unset pagination parameters from requests.
- Forward explicit pagination values unchanged to the server.
- Add shared sync and async pagination tests.
- Document bounded exports, capped response counts, and server-side pagination validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->