### PR TITLE
MPT-24265 add notifications directories, footers and webhooks services

### DIFF
--- a/mpt_api_client/resources/notifications/directories.py
+++ b/mpt_api_client/resources/notifications/directories.py
@@ -1,0 +1,53 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncGetMixin,
+    CollectionMixin,
+    GetMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+
+
+class Directory(Model):
+    """Notifications Directory resource.
+
+    Attributes:
+        account: Reference to the account owning the directory.
+        origin: Reference to the account the directory originates from.
+        type: Directory type.
+        contacts: References to the contacts belonging to the directory.
+        audit: Audit information (created, updated events).
+    """
+
+    account: BaseModel | None
+    origin: BaseModel | None
+    type: str | None
+    contacts: list[BaseModel] | None
+    audit: BaseModel | None
+
+
+class DirectoriesServiceConfig:
+    """Notifications Directories service configuration."""
+
+    _endpoint = "/public/v1/notifications/directories"
+    _model_class = Directory
+    _collection_key = "data"
+
+
+class DirectoriesService(
+    GetMixin[Directory],
+    CollectionMixin[Directory],
+    Service[Directory],
+    DirectoriesServiceConfig,
+):
+    """Notifications Directories service."""
+
+
+class AsyncDirectoriesService(
+    AsyncGetMixin[Directory],
+    AsyncCollectionMixin[Directory],
+    AsyncService[Directory],
+    DirectoriesServiceConfig,
+):
+    """Async Notifications Directories service."""

--- a/mpt_api_client/resources/notifications/footers.py
+++ b/mpt_api_client/resources/notifications/footers.py
@@ -1,0 +1,53 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncManagedResourceMixin,
+    CollectionMixin,
+    ManagedResourceMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+
+
+class Footer(Model):
+    """Notifications Footer resource.
+
+    Attributes:
+        language_code: Language code of the footer.
+        content: Content of the footer.
+        is_default: Whether this footer is the default one.
+        status: Footer status.
+        audit: Audit information (created, updated events).
+    """
+
+    language_code: str | None
+    content: str | None
+    is_default: bool | None
+    status: str | None
+    audit: BaseModel | None
+
+
+class FootersServiceConfig:
+    """Notifications Footers service configuration."""
+
+    _endpoint = "/public/v1/notifications/footers"
+    _model_class = Footer
+    _collection_key = "data"
+
+
+class FootersService(
+    ManagedResourceMixin[Footer],
+    CollectionMixin[Footer],
+    Service[Footer],
+    FootersServiceConfig,
+):
+    """Notifications Footers service."""
+
+
+class AsyncFootersService(
+    AsyncManagedResourceMixin[Footer],
+    AsyncCollectionMixin[Footer],
+    AsyncService[Footer],
+    FootersServiceConfig,
+):
+    """Async Notifications Footers service."""

--- a/mpt_api_client/resources/notifications/notifications.py
+++ b/mpt_api_client/resources/notifications/notifications.py
@@ -6,10 +6,19 @@ from mpt_api_client.resources.notifications.categories import (
     CategoriesService,
 )
 from mpt_api_client.resources.notifications.contacts import AsyncContactsService, ContactsService
+from mpt_api_client.resources.notifications.directories import (
+    AsyncDirectoriesService,
+    DirectoriesService,
+)
+from mpt_api_client.resources.notifications.footers import AsyncFootersService, FootersService
 from mpt_api_client.resources.notifications.messages import AsyncMessagesService, MessagesService
 from mpt_api_client.resources.notifications.subscribers import (
     AsyncSubscribersService,
     SubscribersService,
+)
+from mpt_api_client.resources.notifications.webhooks import (
+    AsyncWebhooksService,
+    WebhooksService,
 )
 
 
@@ -52,6 +61,16 @@ class Notifications:
         return ContactsService(http_client=self.http_client)
 
     @property
+    def directories(self) -> DirectoriesService:
+        """Directories service."""
+        return DirectoriesService(http_client=self.http_client)
+
+    @property
+    def footers(self) -> FootersService:
+        """Footers service."""
+        return FootersService(http_client=self.http_client)
+
+    @property
     def messages(self) -> MessagesService:
         """Messages service."""
         return MessagesService(http_client=self.http_client)
