### PR TITLE
MPT-24264 Add the exchange pairs service

### DIFF
--- a/mpt_api_client/resources/exchange/exchange.py
+++ b/mpt_api_client/resources/exchange/exchange.py
@@ -3,6 +3,7 @@ from mpt_api_client.resources.exchange.currencies import (
     AsyncCurrenciesService,
     CurrenciesService,
 )
+from mpt_api_client.resources.exchange.pairs import AsyncPairsService, PairsService
 
 
 class Exchange:
@@ -16,6 +17,11 @@ class Exchange:
         """Currencies service."""
         return CurrenciesService(http_client=self.http_client)
 
+    @property
+    def pairs(self) -> PairsService:
+        """Pairs service."""
+        return PairsService(http_client=self.http_client)
+
 
 class AsyncExchange:
     """Exchange MPT API Module."""
@@ -27,3 +33,8 @@ class AsyncExchange:
     def currencies(self) -> AsyncCurrenciesService:
         """Currencies service."""
         return AsyncCurrenciesService(http_client=self.http_client)
+
+    @property
+    def pairs(self) -> AsyncPairsService:
+        """Pairs service."""
+        return AsyncPairsService(http_client=self.http_client)

--- a/mpt_api_client/resources/exchange/pairs.py
+++ b/mpt_api_client/resources/exchange/pairs.py
@@ -1,0 +1,69 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncGetMixin,
+    CollectionMixin,
+    GetMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+
+
+class Pair(Model):
+    """Exchange currency pair resource.
+
+    Attributes:
+        name: Pair name.
+        external_id: External identifier of the pair.
+        notes: Free-form notes for the pair.
+        primary: Whether the pair is the primary one for its currencies.
+        reverse: Reference to the pair holding the reverse conversion.
+        source_currency: Currency converted from.
+        destination_currency: Currency converted to.
+        latest_rate: Most recent rate recorded for the pair.
+        agreements: Number of agreements using the pair.
+        rates: Number of rates recorded for the pair.
+        status: Current status of the pair.
+        revision: Revision number.
+        audit: Audit information (created, updated events).
+    """
+
+    name: str | None
+    external_id: str | None
+    notes: str | None
+    primary: bool | None
+    reverse: BaseModel | None
+    source_currency: BaseModel | None
+    destination_currency: BaseModel | None
+    latest_rate: BaseModel | None
+    agreements: int | None
+    rates: int | None
+    status: str | None
+    revision: int | None
+    audit: BaseModel | None
+
+
+class PairsServiceConfig:
+    """Exchange Pairs service configuration."""
+
+    _endpoint = "/public/v1/exchange/pairs"
+    _model_class = Pair
+    _collection_key = "data"
+
+
+class PairsService(
+    GetMixin[Pair],
+    CollectionMixin[Pair],
+    Service[Pair],
+    PairsServiceConfig,
+):
+    """Exchange Pairs service."""
+
+
+class AsyncPairsService(
+    AsyncGetMixin[Pair],
+    AsyncCollectionMixin[Pair],
+    AsyncService[Pair],
+    PairsServiceConfig,
+):
+    """Async Exchange Pairs service."""

--- a/tests/unit/resources/exchange/test_exchange.py
+++ b/tests/unit/resources/exchange/test_exchange.py
@@ -5,6 +5,7 @@ from mpt_api_client.resources.exchange.currencies import (
     CurrenciesService,
 )
 from mpt_api_client.resources.exchange.exchange import AsyncExchange, Exchange
+from mpt_api_client.resources.exchange.pairs import AsyncPairsService, PairsService
 
 
 @pytest.fixture
@@ -40,4 +41,18 @@ def test_async_exchange_currencies_property(async_exchange):
     result = async_exchange.currencies
 
     assert isinstance(result, AsyncCurrenciesService)
+    assert result.http_client is async_exchange.http_client
+
+
+def test_exchange_pairs_property(exchange):
+    result = exchange.pairs
+
+    assert isinstance(result, PairsService)
+    assert result.http_client is exchange.http_client
+
+
+def test_async_exchange_pairs_property(async_exchange):
+    result = async_exchange.pairs
+
+    assert isinstance(result, AsyncPairsService)
     assert result.http_client is async_exchange.http_client

