### PR TITLE
MPT-24263 add accounts account-users and services services

### DIFF
--- a/mpt_api_client/resources/accounts/account_users.py
+++ b/mpt_api_client/resources/accounts/account_users.py
@@ -1,0 +1,73 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncCreateMixin,
+    AsyncDeleteMixin,
+    AsyncGetMixin,
+    CollectionMixin,
+    CreateMixin,
+    DeleteMixin,
+    GetMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+from mpt_api_client.resources.accounts.mixins import (
+    AsyncInvitableMixin,
+    InvitableMixin,
+)
+
+
+class AccountUser(Model):
+    """Account User resource.
+
+    Attributes:
+        user: Reference to the platform user.
+        account: Reference to the account the user belongs to.
+        groups: User groups the account user belongs to.
+        buyers: Buyers the account user is scoped to.
+        modules: Modules the account user has access to.
+        invitation: Invitation details for the account user.
+        last_login_at: Timestamp of the last successful login.
+        audit: Audit information.
+    """
+
+    user: BaseModel | None
+    account: BaseModel | None
+    groups: list[BaseModel] | None
+    buyers: list[BaseModel] | None
+    modules: list[BaseModel] | None
+    invitation: BaseModel | None
+    last_login_at: str | None
+    audit: BaseModel | None
+
+
+class AccountUsersServiceConfig:
+    """Account Users Service Configuration."""
+
+    _endpoint = "/public/v1/accounts/account-users"
+    _model_class = AccountUser
+    _collection_key = "data"
+
+
+class AccountUsersService(
+    CreateMixin[AccountUser],
+    GetMixin[AccountUser],
+    DeleteMixin,
+    InvitableMixin[AccountUser],
+    CollectionMixin[AccountUser],
+    Service[AccountUser],
+    AccountUsersServiceConfig,
+):
+    """Account Users Service."""
+
+
+class AsyncAccountUsersService(
+    AsyncCreateMixin[AccountUser],
+    AsyncGetMixin[AccountUser],
+    AsyncDeleteMixin,
+    AsyncInvitableMixin[AccountUser],
+    AsyncCollectionMixin[AccountUser],
+    AsyncService[AccountUser],
+    AccountUsersServiceConfig,
+):
+    """Asynchronous Account Users Service."""

--- a/mpt_api_client/resources/accounts/accounts.py
+++ b/mpt_api_client/resources/accounts/accounts.py
@@ -1,5 +1,9 @@
 from mpt_api_client.http import AsyncHTTPClient, HTTPClient
 from mpt_api_client.resources.accounts.account import AccountsService, AsyncAccountsService