@@ -60,6 +79,11 @@ class Notifications:
     def subscribers(self) -> SubscribersService:
         """Subscriptions service."""
         return SubscribersService(http_client=self.http_client)
+
+    @property
+    def webhooks(self) -> WebhooksService:
+        """Webhooks service."""
+        return WebhooksService(http_client=self.http_client)
 
 
 class AsyncNotifications:
@@ -101,6 +125,16 @@ class AsyncNotifications:
         return AsyncContactsService(http_client=self.http_client)
 
     @property
+    def directories(self) -> AsyncDirectoriesService:
+        """Async Directories service."""
+        return AsyncDirectoriesService(http_client=self.http_client)
+
+    @property
+    def footers(self) -> AsyncFootersService:
+        """Async Footers service."""
+        return AsyncFootersService(http_client=self.http_client)
+
+    @property
     def messages(self) -> AsyncMessagesService:
         """Async Messages service."""
         return AsyncMessagesService(http_client=self.http_client)
@@ -109,3 +143,8 @@ class AsyncNotifications:
     def subscribers(self) -> AsyncSubscribersService:
         """Subscriptions service."""
         return AsyncSubscribersService(http_client=self.http_client)
+
+    @property
+    def webhooks(self) -> AsyncWebhooksService:
+        """Async Webhooks service."""
+        return AsyncWebhooksService(http_client=self.http_client)