--- a/tests/unit/resources/exchange/test_pairs.py
+++ b/tests/unit/resources/exchange/test_pairs.py
@@ -1,0 +1,167 @@
+import httpx
+import pytest
+import respx
+
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.exchange.pairs import AsyncPairsService, Pair, PairsService
+
+
+@pytest.fixture
+def pairs_service(http_client):
+    return PairsService(http_client=http_client)
+
+
+@pytest.fixture
+def async_pairs_service(async_http_client):
+    return AsyncPairsService(http_client=async_http_client)
+
+
+@pytest.fixture
+def pair_data():
+    return {
+        "id": "PAI-001",
+        "name": "USD/EUR",
+        "externalId": "EXT-001",
+        "notes": "Primary conversion pair",
+        "primary": True,
+        "reverse": {"id": "PAI-002", "name": "EUR/USD"},
+        "sourceCurrency": {"id": "CUR-001", "code": "USD"},
+        "destinationCurrency": {"id": "CUR-002", "code": "EUR"},
+        "latestRate": {"id": "RAT-001", "value": 0.92},
+        "agreements": 3,
+        "rates": 12,
+        "status": "Active",
+        "revision": 1,
+        "audit": {"created": {"at": "2024-01-01T00:00:00Z"}},
+    }
+
+
+@pytest.mark.parametrize("method", ["get", "fetch_page", "fetch_one", "iterate"])
+def test_mixins_present(pairs_service, method):
+    result = hasattr(pairs_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get", "fetch_page", "fetch_one", "iterate"])
+def test_async_mixins_present(async_pairs_service, method):
+    result = hasattr(async_pairs_service, method)
+
+    assert result is True
+
+
+def test_pairs_service_endpoint(pairs_service):
+    result = pairs_service.build_path()
+
+    assert result == "/public/v1/exchange/pairs"
+
+
+def test_async_pairs_service_endpoint(async_pairs_service):
+    result = async_pairs_service.build_path()
+
+    assert result == "/public/v1/exchange/pairs"
+
+
+def test_pair_primitive_fields(pair_data):
+    result = Pair(pair_data)
+
+    assert result.to_dict() == pair_data
+
+
+@pytest.mark.parametrize("field", ["name", "external_id", "notes", "status"])
+def test_pair_string_fields(pair_data, field):
+    result = Pair(pair_data)
+
+    assert isinstance(getattr(result, field), str)
+
+
+@pytest.mark.parametrize("field", ["agreements", "rates", "revision"])
+def test_pair_integer_fields(pair_data, field):
+    result = Pair(pair_data)
+
+    assert isinstance(getattr(result, field), int)
+
+
+def test_pair_primary_field(pair_data):
+    result = Pair(pair_data)
+
+    assert result.primary is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["reverse", "source_currency", "destination_currency", "latest_rate", "audit"],
+)
+def test_pair_nested_model_fields(pair_data, field):
+    result = Pair(pair_data)
+
+    assert isinstance(getattr(result, field), BaseModel)
+
+
+@pytest.mark.parametrize("field", ["name", "external_id", "status", "audit"])
+def test_pair_optional_fields_absent(field):
+    result = Pair({"id": "PAI-001"})
+
+    assert not hasattr(result, field)
+
+
+def test_pair_id_present():
+    result = Pair({"id": "PAI-001"})
+
+    assert result.id == "PAI-001"
+
+
+def test_get_pair(pairs_service):
+    pair_id = "PAI-001"
+    expected_response = {"id": pair_id, "name": "USD/EUR", "primary": True}
+    with respx.mock:
+        respx.get(f"https://api.example.com/public/v1/exchange/pairs/{pair_id}").mock(
+            return_value=httpx.Response(httpx.codes.OK, json=expected_response)
+        )
+
+        result = pairs_service.get(pair_id)
+
+    assert result.to_dict() == expected_response
+
+
+async def test_async_get_pair(async_pairs_service):
+    pair_id = "PAI-001"
+    expected_response = {"id": pair_id, "name": "USD/EUR", "primary": True}
+    with respx.mock:
+        respx.get(f"https://api.example.com/public/v1/exchange/pairs/{pair_id}").mock(
+            return_value=httpx.Response(httpx.codes.OK, json=expected_response)
+        )
+
+        result = await async_pairs_service.get(pair_id)
+
+    assert result.to_dict() == expected_response
+
+
+def test_fetch_page_pairs(pairs_service):
+    expected_pairs = [{"id": "PAI-001", "name": "USD/EUR"}, {"id": "PAI-002", "name": "EUR/USD"}]
+    with respx.mock:
+        respx.get("https://api.example.com/public/v1/exchange/pairs").mock(
+            return_value=httpx.Response(
+                httpx.codes.OK,
+                json={"data": expected_pairs, "$meta": {"pagination": {"total": 2}}},
+            )
+        )
+
+        result = pairs_service.fetch_page()
+
+    assert [pair.to_dict() for pair in result] == expected_pairs
+
+
+async def test_async_fetch_page_pairs(async_pairs_service):
+    expected_pairs = [{"id": "PAI-001", "name": "USD/EUR"}, {"id": "PAI-002", "name": "EUR/USD"}]
+    with respx.mock:
+        respx.get("https://api.example.com/public/v1/exchange/pairs").mock(
+            return_value=httpx.Response(
+                httpx.codes.OK,
+                json={"data": expected_pairs, "$meta": {"pagination": {"total": 2}}},
+            )
+        )
+
+        result = await async_pairs_service.fetch_page()
+
+    assert [pair.to_dict() for pair in result] == expected_pairs


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