+from mpt_api_client.resources.accounts.account_users import (
+    AccountUsersService,
+    AsyncAccountUsersService,
+)
 from mpt_api_client.resources.accounts.api_tokens import ApiTokensService, AsyncApiTokensService
 from mpt_api_client.resources.accounts.buyers import AsyncBuyersService, BuyersService
 from mpt_api_client.resources.accounts.cloud_tenants import (
@@ -10,6 +14,7 @@ from mpt_api_client.resources.accounts.erp_links import AsyncErpLinksService, Er
 from mpt_api_client.resources.accounts.licensees import AsyncLicenseesService, LicenseesService
 from mpt_api_client.resources.accounts.modules import AsyncModulesService, ModulesService
 from mpt_api_client.resources.accounts.sellers import AsyncSellersService, SellersService
+from mpt_api_client.resources.accounts.services import AsyncServicesService, ServicesService
 from mpt_api_client.resources.accounts.user_groups import (
     AsyncUserGroupsService,
     UserGroupsService,
@@ -73,6 +78,16 @@ class Accounts:
         """ERP Links service."""
         return ErpLinksService(http_client=self.http_client)
 
+    @property
+    def account_users(self) -> AccountUsersService:
+        """Account Users service."""
+        return AccountUsersService(http_client=self.http_client)
+
+    @property
+    def services(self) -> ServicesService:
+        """Services service."""
+        return ServicesService(http_client=self.http_client)
+
 
 class AsyncAccounts:
     """Async Accounts MPT API Module."""
@@ -129,3 +144,13 @@ class AsyncAccounts:
     def erp_links(self) -> AsyncErpLinksService:
         """ERP Links service."""
         return AsyncErpLinksService(http_client=self.http_client)
+
+    @property
+    def account_users(self) -> AsyncAccountUsersService:
+        """Account Users service."""
+        return AsyncAccountUsersService(http_client=self.http_client)
+
+    @property
+    def services(self) -> AsyncServicesService:
+        """Services service."""
+        return AsyncServicesService(http_client=self.http_client)

--- a/mpt_api_client/resources/accounts/services.py
+++ b/mpt_api_client/resources/accounts/services.py
@@ -1,0 +1,53 @@
+from mpt_api_client.http import AsyncService, Service
+from mpt_api_client.http.mixins import (
+    AsyncCollectionMixin,
+    AsyncGetMixin,
+    CollectionMixin,
+    GetMixin,
+)
+from mpt_api_client.models import Model
+from mpt_api_client.models.model import BaseModel
+
+
+class ServiceIdentity(Model):
+    """Service identity resource exposed by the accounts services endpoint.
+
+    Attributes:
+        name: Service identity name.
+        status: Service identity status.
+        description: Service identity description.
+        icon: URL or identifier for the service identity icon.
+        audit: Audit information.
+    """
+
+    name: str | None
+    status: str | None
+    description: str | None
+    icon: str | None
+    audit: BaseModel | None
+
+
+class ServicesServiceConfig:
+    """Services Service Configuration."""
+
+    _endpoint = "/public/v1/accounts/services"
+    _model_class = ServiceIdentity
+    _collection_key = "data"
+
+
+class ServicesService(
+    GetMixin[ServiceIdentity],
+    CollectionMixin[ServiceIdentity],
+    Service[ServiceIdentity],
+    ServicesServiceConfig,
+):
+    """Services Service."""
+
+
+class AsyncServicesService(
+    AsyncGetMixin[ServiceIdentity],
+    AsyncCollectionMixin[ServiceIdentity],
+    AsyncService[ServiceIdentity],
+    ServicesServiceConfig,
+):
+    """Asynchronous Services Service."""

--- a/tests/unit/resources/accounts/test_account_users.py
+++ b/tests/unit/resources/accounts/test_account_users.py
@@ -1,0 +1,64 @@
+import pytest
+
+from mpt_api_client.resources.accounts.account_users import (
+    AccountUsersService,
+    AsyncAccountUsersService,
+)
+
+ACCOUNT_USERS_PATH = "/public/v1/accounts/account-users"
+
+
+@pytest.fixture
+def account_users_service(http_client):
+    return AccountUsersService(http_client=http_client)
+
+
+@pytest.fixture
+def async_account_users_service(async_http_client):
+    return AsyncAccountUsersService(http_client=async_http_client)
+
+
+def test_endpoint(account_users_service):
+    result = account_users_service.build_path()
+
+    assert result == ACCOUNT_USERS_PATH
+
+
+def test_async_endpoint(async_account_users_service):
+    result = async_account_users_service.build_path()
+
+    assert result == ACCOUNT_USERS_PATH
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "delete", "accept_invite", "resend_invite", "send_new_invite"],
+)
+def test_methods_present(account_users_service, method):
+    result = hasattr(account_users_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "create", "delete", "accept_invite", "resend_invite", "send_new_invite"],
+)
+def test_async_methods_present(async_account_users_service, method):
+    result = hasattr(async_account_users_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["update"])
+def test_undocumented_methods_absent(account_users_service, method):
+    result = hasattr(account_users_service, method)
+
+    assert result is False
+
+
+@pytest.mark.parametrize("method", ["update"])
+def test_async_undocumented_methods_absent(async_account_users_service, method):
+    result = hasattr(async_account_users_service, method)
+
+    assert result is False

--- a/tests/unit/resources/accounts/test_accounts.py
+++ b/tests/unit/resources/accounts/test_accounts.py
@@ -1,6 +1,10 @@
 import pytest
 
 from mpt_api_client.resources.accounts.account import AccountsService, AsyncAccountsService
+from mpt_api_client.resources.accounts.account_users import (
+    AccountUsersService,
+    AsyncAccountUsersService,
+)
 from mpt_api_client.resources.accounts.accounts import Accounts, AsyncAccounts
 from mpt_api_client.resources.accounts.api_tokens import (
     ApiTokensService,
@@ -15,6 +19,7 @@ from mpt_api_client.resources.accounts.erp_links import AsyncErpLinksService, Er
 from mpt_api_client.resources.accounts.licensees import AsyncLicenseesService, LicenseesService
 from mpt_api_client.resources.accounts.modules import AsyncModulesService, ModulesService
 from mpt_api_client.resources.accounts.sellers import AsyncSellersService, SellersService
+from mpt_api_client.resources.accounts.services import AsyncServicesService, ServicesService
 from mpt_api_client.resources.accounts.user_groups import (
     AsyncUserGroupsService,
     UserGroupsService,
@@ -45,6 +50,8 @@ def async_accounts(async_http_client):
         ("cloud_tenants", CloudTenantsService),
         ("buyers", BuyersService),
         ("erp_links", ErpLinksService),
+        ("account_users", AccountUsersService),
+        ("services", ServicesService),
     ],
 )
 def test_accounts_properties(accounts, property_name, expected_service_class):
@@ -67,6 +74,8 @@ def test_accounts_properties(accounts, property_name, expected_service_class):
         ("cloud_tenants", AsyncCloudTenantsService),
         ("buyers", AsyncBuyersService),
         ("erp_links", AsyncErpLinksService),
+        ("account_users", AsyncAccountUsersService),
+        ("services", AsyncServicesService),
     ],
 )
 def test_async_accounts_properties(async_accounts, property_name, expected_service_class):