--- a/mpt_api_client/resources/notifications/webhooks.py
+++ b/mpt_api_client/resources/notifications/webhooks.py
@@ -1,0 +1,81 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncDisableMixin,
+    AsyncEnableMixin,
+    AsyncManagedResourceMixin,
+    CollectionMixin,
+    DisableMixin,
+    EnableMixin,
+    ManagedResourceMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+
+
+class Webhook(Model):
+    """Notifications Webhook resource.
+
+    Attributes:
+        name: Webhook name.
+        url: Endpoint the webhook calls.
+        description: Webhook description.
+        status: Webhook status.
+        type: Webhook type.
+        secret: Shared secret used to sign webhook calls.
+        statistics: Call statistics of the webhook.
+        object_type: Type of the object the webhook is bound to.
+        account: Reference to the account owning the webhook.
+        object: Reference to the object the webhook is bound to.
+        criteria: Key/value criteria narrowing when the webhook fires.
+        last_success: Last successful call.
+        last_failure: Last failed call.
+        last_call: Last call regardless of its outcome.
+        audit: Audit information (created, updated events).
+    """
+
+    name: str | None
+    url: str | None
+    description: str | None
+    status: str | None
+    type: str | None
+    secret: str | None
+    statistics: BaseModel | None
+    object_type: str | None
+    account: BaseModel | None
+    object: BaseModel | None
+    criteria: list[BaseModel] | None
+    last_success: BaseModel | None
+    last_failure: BaseModel | None
+    last_call: BaseModel | None
+    audit: BaseModel | None
+
+
+class WebhooksServiceConfig:
+    """Notifications Webhooks service configuration."""
+
+    _endpoint = "/public/v1/notifications/webhooks"
+    _model_class = Webhook
+    _collection_key = "data"
+
+
+class WebhooksService(
+    EnableMixin[Webhook],
+    DisableMixin[Webhook],
+    ManagedResourceMixin[Webhook],
+    CollectionMixin[Webhook],
+    Service[Webhook],
+    WebhooksServiceConfig,
+):
+    """Notifications Webhooks service."""
+
+
+class AsyncWebhooksService(
+    AsyncEnableMixin[Webhook],
+    AsyncDisableMixin[Webhook],
+    AsyncManagedResourceMixin[Webhook],
+    AsyncCollectionMixin[Webhook],
+    AsyncService[Webhook],
+    WebhooksServiceConfig,
+):
+    """Async Notifications Webhooks service."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ per-file-ignores = [
   "mpt_api_client/resources/commerce/*.py: WPS235 WPS215",
   "mpt_api_client/resources/exchange/*.py: WPS235 WPS215",
   "mpt_api_client/resources/integration/*.py: WPS204 WPS214 WPS215 WPS235",
+  "mpt_api_client/resources/notifications/*.py: WPS110 WPS214 WPS215",
   "mpt_api_client/resources/helpdesk/*.py: WPS204 WPS215 WPS214",
   "mpt_api_client/resources/program/*.py: WPS204 WPS215 WPS235",
   "mpt_api_client/rql/query_builder.py: WPS110 WPS115 WPS210 WPS214",

--- a/tests/unit/resources/notifications/test_directories.py
+++ b/tests/unit/resources/notifications/test_directories.py
@@ -1,0 +1,90 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.resources.notifications.directories import (
+    AsyncDirectoriesService,
+    DirectoriesService,
+)
+
+
+@pytest.fixture
+def directories_service(http_client):
+    return DirectoriesService(http_client=http_client)
+
+
+@pytest.fixture
+def async_directories_service(async_http_client):
+    return AsyncDirectoriesService(http_client=async_http_client)
+
+
+@pytest.fixture
+def directory_data():
+    return {
+        "id": "NDR-1234",
+        "type": "Vendor",
+        "account": {"id": "ACC-1234", "name": "Account"},
+        "origin": {"id": "ACC-5678", "name": "Origin account"},
+        "contacts": [{"id": "CON-1234", "email": "contact@example.com"}],
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+def test_endpoint(directories_service):
+    result = directories_service.build_path()
+
+    assert result == "/public/v1/notifications/directories"
+
+
+def test_async_endpoint(async_directories_service):
+    result = async_directories_service.build_path()
+
+    assert result == "/public/v1/notifications/directories"
+
+
+@pytest.mark.parametrize("method", ["get", "iterate", "fetch_page"])
+def test_mixins_present(directories_service, method):
+    result = hasattr(directories_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get", "iterate", "fetch_page"])
+def test_async_mixins_present(async_directories_service, method):
+    result = hasattr(async_directories_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["create", "update", "delete"])
+def test_write_mixins_absent(directories_service, method):
+    result = hasattr(directories_service, method)
+
+    assert result is False
+
+
+@pytest.mark.parametrize("method", ["create", "update", "delete"])
+def test_async_write_mixins_absent(async_directories_service, method):
+    result = hasattr(async_directories_service, method)
+
+    assert result is False
+
+
+def test_get_directory(directories_service, directory_data):
+    with respx.mock:
+        mock_route = respx.get(
+            "https://api.example.com/public/v1/notifications/directories/NDR-1234"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=directory_data,
+            )
+        )
+
+        result = directories_service.get("NDR-1234")
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == directory_data
+        assert result.account.id == "ACC-1234"
+        assert result.contacts[0].id == "CON-1234"

--- a/tests/unit/resources/notifications/test_footers.py
+++ b/tests/unit/resources/notifications/test_footers.py
@@ -1,0 +1,95 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.resources.notifications.footers import (
+    AsyncFootersService,
+    FootersService,
+)
+
+
+@pytest.fixture
+def footers_service(http_client):
+    return FootersService(http_client=http_client)
+
+
+@pytest.fixture
+def async_footers_service(async_http_client):
+    return AsyncFootersService(http_client=async_http_client)
+
+
+@pytest.fixture
+def footer_data():
+    return {
+        "id": "NFT-1234",
+        "languageCode": "en-US",
+        "content": "Footer content",
+        "isDefault": True,
+        "status": "Active",
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+def test_endpoint(footers_service):
+    result = footers_service.build_path()
+
+    assert result == "/public/v1/notifications/footers"
+
+
+def test_async_endpoint(async_footers_service):
+    result = async_footers_service.build_path()
+
+    assert result == "/public/v1/notifications/footers"
+
+
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "fetch_page"])
+def test_mixins_present(footers_service, method):
+    result = hasattr(footers_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get", "create", "update", "delete", "iterate", "fetch_page"])
+def test_async_mixins_present(async_footers_service, method):
+    result = hasattr(async_footers_service, method)
+
+    assert result is True
+
+
+def test_get_footer(footers_service, footer_data):
+    with respx.mock:
+        mock_route = respx.get(
+            "https://api.example.com/public/v1/notifications/footers/NFT-1234"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=footer_data,
+            )
+        )
+
+        result = footers_service.get("NFT-1234")
+
+        assert mock_route.call_count == 1
+        assert result.id == "NFT-1234"
+        assert result.language_code == "en-US"
+        assert result.is_default is True
+        assert result.status == "Active"
+
+
+async def test_async_get_footer(async_footers_service, footer_data):
+    with respx.mock:
+        mock_route = respx.get(
+            "https://api.example.com/public/v1/notifications/footers/NFT-1234"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=footer_data,
+            )
+        )
+
+        result = await async_footers_service.get("NFT-1234")
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == footer_data

--- a/tests/unit/resources/notifications/test_notifications.py
+++ b/tests/unit/resources/notifications/test_notifications.py
@@ -8,10 +8,19 @@ from mpt_api_client.resources.notifications.categories import (
     CategoriesService,
 )
 from mpt_api_client.resources.notifications.contacts import AsyncContactsService, ContactsService
+from mpt_api_client.resources.notifications.directories import (
+    AsyncDirectoriesService,
+    DirectoriesService,
+)
+from mpt_api_client.resources.notifications.footers import AsyncFootersService, FootersService
 from mpt_api_client.resources.notifications.messages import AsyncMessagesService, MessagesService
 from mpt_api_client.resources.notifications.subscribers import (
     AsyncSubscribersService,
     SubscribersService,
+)
+from mpt_api_client.resources.notifications.webhooks import (
+    AsyncWebhooksService,
+    WebhooksService,
 )
 
 
@@ -37,6 +46,9 @@ def test_async_notifications_init(async_http_client):
         ("messages", MessagesService),
         ("batches", BatchesService),
         ("subscribers", SubscribersService),
+        ("directories", DirectoriesService),
+        ("footers", FootersService),
+        ("webhooks", WebhooksService),
     ],
 )
 def test_notifications_properties(http_client, attr_name, expected):
@@ -55,6 +67,9 @@ def test_notifications_properties(http_client, attr_name, expected):
         ("messages", AsyncMessagesService),
         ("batches", AsyncBatchesService),
         ("subscribers", AsyncSubscribersService),
+        ("directories", AsyncDirectoriesService),
+        ("footers", AsyncFootersService),
+        ("webhooks", AsyncWebhooksService),
     ],
 )
 def test_async_notifications_properties(http_client, attr_name, expected):

--- a/tests/unit/resources/notifications/test_webhooks.py
+++ b/tests/unit/resources/notifications/test_webhooks.py
@@ -1,0 +1,129 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.resources.notifications.webhooks import (
+    AsyncWebhooksService,
+    WebhooksService,
+)
+
+
+@pytest.fixture
+def webhooks_service(http_client):
+    return WebhooksService(http_client=http_client)
+
+
+@pytest.fixture
+def async_webhooks_service(async_http_client):
+    return AsyncWebhooksService(http_client=async_http_client)
+
+
+@pytest.fixture
+def webhook_data():
+    return {
+        "id": "WH-1234",
+        "name": "Order validation",
+        "url": "https://example.com/hook",
+        "description": "Validates draft orders",
+        "status": "Enabled",
+        "type": "ValidatePurchaseOrderDraft",
+        "secret": "s3cret",
+        "objectType": "Order",
+        "account": {"id": "ACC-1234", "name": "Account"},
+        "object": {"id": "PRD-1234", "name": "Product"},
+        "criteria": [{"key": "product.id", "value": "PRD-1234"}],
+        "statistics": {"total": 10, "failed": 1},
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+def test_endpoint(webhooks_service):
+    result = webhooks_service.build_path()
+
+    assert result == "/public/v1/notifications/webhooks"
+
+
+def test_async_endpoint(async_webhooks_service):
+    result = async_webhooks_service.build_path()
+
+    assert result == "/public/v1/notifications/webhooks"
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "enable", "disable", "iterate", "fetch_page"],
+)
+def test_mixins_present(webhooks_service, method):
+    result = hasattr(webhooks_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "update", "delete", "enable", "disable", "iterate", "fetch_page"],
+)
+def test_async_mixins_present(async_webhooks_service, method):
+    result = hasattr(async_webhooks_service, method)
+
+    assert result is True
+
+
+def test_get_webhook(webhooks_service, webhook_data):
+    with respx.mock:
+        mock_route = respx.get(
+            "https://api.example.com/public/v1/notifications/webhooks/WH-1234"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=webhook_data,
+            )
+        )
+
+        result = webhooks_service.get("WH-1234")
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == webhook_data
+        assert result.object_type == "Order"
+        assert result.object.id == "PRD-1234"
+
+
+@pytest.mark.parametrize("action", ["enable", "disable"])
+def test_webhook_state_actions(webhooks_service, action):
+    response_expected_data = {"id": "WH-1234", "status": "Enabled"}
+    with respx.mock:
+        mock_route = respx.post(
+            f"https://api.example.com/public/v1/notifications/webhooks/WH-1234/{action}"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+
+        result = getattr(webhooks_service, action)("WH-1234")
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data
+
+
+@pytest.mark.parametrize("action", ["enable", "disable"])
+async def test_async_webhook_state_actions(async_webhooks_service, action):
+    response_expected_data = {"id": "WH-1234", "status": "Enabled"}
+    with respx.mock:
+        mock_route = respx.post(
+            f"https://api.example.com/public/v1/notifications/webhooks/WH-1234/{action}"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                json=response_expected_data,
+            )
+        )
+
+        result = await getattr(async_webhooks_service, action)("WH-1234")
+
+        assert mock_route.call_count == 1
+        assert result.to_dict() == response_expected_data


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

> 📚 **Bottom of a two-PR stack.** [#389](https://github.com/softwareone-platform/mpt-api-python-client/pull/389) (MPT-24266, templates and template variants) is stacked on this branch and will retarget to `main` once this merges. Merge this one first.

## What

Adds sync and async services for three `notifications` collection endpoints that had no service class and were therefore unreachable from `MPTClient` / `AsyncMPTClient`:

| Endpoint | Service | Mixins (per OpenAPI spec) |
|---|---|---|
| `/public/v1/notifications/directories` | `DirectoriesService` / `AsyncDirectoriesService` | `GetMixin`, `CollectionMixin` — spec documents only `GET` collection and `GET {id}` |
| `/public/v1/notifications/footers` | `FootersService` / `AsyncFootersService` | `ManagedResourceMixin`, `CollectionMixin` — `GET`/`POST` collection, `GET`/`PUT`/`DELETE {id}` |
| `/public/v1/notifications/webhooks` | `WebhooksService` / `AsyncWebhooksService` | `EnableMixin`, `DisableMixin`, `ManagedResourceMixin`, `CollectionMixin` — managed plus `POST {id}/enable` and `POST {id}/disable` |

Each module follows the existing `notifications/contacts.py` shape: a `Model` subclass carrying the resource attributes documented in the spec, a `<Name>ServiceConfig`, and the sync/async service pair. All three are registered as properties on both `Notifications` and `AsyncNotifications`.

## Why the `pyproject.toml` change

`Notifications` sat at exactly 7 methods, which is wemake-python-styleguide's `max_methods` default, and `mpt_api_client/resources/notifications/*` was absent from `[tool.flake8] per-file-ignores`. Adding any service to the group trips `WPS214`, so the group now carries the same ignore every other 8+ method group (Catalog, Billing, Helpdesk, Accounts) already has.

The new entry is `mpt_api_client/resources/notifications/*.py: WPS110 WPS214 WPS215`:

- `WPS214` — the max-methods threshold described above.
- `WPS215` — previously inherited from the broader `mpt_api_client/resources/*` entry. A more specific `per-file-ignores` pattern **replaces** the broader one rather than extending it, so `WPS215` has to be repeated or the pre-existing services in the group start failing. This matches how the accounts/billing/catalog entries are written.
- `WPS110` — for `Footer.content`, an API-mandated field name on the `Footer` model.

## Scope

- Streaming support for these endpoints is **not** in scope; it is tracked separately in MPT-24241.
- No e2e tests, per the subtask scope.
- **Docs were deliberately not touched.** `docs/usage.md` has no service list, and `docs/architecture.md`'s resource tree is group-granular with ellipses (`notifications/  # Messages, Batches, Subscribers, …`), so new services are already absorbed by the existing text. Appending to that line would collide with sibling branches working on other resource groups for no reader benefit.

## Testing

- New unit test modules: `tests/unit/resources/notifications/test_directories.py`, `test_footers.py`, `test_webhooks.py` — endpoint paths, mixin presence (and absence of write mixins on the read-only directories service), model field mapping, and the webhook `enable`/`disable` actions for both sync and async.
- All three services added to the parametrized property lists in `tests/unit/resources/notifications/test_notifications.py`.
- `make check-all` passes (ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, 2416 unit tests).
- Reachability verified against a constructed client: every new property resolves and `build_path()` returns the expected `/public/v1/...` path, checked against the MPT OpenAPI spec.

MPT-24265