`/public/v1/exchange/pairs` was the only `exchange` endpoint in the Marketplace OpenAPI spec without a service class, so currency pairs were unreachable from the client. This adds the service and registers it on the resource group.

- New `mpt_api_client/resources/exchange/pairs.py` with:
  - `Pair` model covering the documented `Pair` schema attributes.
  - `PairsServiceConfig` (`_endpoint = "/public/v1/exchange/pairs"`, `_model_class`, `_collection_key = "data"`).
  - `PairsService` and `AsyncPairsService`.
- `pairs` property registered on both `Exchange` and `AsyncExchange`.

The module follows the existing service pattern (`notifications/contacts.py`, `accounts/modules.py`); no new abstraction was introduced.

## Mixin selection

Mixins were picked from what the spec actually documents for this endpoint, not from an assumed CRUD shape:

| Spec operation | Handled by |
| --- | --- |
| `GET /exchange/pairs` | `CollectionMixin` / `AsyncCollectionMixin` |
| `GET /exchange/pairs/{id}` | `GetMixin` / `AsyncGetMixin` |

The collection also documents bulk `POST`, `PUT` and `DELETE`, all of which take a `PairBulkData` envelope (`{"data": [Pair, ...]}`) and return an envelope or a bare array. These do not match any existing mixin — `CreateMixin` returns a single model, and `UpdateMixin`/`DeleteMixin` operate on `/{id}`, which the spec does not define for `PUT`/`DELETE` here. There is no bulk-operation precedent anywhere in this client, so adding them would mean inventing a pattern. They are deliberately left out of this change; see the note below.

Streaming support for this endpoint is out of scope here and tracked in MPT-24241.

## Testing

- `make check-all` passes: ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, and the full unit suite (2391 passed). `pairs.py` reports 100% coverage.
- New `tests/unit/resources/exchange/test_pairs.py` covers mixin presence, endpoint construction, `Pair` field typing and optional-field absence, and mocked `get` / `fetch_page` for both sync and async.
- `tests/unit/resources/exchange/test_exchange.py` gained the `pairs` property assertions for both `Exchange` and `AsyncExchange`.
- Reachability verified explicitly rather than assumed: a client built via `MPTClient.from_config` / `AsyncMPTClient.from_config` resolves `client.exchange.pairs` to the right class, `build_path()` returns `/public/v1/exchange/pairs`, and that path was checked against the live OpenAPI spec.
- No e2e tests in this subtask.
- No `pyproject.toml` change was needed: `Exchange` goes from 2 to 3 methods, well under wemake's `max_methods` limit, and flake8 reported no `WPS214`.

## Docs

`docs/usage.md` and `docs/architecture.md` were deliberately left untouched — this is not an omission. Neither enumerates individual services: `usage.md` has no service list, and the resource tree in `architecture.md` is group-granular with ellipses, so a new service under an existing group is already covered. Sibling work on other resource groups is in flight, and doc edits would be the only collision point.

## Reported, not changed

Two things worth a reviewer's attention rather than a unilateral fix:

1. **Bulk operations are unimplemented.** The spec's bulk `POST`/`PUT`/`DELETE` on `/exchange/pairs` need a bulk-capable mixin (request and response both use a `data` array). That is a framework addition, not a per-service one, and belongs in its own ticket.
2. **`test_exchange.py` uses per-service tests, not parametrized lists.** Every other group test (`test_accounts.py`, `test_catalog.py`, `test_billing.py`, `test_commerce.py`, `test_notifications.py`) enumerates group properties with `@pytest.mark.parametrize`; `test_exchange.py` is the outlier with individual test functions. The new coverage follows the file's existing local style for consistency. Converting this file to the repo-wide parametrized convention is a reasonable tidy-up, but out of scope here.

MPT-24264