--- a/tests/unit/resources/accounts/test_services.py
+++ b/tests/unit/resources/accounts/test_services.py
@@ -1,0 +1,55 @@
+import pytest
+
+from mpt_api_client.resources.accounts.services import AsyncServicesService, ServicesService
+
+SERVICES_PATH = "/public/v1/accounts/services"
+
+
+@pytest.fixture
+def services_service(http_client):
+    return ServicesService(http_client=http_client)
+
+
+@pytest.fixture
+def async_services_service(async_http_client):
+    return AsyncServicesService(http_client=async_http_client)
+
+
+def test_endpoint(services_service):
+    result = services_service.build_path()
+
+    assert result == SERVICES_PATH
+
+
+def test_async_endpoint(async_services_service):
+    result = async_services_service.build_path()
+
+    assert result == SERVICES_PATH
+
+
+@pytest.mark.parametrize("method", ["get"])
+def test_methods_present(services_service, method):
+    result = hasattr(services_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["get"])
+def test_async_methods_present(async_services_service, method):
+    result = hasattr(async_services_service, method)
+
+    assert result is True
+
+
+@pytest.mark.parametrize("method", ["create", "update", "delete"])
+def test_undocumented_methods_absent(services_service, method):
+    result = hasattr(services_service, method)
+
+    assert result is False
+
+
+@pytest.mark.parametrize("method", ["create", "update", "delete"])
+def test_async_undocumented_methods_absent(async_services_service, method):
+    result = hasattr(async_services_service, method)
+
+    assert result is False


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Two `accounts` collection endpoints documented in the Marketplace OpenAPI spec had no client
service, so they were unreachable from `MPTClient` / `AsyncMPTClient`. This PR adds them.

| Endpoint | Module | Group property | Service classes |
|---|---|---|---|
| `/public/v1/accounts/account-users` | `mpt_api_client/resources/accounts/account_users.py` | `accounts.account_users` | `AccountUsersService` / `AsyncAccountUsersService` |
| `/public/v1/accounts/services` | `mpt_api_client/resources/accounts/services.py` | `accounts.services` | `ServicesService` / `AsyncServicesService` |

Each module follows the existing resource-service pattern: a `Model` subclass with the
documented attributes, a shared `<Name>ServiceConfig` (`_endpoint`, `_model_class`,
`_collection_key = "data"`), and a sync service plus its async mirror. Both are exposed as
`@property` on `Accounts` and `AsyncAccounts`.

## Mixin selection

Mixins were chosen from what the OpenAPI spec actually documents per endpoint, not from an
assumed CRUD shape:

- **`account-users`** — spec has `GET`/`POST` on the collection, `GET`/`DELETE` on `/{id}`, and
  the `accept-invite`, `resend-invite`, `send-new-invite` actions. So:
  `CreateMixin`, `GetMixin`, `DeleteMixin`, `InvitableMixin`, `CollectionMixin`.
  Deliberately **no** `UpdateMixin` — the spec documents no `PUT`/`PATCH` on `/{id}`.
- **`services`** — spec has `GET` on the collection and on `/{id}` only, so the service is
  read-only: `GetMixin`, `CollectionMixin`.

## Naming

`account_users.py` is a **new** module and is not the same resource as the pre-existing
`accounts_users.py`, whose endpoint is `/public/v1/accounts/accounts/{account_id}/users`
(users nested under a specific account). `accounts_users.py` is untouched.

The model in `services.py` is named `ServiceIdentity` rather than `Service` because
`mpt_api_client.http.Service` is the service base class imported in the same module. The spec
itself calls the resource a "service identity" (`List service identities` / `Get service
identity by ID`).

## Out of scope

- Streaming (`MPT-Streaming`) support for these endpoints is tracked in **MPT-24241**.
- `/public/v1/accounts/account-users/{id}/groups` is a separate nested sub-collection endpoint
  and is not one of the two endpoints named in MPT-24263, so no sub-service was added for it.
- No e2e tests in this subtask.

## Documentation

**No docs were changed, deliberately** — this is not an omission. Neither `docs/usage.md` nor
`docs/architecture.md` enumerates individual services: `usage.md` has no service list, and the
resource tree in `architecture.md` is group-granular with ellipses
(`accounts/  # Account, Users, Buyers, Sellers, API Tokens, …`), so the two new services are
already covered by the existing text.

## Testing

`make check-all` passes — ruff format, ruff, flake8/WPS, mypy, `uv lock --check`, and the full
unit suite (**2386 passed**). Both new modules report 100% coverage.

New unit tests:

- `tests/unit/resources/accounts/test_account_users.py` — path, documented methods present,
  `update` absent.
- `tests/unit/resources/accounts/test_services.py` — path, `get` present, write methods absent.
- `tests/unit/resources/accounts/test_accounts.py` — both new services added to the sync and
  async parametrized group-property lists.

Reachability was verified against a real client instance rather than assumed — each property
resolves to the expected class and `build_path()` returns the spec path:

```text
sync  accounts.account_users  -> AccountUsersService       /public/v1/accounts/account-users
sync  accounts.services       -> ServicesService           /public/v1/accounts/services
async accounts.account_users  -> AsyncAccountUsersService  /public/v1/accounts/account-users
async accounts.services       -> AsyncServicesService      /public/v1/accounts/services
```

No `pyproject.toml` change was needed: `mpt_api_client/resources/accounts/*.py` already carries
`WPS214`/`WPS235` in the per-file ignores.

MPT-24263
